### PR TITLE
Slice 05: implement trusted endpoint declaration seam

### DIFF
--- a/packages/core/src/declarations.ts
+++ b/packages/core/src/declarations.ts
@@ -26,7 +26,31 @@ export interface ValidatedEndpointDeclaration {
   provider: string;
 }
 
+export interface EndpointDeclarationValidationError {
+  path: "name" | "role" | "provider";
+  code: "required";
+}
+
+export type EndpointDeclarationValidationResult<T> =
+  | {
+      ok: true;
+      value: T;
+    }
+  | {
+      ok: false;
+      errors: EndpointDeclarationValidationError[];
+    };
+
 function requiredError(path: string): DeclarationValidationError {
+  return {
+    path,
+    code: "required"
+  };
+}
+
+function requiredEndpointError(
+  path: EndpointDeclarationValidationError["path"]
+): EndpointDeclarationValidationError {
   return {
     path,
     code: "required"
@@ -88,31 +112,21 @@ export function validateResourceDeclaration(input: {
   };
 }
 
-export function validateEndpointDeclaration(input: {
-  endpoint: EndpointDeclaration;
-  index: number;
-}):
-  | {
-      ok: true;
-      value: ValidatedEndpointDeclaration;
-    }
-  | {
-      ok: false;
-      errors: DeclarationValidationError[];
-    } {
-  const { endpoint, index } = input;
-  const errors: DeclarationValidationError[] = [];
+export function validateEndpointDeclaration(
+  input: EndpointDeclaration
+): EndpointDeclarationValidationResult<ValidatedEndpointDeclaration> {
+  const errors: EndpointDeclarationValidationError[] = [];
 
-  if (!endpoint.name) {
-    errors.push(requiredError(`endpoints[${index}].name`));
+  if (!input.name) {
+    errors.push(requiredEndpointError("name"));
   }
 
-  if (!endpoint.role) {
-    errors.push(requiredError(`endpoints[${index}].role`));
+  if (!input.role) {
+    errors.push(requiredEndpointError("role"));
   }
 
-  if (!endpoint.provider) {
-    errors.push(requiredError(`endpoints[${index}].provider`));
+  if (!input.provider) {
+    errors.push(requiredEndpointError("provider"));
   }
 
   if (errors.length > 0) {
@@ -125,10 +139,54 @@ export function validateEndpointDeclaration(input: {
   return {
     ok: true,
     value: {
-      name: endpoint.name!,
-      role: endpoint.role!,
-      provider: endpoint.provider!
+      name: input.name!,
+      role: input.role!,
+      provider: input.provider!
     }
+  };
+}
+
+export function withValidatedEndpointDeclaration<TResult>(
+  input: EndpointDeclaration,
+  onValidated: (endpoint: ValidatedEndpointDeclaration) => TResult
+): EndpointDeclarationValidationResult<TResult> {
+  const validation = validateEndpointDeclaration(input);
+  if (!validation.ok) {
+    return validation;
+  }
+
+  return {
+    ok: true,
+    value: onValidated(validation.value)
+  };
+}
+
+export function validateIndexedEndpointDeclaration(input: {
+  endpoint: EndpointDeclaration;
+  index: number;
+}):
+  | {
+      ok: true;
+      value: ValidatedEndpointDeclaration;
+    }
+  | {
+      ok: false;
+      errors: DeclarationValidationError[];
+    } {
+  const validation = validateEndpointDeclaration(input.endpoint);
+
+  if (!validation.ok) {
+    return {
+      ok: false,
+      errors: validation.errors.map((error) =>
+        requiredError(`endpoints[${input.index}].${error.path}`)
+      )
+    };
+  }
+
+  return {
+    ok: true,
+    value: validation.value
   };
 }
 
@@ -150,10 +208,7 @@ export function toValidatedResource(
 export function toValidatedEndpoint(
   endpoint: EndpointDeclaration
 ): ValidatedEndpointDeclaration | FailureResult {
-  const validation = validateEndpointDeclaration({
-    endpoint,
-    index: 0
-  });
+  const validation = validateEndpointDeclaration(endpoint);
 
   if (!validation.ok) {
     return invalidConfiguration("Endpoint declaration is invalid.");

--- a/packages/core/src/repository-configuration.ts
+++ b/packages/core/src/repository-configuration.ts
@@ -1,7 +1,7 @@
 import type { RepositoryConfiguration } from "../../provider-contracts/index";
 
 import {
-  validateEndpointDeclaration,
+  validateIndexedEndpointDeclaration,
   validateResourceDeclaration,
   type DeclarationValidationError,
   type ValidatedEndpointDeclaration,
@@ -47,7 +47,7 @@ export function validateRepositoryConfiguration(
   }
 
   for (const [index, endpoint] of input.endpoints.entries()) {
-    const validation = validateEndpointDeclaration({
+    const validation = validateIndexedEndpointDeclaration({
       endpoint,
       index
     });

--- a/tests/acceptance/dev-slice-05.acceptance.test.ts
+++ b/tests/acceptance/dev-slice-05.acceptance.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { resolveSlice01 } from "../../packages/core/index";
+import {
+  createExplicitTestProviders,
+  createValidRepositoryConfiguration,
+  createWorktreeInstance
+} from "../../packages/providers-testkit/index";
+
+describe("Development Slice 05 acceptance", () => {
+  it("accepts valid raw endpoint declarations through the current orchestration path", () => {
+    const outcome = resolveSlice01({
+      repository: createValidRepositoryConfiguration(),
+      worktree: createWorktreeInstance({
+        id: "wt-valid-endpoint-declaration"
+      }),
+      providers: createExplicitTestProviders()
+    });
+
+    expect(outcome.ok).toBe(true);
+  });
+
+  it("rejects an endpoint missing a name", () => {
+    const outcome = resolveSlice01({
+      repository: createValidRepositoryConfiguration({
+        endpoints: [
+          {
+            role: "application-base-url",
+            provider: "test-endpoint-provider"
+          }
+        ]
+      }),
+      worktree: createWorktreeInstance({
+        id: "wt-missing-endpoint-name"
+      }),
+      providers: createExplicitTestProviders()
+    });
+
+    expect(outcome).toMatchObject({
+      ok: false,
+      refusal: {
+        category: "invalid_configuration"
+      }
+    });
+  });
+
+  it("rejects an endpoint missing a role", () => {
+    const outcome = resolveSlice01({
+      repository: createValidRepositoryConfiguration({
+        endpoints: [
+          {
+            name: "app-base-url",
+            provider: "test-endpoint-provider"
+          }
+        ]
+      }),
+      worktree: createWorktreeInstance({
+        id: "wt-missing-endpoint-role"
+      }),
+      providers: createExplicitTestProviders()
+    });
+
+    expect(outcome).toMatchObject({
+      ok: false,
+      refusal: {
+        category: "invalid_configuration"
+      }
+    });
+  });
+
+  it("rejects an endpoint missing a provider", () => {
+    const outcome = resolveSlice01({
+      repository: createValidRepositoryConfiguration({
+        endpoints: [
+          {
+            name: "app-base-url",
+            role: "application-base-url"
+          }
+        ]
+      }),
+      worktree: createWorktreeInstance({
+        id: "wt-missing-endpoint-provider"
+      }),
+      providers: createExplicitTestProviders()
+    });
+
+    expect(outcome).toMatchObject({
+      ok: false,
+      refusal: {
+        category: "invalid_configuration"
+      }
+    });
+  });
+
+  it("does not invoke endpoint derivation for invalid raw endpoint declarations", () => {
+    const providers = createExplicitTestProviders();
+    const deriveEndpoint = vi.spyOn(
+      providers.endpoints["test-endpoint-provider"],
+      "deriveEndpoint"
+    );
+
+    const outcome = resolveSlice01({
+      repository: createValidRepositoryConfiguration({
+        endpoints: [
+          {
+            name: "app-base-url",
+            provider: "test-endpoint-provider"
+          }
+        ]
+      }),
+      worktree: createWorktreeInstance({
+        id: "wt-invalid-endpoint-declaration"
+      }),
+      providers
+    });
+
+    expect(outcome).toMatchObject({
+      ok: false,
+      refusal: {
+        category: "invalid_configuration"
+      }
+    });
+    expect(deriveEndpoint).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/endpoint-declaration-boundary.test.ts
+++ b/tests/unit/endpoint-declaration-boundary.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  validateEndpointDeclaration,
+  withValidatedEndpointDeclaration
+} from "../../packages/core/src/declarations";
+
+describe("endpoint declaration boundary validation", () => {
+  it("accepts a valid endpoint declaration and returns a trusted representation", () => {
+    expect(
+      validateEndpointDeclaration({
+        name: "app-base-url",
+        role: "application-base-url",
+        provider: "test-endpoint-provider"
+      })
+    ).toEqual({
+      ok: true,
+      value: {
+        name: "app-base-url",
+        role: "application-base-url",
+        provider: "test-endpoint-provider"
+      }
+    });
+  });
+
+  it("returns structured errors for missing required endpoint fields", () => {
+    expect(
+      validateEndpointDeclaration({
+        role: "application-base-url"
+      })
+    ).toEqual({
+      ok: false,
+      errors: [
+        {
+          path: "name",
+          code: "required"
+        },
+        {
+          path: "provider",
+          code: "required"
+        }
+      ]
+    });
+  });
+
+  it("does not invoke downstream logic when endpoint declaration validation fails", () => {
+    const downstream = vi.fn();
+
+    const outcome = withValidatedEndpointDeclaration(
+      {
+        name: "app-base-url",
+        provider: "test-endpoint-provider"
+      },
+      downstream
+    );
+
+    expect(outcome).toEqual({
+      ok: false,
+      errors: [
+        {
+          path: "role",
+          code: "required"
+        }
+      ]
+    });
+    expect(downstream).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
Implement the Slice 05 trusted endpoint declaration seam in core.

## Implemented Work For The Slice 05 Production Lane
- add an explicit endpoint declaration validation seam in core declarations
- route repository endpoint admission through that seam while preserving current orchestration behavior
- add Slice 05 acceptance coverage for endpoint declaration admission and refusal before endpoint derivation
- add focused unit coverage for the internal endpoint declaration validation seam

## Planning-Only Output For Child Planning Issues
- issue #15: prepared an implementation-ready draft for the first thin CLI command issue body, grounded in current core result shapes and thin-CLI boundaries
- issue #16: identified the narrow post-Slice-04 docs mismatch and recommended a minimal follow-up scope limited to Slice 04 development docs plus small stale strategy text cleanup

## Explicitly Deferred Work
- no CLI implementation in this PR
- no provider-contract redesign
- no docs changes in this PR
- no second core behavior slice

## Validation
- scripts/codex-env.sh pnpm test:acceptance
- scripts/codex-env.sh pnpm test:contracts
- scripts/codex-env.sh pnpm test:unit
- scripts/codex-env.sh pnpm typecheck