### PR TITLE
Implement refusal propagation and worktree boundary validation

### DIFF
--- a/.agents/skills/git-task-workflow/SKILL.md
+++ b/.agents/skills/git-task-workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: git-task-workflow
-description: Use this skill when a Multiverse task is ready for Git workflow handling on a task branch, including confirming or creating the correct branch, validating and grouping changes, making focused commits, pushing the branch, and creating a concise pull request for human review without merging.
+description: Use this skill when a Multiverse task is ready for Git workflow handling on a task branch, including autonomously confirming or creating the correct branch, validating and grouping changes, making focused commits, pushing the branch, and creating a concise pull request for human review without merging.
 ---
 
 # Git Task Workflow
@@ -24,6 +24,8 @@ Use this skill when the task requires:
 - pushing the branch
 - creating a pull request with `gh`
 
+In this repository, these workflow steps are autonomous by default once the work is ready and required checks have passed.
+
 ## Do not use this skill when
 
 Do not use this skill when:
@@ -43,7 +45,7 @@ Do not use this skill when:
 6. Stage only the intended files.
 7. Commit in focused logical groups.
 8. Push the branch to origin.
-9. Create a concise PR with `gh pr create` if requested and available.
+9. Create a concise PR with `gh pr create` when the work is ready and `gh` is available.
 10. Stop for human review. Do not merge.
 
 ## Validation
@@ -82,5 +84,6 @@ Stop if:
 - unrelated changes cannot be safely separated
 - required checks are failing
 - the correct branch is unclear
-- `gh` is unavailable or unauthenticated when PR creation is requested
+- `gh` is unavailable or unauthenticated when PR creation is part of task completion
+- business truth is ambiguous and would need to be invented
 - the workflow would require merge or force-push without explicit instruction

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,10 +94,19 @@ For coding-agent work in this repository:
 - never push directly to `main`
 - use a task-scoped branch for implementation work
 - pull requests are required for review
+- the coding agent should autonomously create branches, commit focused changes, push task branches, and open pull requests when work is ready
 - merges are human-only
 - do not force-push unless explicitly instructed
 
 Use the `git-task-workflow` skill when a task reaches branch, commit, push, or pull request stages.
+
+Routine branch, commit, push, and pull request steps do not require additional user approval.
+Stop for user input only when:
+
+- business truth is ambiguous
+- unrelated changes cannot be safely separated
+- required validation is failing and the next step is unclear
+- a force-push or merge would be required
 
 ### Pull Request Rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,10 +81,19 @@ For coding-agent work in this repository:
 - never push directly to `main`
 - use a task-scoped branch for implementation work
 - pull requests are required for review
+- the coding agent should autonomously create branches, commit focused changes, push task branches, and open pull requests when work is ready
 - merges are human-only
 - do not force-push unless explicitly instructed
 
 Use the `git-task-workflow` skill when a task reaches branch, commit, push, or pull request stages.
+
+Routine branch, commit, push, and pull request steps do not require additional user approval.
+Stop for user input only when:
+
+- business truth is ambiguous
+- unrelated changes cannot be safely separated
+- required validation is failing and the next step is unclear
+- a force-push or merge would be required
 
 ### Pull Request Rules
 

--- a/docs/development/tasks/dev-slice-06-task-01.md
+++ b/docs/development/tasks/dev-slice-06-task-01.md
@@ -1,0 +1,87 @@
+# Development Slice 06 Task 01
+
+## Objective
+
+Implement a narrow refusal-propagation slice that proves provider-originated refusal categories survive core coordination unchanged for the current single-resource, single-endpoint path.
+
+## Business Context
+
+Multiverse is a behavior-first isolation tool for parallel development across git worktrees of the same repository on one machine.
+
+This task must preserve explicit worktree-instance boundaries, declarative repository configuration, explicit provider coordination, and refusal-first safety behavior.
+
+## In Scope
+
+- add executable coverage proving provider-originated `unsafe_scope` during derive is returned through the core orchestration path
+- add executable coverage proving provider-originated `provider_failure` during derive is returned through the core orchestration path
+- add executable coverage proving provider-originated `unsafe_scope` during validate is returned through the Slice 02 path
+- add executable coverage proving provider-originated `provider_failure` during validate is returned through the Slice 02 path
+- add the minimum test-provider support required to exercise those refusal paths
+- preserve the current intended workspace areas only:
+  - `packages/core/`
+  - `packages/providers-testkit/`
+  - `tests/`
+
+## Out of Scope
+
+- provider inference
+- managed object inference
+- broad CLI UX expansion
+- arbitrary process orchestration
+- unsupported-capability taxonomy changes
+- reset execution
+- cleanup execution
+- multi-provider coordination
+- multiple-resource expansion
+- multiple-endpoint expansion
+- speculative abstractions not required by this slice
+
+## Source Documents
+
+Use these as the source of truth:
+
+- `docs/adr/0008-unsafe-operations-are-refused-in-1-0.md`
+- `docs/spec/safety-and-refusal.md`
+- `docs/spec/system-boundary.md`
+- `docs/spec/provider-model.md`
+- `docs/scenarios/safety-and-refusal.scenarios.md`
+- `docs/scenarios/system-boundary.scenarios.md`
+- `docs/scenarios/provider-model.scenarios.md`
+- `AGENTS.md`
+- `docs/development/testing-strategy.md`
+- `docs/development/implementation-strategy.md`
+
+## Required Constraints
+
+- refusal must remain a first-class behavior
+- do not guess when safe scope is ambiguous
+- core must not absorb provider-specific implementation details
+- providers must not redefine business concepts
+- repository configuration remains explicit
+- preserve the distinction between `unsafe_scope` and `provider_failure`
+
+## Expected Deliverables
+
+- executable acceptance tests for the in-scope refusal propagation behavior
+- focused contract tests where provider refusal behavior is central
+- minimal production and testkit changes required to satisfy those tests
+- no unrelated refactors
+
+## Acceptance Criteria
+
+- provider-originated `unsafe_scope` during derive is returned unchanged by the core path
+- provider-originated `provider_failure` during derive is returned unchanged by the core path
+- provider-originated `unsafe_scope` during validate is returned unchanged by the Slice 02 path
+- provider-originated `provider_failure` during validate is returned unchanged by the Slice 02 path
+- the implementation preserves the current core/provider/configuration boundary
+
+## Notes for the Coding Agent
+
+Before making changes:
+
+1. identify the smallest set of files required
+2. confirm the change preserves current boundaries
+3. implement tests before broadening production code
+4. stop at the slice boundary
+
+When uncertain, prefer refusal and explicitness over convenience behavior.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -17,6 +17,14 @@ export {
   validateWorktreeIdentity,
   withValidatedWorktreeIdentity
 } from "./worktree-identity";
+export {
+  validateEndpointDeclaration,
+  withValidatedEndpointDeclaration
+} from "./declarations";
+export {
+  validateRepositoryConfiguration,
+  withValidatedRepositoryConfiguration
+} from "./repository-configuration";
 
 function isFailureOutcome(
   value: ResolvedSliceExecution | Extract<ResolveSlice01Result, { ok: false }>

--- a/packages/core/src/orchestration.ts
+++ b/packages/core/src/orchestration.ts
@@ -16,6 +16,7 @@ import {
   withValidatedRepositoryConfiguration
 } from "./repository-configuration";
 import { invalidConfiguration, isRefusal, unsafeScope, type FailureResult } from "./refusals";
+import { validateWorktreeIdentity } from "./worktree-identity";
 
 export interface ResolvedWorktree {
   id: string;
@@ -127,12 +128,16 @@ export function resolveSliceExecution(input: {
 function requireResolvedWorktree(
   worktree: WorktreeInstanceInput
 ): ResolvedWorktree | FailureResult {
-  if (!worktree.id) {
+  const validation = validateWorktreeIdentity({
+    worktreeId: worktree.id
+  });
+
+  if (!validation.ok) {
     return unsafeScope("Safe worktree scope cannot be determined.");
   }
 
   return {
-    id: worktree.id,
+    id: validation.value.value,
     label: worktree.label,
     branch: worktree.branch
   };

--- a/packages/providers-testkit/src/index.ts
+++ b/packages/providers-testkit/src/index.ts
@@ -98,6 +98,50 @@ export function createExplicitTestProviders(): ProviderRegistry {
   };
 }
 
+export function createProvidersWithResourceDeriveRefusal(
+  refusal: Refusal
+): ProviderRegistry {
+  const providers = createExplicitTestProviders();
+
+  providers.resources["test-resource-provider"] = {
+    ...providers.resources["test-resource-provider"],
+    deriveResource() {
+      return refusal;
+    }
+  };
+
+  return providers;
+}
+
+export function createProvidersWithEndpointDeriveRefusal(
+  refusal: Refusal
+): ProviderRegistry {
+  const providers = createExplicitTestProviders();
+
+  providers.endpoints["test-endpoint-provider"] = {
+    deriveEndpoint() {
+      return refusal;
+    }
+  };
+
+  return providers;
+}
+
+export function createProvidersWithResourceValidateRefusal(
+  refusal: Refusal
+): ProviderRegistry {
+  const providers = createExplicitTestProviders();
+
+  providers.resources["test-resource-provider"] = {
+    ...providers.resources["test-resource-provider"],
+    validateResource() {
+      return refusal;
+    }
+  };
+
+  return providers;
+}
+
 export function createValidRepositoryConfiguration(
   overrides: Partial<RepositoryConfiguration> = {}
 ): RepositoryConfiguration {

--- a/tests/acceptance/dev-slice-01.acceptance.test.ts
+++ b/tests/acceptance/dev-slice-01.acceptance.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { resolveSlice01 } from "../../packages/core/index";
 import {
@@ -56,6 +56,30 @@ describe("Development Slice 01 acceptance", () => {
     const second = resolveSlice01({ repository, worktree, providers });
 
     expect(first).toEqual(second);
+  });
+
+  it("resolves successfully for the reserved main worktree identity", () => {
+    const outcome = resolveSlice01({
+      repository: createValidRepositoryConfiguration(),
+      worktree: createWorktreeInstance({
+        id: "main",
+        label: "main"
+      }),
+      providers: createExplicitTestProviders()
+    });
+
+    expect(outcome.ok).toBe(true);
+
+    if (!outcome.ok) {
+      return;
+    }
+
+    expect(outcome.resourcePlans[0]).toMatchObject({
+      worktreeId: "main"
+    });
+    expect(outcome.endpointMappings[0]).toMatchObject({
+      worktreeId: "main"
+    });
   });
 
   it("resolves different isolated outputs for different worktree instances", () => {
@@ -160,5 +184,35 @@ describe("Development Slice 01 acceptance", () => {
         category: "unsafe_scope"
       }
     });
+  });
+
+  it("refuses whitespace-only worktree identity before provider invocation", () => {
+    const providers = createExplicitTestProviders();
+    const deriveResource = vi.spyOn(
+      providers.resources["test-resource-provider"],
+      "deriveResource"
+    );
+    const deriveEndpoint = vi.spyOn(
+      providers.endpoints["test-endpoint-provider"],
+      "deriveEndpoint"
+    );
+
+    const outcome = resolveSlice01({
+      repository: createValidRepositoryConfiguration(),
+      worktree: createWorktreeInstance({
+        id: "   ",
+        label: "invalid-worktree-id"
+      }),
+      providers
+    });
+
+    expect(outcome).toMatchObject({
+      ok: false,
+      refusal: {
+        category: "unsafe_scope"
+      }
+    });
+    expect(deriveResource).not.toHaveBeenCalled();
+    expect(deriveEndpoint).not.toHaveBeenCalled();
   });
 });

--- a/tests/acceptance/dev-slice-03.acceptance.test.ts
+++ b/tests/acceptance/dev-slice-03.acceptance.test.ts
@@ -31,6 +31,34 @@ describe("Development Slice 03 acceptance", () => {
     });
   });
 
+  it("accepts the reserved main worktree identity and passes a trusted value downstream", () => {
+    const downstream = vi.fn((worktreeIdentity) => ({
+      trusted: worktreeIdentity
+    }));
+
+    const outcome = withValidatedWorktreeIdentity(
+      {
+        worktreeId: "main"
+      },
+      downstream
+    );
+
+    expect(outcome).toEqual({
+      ok: true,
+      value: {
+        trusted: {
+          kind: "worktree_identity",
+          value: "main"
+        }
+      }
+    });
+    expect(downstream).toHaveBeenCalledTimes(1);
+    expect(downstream).toHaveBeenCalledWith({
+      kind: "worktree_identity",
+      value: "main"
+    });
+  });
+
   it("rejects missing worktree identity with structured validation output", () => {
     const downstream = vi.fn();
 

--- a/tests/acceptance/dev-slice-06.acceptance.test.ts
+++ b/tests/acceptance/dev-slice-06.acceptance.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveSlice01, resolveSlice02 } from "../../packages/core/index";
+import {
+  createProvidersWithEndpointDeriveRefusal,
+  createProvidersWithResourceDeriveRefusal,
+  createProvidersWithResourceValidateRefusal,
+  createValidRepositoryConfiguration,
+  createWorktreeInstance
+} from "../../packages/providers-testkit/index";
+
+describe("Development Slice 06 acceptance", () => {
+  it("returns provider-originated unsafe scope during derive unchanged", () => {
+    const outcome = resolveSlice01({
+      repository: createValidRepositoryConfiguration(),
+      worktree: createWorktreeInstance({
+        id: "wt-provider-unsafe-derive"
+      }),
+      providers: createProvidersWithResourceDeriveRefusal({
+        category: "unsafe_scope",
+        reason: "Provider could not verify owning scope for derived resource."
+      })
+    });
+
+    expect(outcome).toEqual({
+      ok: false,
+      refusal: {
+        category: "unsafe_scope",
+        reason: "Provider could not verify owning scope for derived resource."
+      }
+    });
+  });
+
+  it("returns provider-originated provider failure during derive unchanged", () => {
+    const outcome = resolveSlice01({
+      repository: createValidRepositoryConfiguration(),
+      worktree: createWorktreeInstance({
+        id: "wt-provider-failure-derive"
+      }),
+      providers: createProvidersWithEndpointDeriveRefusal({
+        category: "provider_failure",
+        reason: "Endpoint provider failed after safe scope was established."
+      })
+    });
+
+    expect(outcome).toEqual({
+      ok: false,
+      refusal: {
+        category: "provider_failure",
+        reason: "Endpoint provider failed after safe scope was established."
+      }
+    });
+  });
+
+  it("returns provider-originated unsafe scope during validate unchanged", () => {
+    const outcome = resolveSlice02({
+      repository: createValidRepositoryConfiguration({
+        resources: [
+          {
+            name: "primary-db",
+            provider: "test-resource-provider",
+            isolationStrategy: "name-scoped",
+            scopedValidate: true,
+            scopedReset: false,
+            scopedCleanup: false
+          }
+        ]
+      }),
+      worktree: createWorktreeInstance({
+        id: "wt-provider-unsafe-validate"
+      }),
+      providers: createProvidersWithResourceValidateRefusal({
+        category: "unsafe_scope",
+        reason: "Provider could not verify owning scope for validation."
+      })
+    });
+
+    expect(outcome).toEqual({
+      ok: false,
+      refusal: {
+        category: "unsafe_scope",
+        reason: "Provider could not verify owning scope for validation."
+      }
+    });
+  });
+
+  it("returns provider-originated provider failure during validate unchanged", () => {
+    const outcome = resolveSlice02({
+      repository: createValidRepositoryConfiguration({
+        resources: [
+          {
+            name: "primary-db",
+            provider: "test-resource-provider",
+            isolationStrategy: "name-scoped",
+            scopedValidate: true,
+            scopedReset: false,
+            scopedCleanup: false
+          }
+        ]
+      }),
+      worktree: createWorktreeInstance({
+        id: "wt-provider-failure-validate"
+      }),
+      providers: createProvidersWithResourceValidateRefusal({
+        category: "provider_failure",
+        reason: "Provider validation failed after safe scope was established."
+      })
+    });
+
+    expect(outcome).toEqual({
+      ok: false,
+      refusal: {
+        category: "provider_failure",
+        reason: "Provider validation failed after safe scope was established."
+      }
+    });
+  });
+});

--- a/tests/contracts/resource-provider.refusal.contract.test.ts
+++ b/tests/contracts/resource-provider.refusal.contract.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import { createProvidersWithResourceValidateRefusal } from "../../packages/providers-testkit/index";
+
+describe("resource provider refusal contract", () => {
+  it("may refuse validate with provider failure distinctly from unsafe scope", () => {
+    const providers = createProvidersWithResourceValidateRefusal({
+      category: "provider_failure",
+      reason: "Provider validation failed after safe scope was established."
+    });
+    const resourceProvider = providers.resources["test-resource-provider"];
+
+    if (!resourceProvider.validateResource) {
+      throw new Error("Expected validateResource to be defined.");
+    }
+
+    const validation = resourceProvider.validateResource({
+      resource: {
+        name: "primary-db",
+        provider: "test-resource-provider",
+        isolationStrategy: "name-scoped",
+        scopedReset: false,
+        scopedCleanup: false,
+        scopedValidate: true
+      },
+      derived: {
+        resourceName: "primary-db",
+        provider: "test-resource-provider",
+        isolationStrategy: "name-scoped",
+        worktreeId: "wt-contract-provider-failure",
+        handle: "primary-db--wt-contract-provider-failure"
+      },
+      worktree: {
+        id: "wt-contract-provider-failure"
+      }
+    });
+
+    expect(validation).toEqual({
+      category: "provider_failure",
+      reason: "Provider validation failed after safe scope was established."
+    });
+  });
+});

--- a/tests/unit/endpoint-declaration-boundary.test.ts
+++ b/tests/unit/endpoint-declaration-boundary.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   validateEndpointDeclaration,
   withValidatedEndpointDeclaration
-} from "../../packages/core/src/declarations";
+} from "../../packages/core/index";
 
 describe("endpoint declaration boundary validation", () => {
   it("accepts a valid endpoint declaration and returns a trusted representation", () => {

--- a/tests/unit/repository-configuration-boundary.test.ts
+++ b/tests/unit/repository-configuration-boundary.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   validateRepositoryConfiguration,
   withValidatedRepositoryConfiguration
-} from "../../packages/core/src/repository-configuration";
+} from "../../packages/core/index";
 import { createValidRepositoryConfiguration } from "../../packages/providers-testkit/index";
 
 describe("repository configuration boundary validation", () => {


### PR DESCRIPTION
Summary
- validate raw worktree identity before the core orchestration path treats it as trusted scope
- add acceptance coverage for reserved main identity and refusal of whitespace-only worktree IDs before provider invocation
- complete Slice 06 refusal propagation coverage and testkit support so provider-originated refusal categories survive core coordination unchanged
- update repository git workflow guidance so branch, commit, push, and PR creation are autonomous by default while merges remain human-only

Scope
- core orchestration boundary validation
- refusal propagation acceptance and contract coverage
- test provider fixtures for refusal paths
- repository workflow documentation and skill guidance

Validation
- scripts/codex-env.sh pnpm test:acceptance
- scripts/codex-env.sh pnpm test:contracts
- scripts/codex-env.sh pnpm test:unit
- scripts/codex-env.sh pnpm typecheck

Deferred
- workspace package manifests and explicit ESM package boundaries
- boundary enforcement for cross-package relative imports
- any deliberate taxonomy decision around remaining unsupported_capability versus provider_failure tension in existing docs/tests
