### PR TITLE
feat: implement development slice 02 validate capability path

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,7 +6,9 @@ import type {
   IsolationStrategy,
   ProviderRegistry,
   Refusal,
+  ResolveSlice02Result,
   RepositoryConfiguration,
+  ResourceValidation,
   ResolveSlice01Result,
   ResourceDeclaration,
   ResourceProvider,
@@ -30,6 +32,19 @@ function unsafeScope(reason: string): FailureResult {
     ok: false,
     refusal: {
       category: "unsafe_scope",
+      reason
+    }
+  };
+}
+
+function unsupportedCapability(reason: string): Extract<
+  ResolveSlice02Result,
+  { ok: false }
+> {
+  return {
+    ok: false,
+    refusal: {
+      category: "unsupported_capability",
       reason
     }
   };
@@ -94,6 +109,7 @@ interface ValidatedResourceDeclaration {
   name: string;
   provider: string;
   isolationStrategy: IsolationStrategy;
+  scopedValidate: boolean;
   scopedReset: boolean;
   scopedCleanup: boolean;
 }
@@ -137,6 +153,7 @@ function toValidatedResource(
     name: resource.name,
     provider: resource.provider,
     isolationStrategy: resource.isolationStrategy,
+    scopedValidate: resource.scopedValidate === true,
     scopedReset: resource.scopedReset,
     scopedCleanup: resource.scopedCleanup
   };
@@ -184,6 +201,30 @@ function deriveResourcePlan(input: {
 }): DerivedResourcePlan | Refusal {
   return input.provider.deriveResource({
     resource: input.resource,
+    worktree: input.worktree
+  });
+}
+
+function validateResourcePlan(input: {
+  provider: ResourceProvider;
+  resource: ValidatedResourceDeclaration;
+  derived: DerivedResourcePlan;
+  worktree: {
+    id?: string;
+    label?: string;
+    branch?: string;
+  };
+}): ResourceValidation | Refusal {
+  if (!input.provider.capabilities?.validate || !input.provider.validateResource) {
+    return {
+      category: "unsupported_capability",
+      reason: `Resource provider "${input.resource.provider}" does not support validate.`
+    };
+  }
+
+  return input.provider.validateResource({
+    resource: input.resource,
+    derived: input.derived,
     worktree: input.worktree
   });
 }
@@ -289,5 +330,133 @@ export function resolveSlice01(input: {
     ok: true,
     resourcePlans: [resourcePlan],
     endpointMappings: [endpointMapping]
+  };
+}
+
+export function resolveSlice02(input: {
+  repository: RepositoryConfiguration;
+  worktree: WorktreeInstanceInput;
+  providers: ProviderRegistry;
+}): ResolveSlice02Result {
+  const { repository, worktree, providers } = input;
+
+  if (!worktree.id) {
+    return {
+      ok: false,
+      refusal: {
+        category: "unsafe_scope",
+        reason: "Safe worktree scope cannot be determined."
+      }
+    };
+  }
+
+  if (repository.resources.length !== 1) {
+    return {
+      ok: false,
+      refusal: {
+        category: "invalid_configuration",
+        reason: "Slice 02 requires exactly one declared managed resource."
+      }
+    };
+  }
+
+  if (repository.endpoints.length !== 1) {
+    return {
+      ok: false,
+      refusal: {
+        category: "invalid_configuration",
+        reason: "Slice 02 requires exactly one declared managed endpoint."
+      }
+    };
+  }
+
+  const resource = repository.resources[0];
+  const endpoint = repository.endpoints[0];
+
+  const validatedResource = toValidatedResource(resource);
+  if (isFailureResult(validatedResource)) {
+    return validatedResource;
+  }
+
+  const validatedEndpoint = toValidatedEndpoint(endpoint);
+  if (isFailureResult(validatedEndpoint)) {
+    return validatedEndpoint;
+  }
+
+  const resourceProvider = providers.resources[validatedResource.provider];
+  if (!resourceProvider) {
+    return invalidConfiguration(
+      `No resource provider is registered for "${validatedResource.provider}".`
+    );
+  }
+
+  const endpointProvider = providers.endpoints[validatedEndpoint.provider];
+  if (!endpointProvider) {
+    return invalidConfiguration(
+      `No endpoint provider is registered for "${validatedEndpoint.provider}".`
+    );
+  }
+
+  const resolvedWorktree = {
+    id: worktree.id,
+    label: worktree.label,
+    branch: worktree.branch
+  };
+
+  const resourcePlan = deriveResourcePlan({
+    provider: resourceProvider,
+    resource: validatedResource,
+    worktree: resolvedWorktree
+  });
+
+  if (isRefusal(resourcePlan)) {
+    return {
+      ok: false,
+      refusal: resourcePlan
+    };
+  }
+
+  const endpointMapping = deriveEndpointMapping({
+    provider: endpointProvider,
+    endpoint: validatedEndpoint,
+    worktree: resolvedWorktree
+  });
+
+  if (isRefusal(endpointMapping)) {
+    return {
+      ok: false,
+      refusal: endpointMapping
+    };
+  }
+
+  const resourceValidations: ResourceValidation[] = [];
+
+  if (validatedResource.scopedValidate) {
+    const validation = validateResourcePlan({
+      provider: resourceProvider,
+      resource: validatedResource,
+      derived: resourcePlan,
+      worktree: resolvedWorktree
+    });
+
+    if (isRefusal(validation)) {
+      if (validation.category === "unsupported_capability") {
+        return unsupportedCapability(validation.reason);
+      }
+
+      return {
+        ok: false,
+        refusal: validation
+      };
+    }
+
+    resourceValidations.push(validation);
+  }
+
+  return {
+    ok: true,
+    resourcePlans: [resourcePlan],
+    endpointMappings: [endpointMapping],
+    resourceValidations
   };
 }

--- a/packages/provider-contracts/src/index.ts
+++ b/packages/provider-contracts/src/index.ts
@@ -9,6 +9,12 @@ export type RefusalCategory =
   | "unsafe_scope"
   | "provider_failure";
 
+export interface ProviderCapabilities {
+  validate?: true;
+  reset?: true;
+  cleanup?: true;
+}
+
 export interface Refusal {
   category: RefusalCategory;
   reason: string;
@@ -24,6 +30,7 @@ export interface ResourceDeclaration {
   name?: string;
   provider?: string;
   isolationStrategy?: IsolationStrategy;
+  scopedValidate?: boolean;
   scopedReset?: boolean;
   scopedCleanup?: boolean;
 }
@@ -55,12 +62,21 @@ export interface DerivedEndpointMapping {
   address: string;
 }
 
+export interface ResourceValidation {
+  resourceName: string;
+  provider: string;
+  worktreeId: string;
+  capability: "validate";
+}
+
 export interface ResourceProvider {
+  capabilities?: ProviderCapabilities;
   deriveResource(input: {
     resource: {
       name: string;
       provider: string;
       isolationStrategy: IsolationStrategy;
+      scopedValidate: boolean;
       scopedReset: boolean;
       scopedCleanup: boolean;
     };
@@ -70,6 +86,22 @@ export interface ResourceProvider {
       branch?: string;
     };
   }): DerivedResourcePlan | Refusal;
+  validateResource?(input: {
+    resource: {
+      name: string;
+      provider: string;
+      isolationStrategy: IsolationStrategy;
+      scopedValidate: boolean;
+      scopedReset: boolean;
+      scopedCleanup: boolean;
+    };
+    derived: DerivedResourcePlan;
+    worktree: {
+      id?: string;
+      label?: string;
+      branch?: string;
+    };
+  }): ResourceValidation | Refusal;
 }
 
 export interface EndpointProvider {
@@ -97,6 +129,18 @@ export type ResolveSlice01Result =
       ok: true;
       resourcePlans: DerivedResourcePlan[];
       endpointMappings: DerivedEndpointMapping[];
+    }
+  | {
+      ok: false;
+      refusal: Refusal;
+    };
+
+export type ResolveSlice02Result =
+  | {
+      ok: true;
+      resourcePlans: DerivedResourcePlan[];
+      endpointMappings: DerivedEndpointMapping[];
+      resourceValidations: ResourceValidation[];
     }
   | {
       ok: false;

--- a/packages/providers-testkit/src/index.ts
+++ b/packages/providers-testkit/src/index.ts
@@ -1,6 +1,8 @@
 import type {
+  DerivedResourcePlan,
   ProviderRegistry,
   Refusal,
+  ResourceValidation,
   RepositoryConfiguration,
   WorktreeInstanceInput
 } from "../../provider-contracts/src";
@@ -12,10 +14,55 @@ function unsafeScope(reason: string): Refusal {
   };
 }
 
+function validateScopedResource(input: {
+  resource: {
+    name: string;
+    provider: string;
+  };
+  derived: DerivedResourcePlan;
+  worktree: WorktreeInstanceInput;
+}): ResourceValidation | Refusal {
+  if (!input.worktree.id) {
+    return unsafeScope("Safe worktree scope cannot be determined.");
+  }
+
+  return {
+    resourceName: input.resource.name,
+    provider: input.resource.provider,
+    worktreeId: input.derived.worktreeId,
+    capability: "validate"
+  };
+}
+
 export function createExplicitTestProviders(): ProviderRegistry {
   return {
     resources: {
       "test-resource-provider": {
+        capabilities: {
+          validate: true
+        },
+        deriveResource({ resource, worktree }) {
+          if (!worktree.id) {
+            return unsafeScope("Safe worktree scope cannot be determined.");
+          }
+
+          return {
+            resourceName: resource.name,
+            provider: resource.provider,
+            isolationStrategy: resource.isolationStrategy,
+            worktreeId: worktree.id,
+            handle: `${resource.name}--${worktree.id}`
+          };
+        },
+        validateResource({ resource, derived, worktree }) {
+          return validateScopedResource({
+            resource,
+            derived,
+            worktree
+          });
+        }
+      },
+      "test-resource-provider-no-validate": {
         deriveResource({ resource, worktree }) {
           if (!worktree.id) {
             return unsafeScope("Safe worktree scope cannot be determined.");
@@ -60,6 +107,7 @@ export function createValidRepositoryConfiguration(
         name: "primary-db",
         provider: "test-resource-provider",
         isolationStrategy: "name-scoped",
+        scopedValidate: false,
         scopedReset: false,
         scopedCleanup: false
       }

--- a/tests/acceptance/dev-slice-02.acceptance.test.ts
+++ b/tests/acceptance/dev-slice-02.acceptance.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveSlice02 } from "../../packages/core/src";
+import {
+  createExplicitTestProviders,
+  createValidRepositoryConfiguration,
+  createWorktreeInstance
+} from "../../packages/providers-testkit/src";
+
+describe("Development Slice 02 acceptance", () => {
+  it("accepts an explicitly supported validate capability request", () => {
+    const outcome = resolveSlice02({
+      repository: createValidRepositoryConfiguration({
+        resources: [
+          {
+            name: "primary-db",
+            provider: "test-resource-provider",
+            isolationStrategy: "name-scoped",
+            scopedReset: false,
+            scopedCleanup: false,
+            scopedValidate: true
+          }
+        ]
+      }),
+      worktree: createWorktreeInstance({
+        id: "wt-validate-supported",
+        label: "validate-supported",
+        branch: "feature/validate-supported"
+      }),
+      providers: createExplicitTestProviders()
+    });
+
+    expect(outcome.ok).toBe(true);
+
+    if (!outcome.ok) {
+      return;
+    }
+
+    expect(outcome.resourcePlans).toHaveLength(1);
+    expect(outcome.endpointMappings).toHaveLength(1);
+    expect(outcome.resourceValidations).toEqual([
+      {
+        resourceName: "primary-db",
+        provider: "test-resource-provider",
+        worktreeId: "wt-validate-supported",
+        capability: "validate"
+      }
+    ]);
+  });
+
+  it("refuses unsupported validate intent explicitly", () => {
+    const outcome = resolveSlice02({
+      repository: createValidRepositoryConfiguration({
+        resources: [
+          {
+            name: "primary-db",
+            provider: "test-resource-provider-no-validate",
+            isolationStrategy: "name-scoped",
+            scopedReset: false,
+            scopedCleanup: false,
+            scopedValidate: true
+          }
+        ]
+      }),
+      worktree: createWorktreeInstance({
+        id: "wt-validate-unsupported",
+        label: "validate-unsupported"
+      }),
+      providers: createExplicitTestProviders()
+    });
+
+    expect(outcome).toMatchObject({
+      ok: false,
+      refusal: {
+        category: "unsupported_capability"
+      }
+    });
+  });
+
+  it("refuses validation when safe scope cannot be established", () => {
+    const outcome = resolveSlice02({
+      repository: createValidRepositoryConfiguration({
+        resources: [
+          {
+            name: "primary-db",
+            provider: "test-resource-provider",
+            isolationStrategy: "name-scoped",
+            scopedReset: false,
+            scopedCleanup: false,
+            scopedValidate: true
+          }
+        ]
+      }),
+      worktree: createWorktreeInstance({
+        label: "validate-unsafe-scope",
+        branch: "feature/validate-unsafe-scope"
+      }),
+      providers: createExplicitTestProviders()
+    });
+
+    expect(outcome).toMatchObject({
+      ok: false,
+      refusal: {
+        category: "unsafe_scope"
+      }
+    });
+  });
+});

--- a/tests/contracts/resource-provider.validate.contract.test.ts
+++ b/tests/contracts/resource-provider.validate.contract.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+
+import { createExplicitTestProviders } from "../../packages/providers-testkit/src";
+
+describe("resource provider validate contract", () => {
+  it("declares validate support explicitly and validates one worktree instance", () => {
+    const providers = createExplicitTestProviders();
+    const resourceProvider = providers.resources["test-resource-provider"];
+
+    expect(resourceProvider.capabilities).toEqual({
+      validate: true
+    });
+
+    if (!resourceProvider.validateResource) {
+      throw new Error("Expected validateResource to be defined.");
+    }
+
+    const validation = resourceProvider.validateResource({
+      resource: {
+        name: "primary-db",
+        provider: "test-resource-provider",
+        isolationStrategy: "name-scoped",
+        scopedReset: false,
+        scopedCleanup: false,
+        scopedValidate: true
+      },
+      derived: {
+        resourceName: "primary-db",
+        provider: "test-resource-provider",
+        isolationStrategy: "name-scoped",
+        worktreeId: "wt-contract",
+        handle: "primary-db--wt-contract"
+      },
+      worktree: {
+        id: "wt-contract",
+        label: "contract"
+      }
+    });
+
+    expect(validation).toEqual({
+      resourceName: "primary-db",
+      provider: "test-resource-provider",
+      worktreeId: "wt-contract",
+      capability: "validate"
+    });
+  });
+
+  it("refuses validation when provider-level scope safety cannot be established", () => {
+    const providers = createExplicitTestProviders();
+    const resourceProvider = providers.resources["test-resource-provider"];
+
+    if (!resourceProvider.validateResource) {
+      throw new Error("Expected validateResource to be defined.");
+    }
+
+    const validation = resourceProvider.validateResource({
+      resource: {
+        name: "primary-db",
+        provider: "test-resource-provider",
+        isolationStrategy: "name-scoped",
+        scopedReset: false,
+        scopedCleanup: false,
+        scopedValidate: true
+      },
+      derived: {
+        resourceName: "primary-db",
+        provider: "test-resource-provider",
+        isolationStrategy: "name-scoped",
+        worktreeId: "wt-contract",
+        handle: "primary-db--wt-contract"
+      },
+      worktree: {
+        label: "contract-unsafe-scope"
+      }
+    });
+
+    expect(validation).toMatchObject({
+      category: "unsafe_scope"
+    });
+  });
+});


### PR DESCRIPTION
Summary
Implement Development Slice 02 by evaluating one explicit validate capability intent for one worktree instance while preserving the existing Slice 01 derive path.

Scope
- add Slice 02 acceptance coverage for supported validate intent, unsupported validate intent, and unsafe-scope refusal
- add a narrow resource-provider contract test for explicit validate capability declaration and unsafe-scope refusal
- extend the resource contract shape only as needed for one explicit validate path
- add resolveSlice02 in core without broadening into reset, cleanup, or general capability orchestration

Refusal-category decision
Use unsupported_capability for repository intent that explicitly requests validate from a provider that does not support it. This remains a configuration-to-provider capability mismatch in the business explanation while preserving the higher-priority refusal-category distinction from ADR/spec/scenario sources.

New contract shapes
- ResourceDeclaration.scopedValidate?: boolean
- ProviderCapabilities with optional validate
- ResourceProvider.capabilities?: ProviderCapabilities
- ResourceProvider.validateResource?(...)
- ResourceValidation
- ResolveSlice02Result

Validation
- scripts/codex-env.sh pnpm test:acceptance
- scripts/codex-env.sh pnpm exec vitest run tests/contracts
- scripts/codex-env.sh pnpm typecheck