### PR TITLE
Implement explicit scoped resource reset

### DIFF
--- a/docs/development/tasks/dev-slice-08-task-01.md
+++ b/docs/development/tasks/dev-slice-08-task-01.md
@@ -1,0 +1,67 @@
+# Dev Slice 08 — Task 01
+
+## Title
+
+Execute one explicit scoped resource reset for one worktree instance, or refuse
+
+## Objective
+
+Implement the minimum production path that proves a destructive resource operation can be requested explicitly for one worktree instance while preserving refusal-first safety behavior.
+
+This task introduces one explicit reset operation for the current single-resource path.
+
+## Sources of truth
+
+Ground this task in:
+
+- `docs/adr/0005-providers-implement-isolation-contracts.md`
+- `docs/adr/0008-unsafe-operations-are-refused-in-1-0.md`
+- `docs/spec/provider-model.md`
+- `docs/spec/resource-isolation.md`
+- `docs/spec/repository-configuration.md`
+- `docs/spec/safety-and-refusal.md`
+- `docs/scenarios/provider-model.scenarios.md`
+- `docs/scenarios/resource-isolation.scenarios.md`
+- `docs/scenarios/safety-and-refusal.scenarios.md`
+- `docs/scenarios/system-boundary.scenarios.md`
+
+## Required outcome
+
+Implement the minimum production change such that:
+
+- the core can request one explicit scoped reset for one declared resource
+- reset is accepted only when repository intent and provider support both allow it
+- reset refuses when safe worktree scope cannot be established
+- reset does not guess, fall back, or silently proceed when scope is unsafe
+
+## In scope
+
+- one explicit reset entry path in the core
+- one resource provider reset contract surface
+- acceptance coverage for explicit reset happy path and refusal paths
+- provider contract tests needed for reset behavior
+- bounded refactor of the touched orchestration path if needed
+
+## Out of scope
+
+- cleanup execution
+- endpoint validation or lifecycle behavior
+- multiple-resource orchestration
+- CLI UX
+- broad runtime orchestration
+- speculative lifecycle abstractions beyond the needs of reset
+
+## Acceptance criteria
+
+- an explicitly supported scoped reset request succeeds for one worktree instance
+- unsupported reset intent is refused as `unsupported_capability`
+- unsafe scope for reset is refused as `unsafe_scope`
+- reset remains explicit and is not performed during derive-only paths
+- the implementation preserves the current core/provider/configuration boundaries
+
+## Safety and boundary expectations
+
+- destructive operations require safe scope determination before execution
+- no reset action may execute implicitly
+- provider-specific reset behavior remains in provider code
+- the core coordinates the reset request and preserves refusal categories

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,14 +1,17 @@
 import type {
   ProviderRegistry,
   Refusal,
+  ResetOneResourceResult,
   ResolveSlice01Result,
   ResolveSlice02Result,
   RepositoryConfiguration,
+  ResourceReset,
   ResourceValidation,
   WorktreeInstanceInput
 } from "@multiverse/provider-contracts";
-import { isRefusal, unsupportedCapability } from "./refusals";
+import { invalidConfiguration, isRefusal, unsupportedCapability } from "./refusals";
 import {
+  resolveSlicePreflight,
   resolveSliceExecution,
   type ResolvedSliceExecution
 } from "./orchestration";
@@ -32,6 +35,15 @@ function isFailureOutcome(
   return "ok" in value && value.ok === false;
 }
 
+function isFailureResult(value: unknown): value is Extract<ResolveSlice01Result, { ok: false }> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "ok" in value &&
+    value.ok === false
+  );
+}
+
 function validateResourcePlan(input: {
   provider: ResolvedSliceExecution["providers"]["resource"];
   resource: ResolvedSliceExecution["declarations"]["resource"];
@@ -50,6 +62,35 @@ function validateResourcePlan(input: {
   }
 
   return input.provider.validateResource({
+    resource: input.resource,
+    derived: input.derived,
+    worktree: input.worktree
+  });
+}
+
+function resetResourcePlan(input: {
+  provider: ResolvedSliceExecution["providers"]["resource"];
+  resource: ResolvedSliceExecution["declarations"]["resource"];
+  derived: ResolvedSliceExecution["derived"]["resourcePlan"];
+  worktree: {
+    id?: string;
+    label?: string;
+    branch?: string;
+  };
+}): ResourceReset | Refusal | Extract<ResetOneResourceResult, { ok: false }> {
+  if (!input.resource.scopedReset) {
+    return invalidConfiguration(
+      `Resource "${input.resource.name}" does not declare scoped reset intent.`
+    );
+  }
+
+  if (!input.provider.capabilities?.reset || !input.provider.resetResource) {
+    return unsupportedCapability(
+      `Resource provider "${input.resource.provider}" does not support reset.`
+    );
+  }
+
+  return input.provider.resetResource({
     resource: input.resource,
     derived: input.derived,
     worktree: input.worktree
@@ -122,5 +163,63 @@ export function resolveSlice02(input: {
     resourcePlans: [execution.derived.resourcePlan],
     endpointMappings: [execution.derived.endpointMapping],
     resourceValidations
+  };
+}
+
+export function resetOneResource(input: {
+  repository: RepositoryConfiguration;
+  worktree: WorktreeInstanceInput;
+  providers: ProviderRegistry;
+}): ResetOneResourceResult {
+  const preflight = resolveSlicePreflight({
+    ...input,
+    resourceCountReason: "Reset requires exactly one declared managed resource.",
+    endpointCountReason: "Reset requires exactly one declared managed endpoint."
+  });
+
+  if (isFailureResult(preflight)) {
+    return preflight;
+  }
+
+  if (!preflight.declarations.resource.scopedReset) {
+    return invalidConfiguration(
+      `Resource "${preflight.declarations.resource.name}" does not declare scoped reset intent.`
+    );
+  }
+
+  const resourcePlan = preflight.providers.resource.deriveResource({
+    resource: preflight.declarations.resource,
+    worktree: preflight.worktree
+  });
+
+  if (isRefusal(resourcePlan)) {
+    return {
+      ok: false,
+      refusal: resourcePlan
+    };
+  }
+
+  const reset = resetResourcePlan({
+    provider: preflight.providers.resource,
+    resource: preflight.declarations.resource,
+    derived: resourcePlan,
+    worktree: preflight.worktree
+  });
+
+  if (isFailureResult(reset)) {
+    return reset;
+  }
+
+  if (isRefusal(reset)) {
+    return {
+      ok: false,
+      refusal: reset
+    };
+  }
+
+  return {
+    ok: true,
+    resourcePlans: [resourcePlan],
+    resourceResets: [reset]
   };
 }

--- a/packages/provider-contracts/src/index.ts
+++ b/packages/provider-contracts/src/index.ts
@@ -69,6 +69,13 @@ export interface ResourceValidation {
   capability: "validate";
 }
 
+export interface ResourceReset {
+  resourceName: string;
+  provider: string;
+  worktreeId: string;
+  capability: "reset";
+}
+
 export interface ResourceProvider {
   capabilities?: ProviderCapabilities;
   deriveResource(input: {
@@ -102,6 +109,22 @@ export interface ResourceProvider {
       branch?: string;
     };
   }): ResourceValidation | Refusal;
+  resetResource?(input: {
+    resource: {
+      name: string;
+      provider: string;
+      isolationStrategy: IsolationStrategy;
+      scopedValidate: boolean;
+      scopedReset: boolean;
+      scopedCleanup: boolean;
+    };
+    derived: DerivedResourcePlan;
+    worktree: {
+      id?: string;
+      label?: string;
+      branch?: string;
+    };
+  }): ResourceReset | Refusal;
 }
 
 export interface EndpointProvider {
@@ -141,6 +164,17 @@ export type ResolveSlice02Result =
       resourcePlans: DerivedResourcePlan[];
       endpointMappings: DerivedEndpointMapping[];
       resourceValidations: ResourceValidation[];
+    }
+  | {
+      ok: false;
+      refusal: Refusal;
+    };
+
+export type ResetOneResourceResult =
+  | {
+      ok: true;
+      resourcePlans: DerivedResourcePlan[];
+      resourceResets: ResourceReset[];
     }
   | {
       ok: false;

--- a/packages/providers-testkit/src/index.ts
+++ b/packages/providers-testkit/src/index.ts
@@ -2,6 +2,7 @@ import type {
   DerivedResourcePlan,
   ProviderRegistry,
   Refusal,
+  ResourceReset,
   ResourceValidation,
   RepositoryConfiguration,
   WorktreeInstanceInput
@@ -34,6 +35,47 @@ function validateScopedResource(input: {
   };
 }
 
+function deriveScopedResource(input: {
+  resource: {
+    name: string;
+    provider: string;
+    isolationStrategy: DerivedResourcePlan["isolationStrategy"];
+  };
+  worktree: WorktreeInstanceInput;
+}): DerivedResourcePlan | Refusal {
+  if (!input.worktree.id) {
+    return unsafeScope("Safe worktree scope cannot be determined.");
+  }
+
+  return {
+    resourceName: input.resource.name,
+    provider: input.resource.provider,
+    isolationStrategy: input.resource.isolationStrategy,
+    worktreeId: input.worktree.id,
+    handle: `${input.resource.name}--${input.worktree.id}`
+  };
+}
+
+function resetScopedResource(input: {
+  resource: {
+    name: string;
+    provider: string;
+  };
+  derived: DerivedResourcePlan;
+  worktree: WorktreeInstanceInput;
+}): ResourceReset | Refusal {
+  if (!input.worktree.id) {
+    return unsafeScope("Safe worktree scope cannot be determined.");
+  }
+
+  return {
+    resourceName: input.resource.name,
+    provider: input.resource.provider,
+    worktreeId: input.derived.worktreeId,
+    capability: "reset"
+  };
+}
+
 export function createExplicitTestProviders(): ProviderRegistry {
   return {
     resources: {
@@ -42,17 +84,10 @@ export function createExplicitTestProviders(): ProviderRegistry {
           validate: true
         },
         deriveResource({ resource, worktree }) {
-          if (!worktree.id) {
-            return unsafeScope("Safe worktree scope cannot be determined.");
-          }
-
-          return {
-            resourceName: resource.name,
-            provider: resource.provider,
-            isolationStrategy: resource.isolationStrategy,
-            worktreeId: worktree.id,
-            handle: `${resource.name}--${worktree.id}`
-          };
+          return deriveScopedResource({
+            resource,
+            worktree
+          });
         },
         validateResource({ resource, derived, worktree }) {
           return validateScopedResource({
@@ -62,19 +97,30 @@ export function createExplicitTestProviders(): ProviderRegistry {
           });
         }
       },
+      "test-resource-provider-with-reset": {
+        capabilities: {
+          reset: true
+        },
+        deriveResource({ resource, worktree }) {
+          return deriveScopedResource({
+            resource,
+            worktree
+          });
+        },
+        resetResource({ resource, derived, worktree }) {
+          return resetScopedResource({
+            resource,
+            derived,
+            worktree
+          });
+        }
+      },
       "test-resource-provider-no-validate": {
         deriveResource({ resource, worktree }) {
-          if (!worktree.id) {
-            return unsafeScope("Safe worktree scope cannot be determined.");
-          }
-
-          return {
-            resourceName: resource.name,
-            provider: resource.provider,
-            isolationStrategy: resource.isolationStrategy,
-            worktreeId: worktree.id,
-            handle: `${resource.name}--${worktree.id}`
-          };
+          return deriveScopedResource({
+            resource,
+            worktree
+          });
         }
       }
     },
@@ -135,6 +181,21 @@ export function createProvidersWithResourceValidateRefusal(
   providers.resources["test-resource-provider"] = {
     ...providers.resources["test-resource-provider"],
     validateResource() {
+      return refusal;
+    }
+  };
+
+  return providers;
+}
+
+export function createProvidersWithResourceResetRefusal(
+  refusal: Refusal
+): ProviderRegistry {
+  const providers = createExplicitTestProviders();
+
+  providers.resources["test-resource-provider-with-reset"] = {
+    ...providers.resources["test-resource-provider-with-reset"],
+    resetResource() {
       return refusal;
     }
   };

--- a/tests/acceptance/dev-slice-08.acceptance.test.ts
+++ b/tests/acceptance/dev-slice-08.acceptance.test.ts
@@ -1,0 +1,245 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { resetOneResource, resolveSlice01 } from "@multiverse/core";
+import {
+  createExplicitTestProviders,
+  createProvidersWithResourceResetRefusal,
+  createValidRepositoryConfiguration,
+  createWorktreeInstance
+} from "@multiverse/providers-testkit";
+
+describe("Development Slice 08 acceptance", () => {
+  it("executes one explicit scoped reset when reset is supported", () => {
+    const outcome = resetOneResource({
+      repository: createValidRepositoryConfiguration({
+        resources: [
+          {
+            name: "primary-db",
+            provider: "test-resource-provider-with-reset",
+            isolationStrategy: "name-scoped",
+            scopedValidate: false,
+            scopedReset: true,
+            scopedCleanup: false
+          }
+        ]
+      }),
+      worktree: createWorktreeInstance({
+        id: "wt-reset-supported"
+      }),
+      providers: createExplicitTestProviders()
+    });
+
+    expect(outcome).toEqual({
+      ok: true,
+      resourcePlans: [
+        {
+          resourceName: "primary-db",
+          provider: "test-resource-provider-with-reset",
+          isolationStrategy: "name-scoped",
+          worktreeId: "wt-reset-supported",
+          handle: "primary-db--wt-reset-supported"
+        }
+      ],
+      resourceResets: [
+        {
+          resourceName: "primary-db",
+          provider: "test-resource-provider-with-reset",
+          worktreeId: "wt-reset-supported",
+          capability: "reset"
+        }
+      ]
+    });
+  });
+
+  it("refuses unsupported reset intent explicitly", () => {
+    const providers = createExplicitTestProviders();
+    const deriveResource = vi.spyOn(
+      providers.resources["test-resource-provider"],
+      "deriveResource"
+    );
+
+    const outcome = resetOneResource({
+      repository: createValidRepositoryConfiguration({
+        resources: [
+          {
+            name: "primary-db",
+            provider: "test-resource-provider",
+            isolationStrategy: "name-scoped",
+            scopedValidate: false,
+            scopedReset: true,
+            scopedCleanup: false
+          }
+        ]
+      }),
+      worktree: createWorktreeInstance({
+        id: "wt-reset-unsupported"
+      }),
+      providers
+    });
+
+    expect(outcome).toMatchObject({
+      ok: false,
+      refusal: {
+        category: "unsupported_capability"
+      }
+    });
+    expect(deriveResource).not.toHaveBeenCalled();
+  });
+
+  it("refuses reset when repository intent does not enable scoped reset", () => {
+    const providers = createExplicitTestProviders();
+    const deriveResource = vi.spyOn(
+      providers.resources["test-resource-provider-with-reset"],
+      "deriveResource"
+    );
+
+    const outcome = resetOneResource({
+      repository: createValidRepositoryConfiguration({
+        resources: [
+          {
+            name: "primary-db",
+            provider: "test-resource-provider-with-reset",
+            isolationStrategy: "name-scoped",
+            scopedValidate: false,
+            scopedReset: false,
+            scopedCleanup: false
+          }
+        ]
+      }),
+      worktree: createWorktreeInstance({
+        id: "wt-reset-not-intended"
+      }),
+      providers
+    });
+
+    expect(outcome).toMatchObject({
+      ok: false,
+      refusal: {
+        category: "invalid_configuration"
+      }
+    });
+    expect(deriveResource).not.toHaveBeenCalled();
+  });
+
+  it("refuses reset when safe scope cannot be established", () => {
+    const outcome = resetOneResource({
+      repository: createValidRepositoryConfiguration({
+        resources: [
+          {
+            name: "primary-db",
+            provider: "test-resource-provider-with-reset",
+            isolationStrategy: "name-scoped",
+            scopedValidate: false,
+            scopedReset: true,
+            scopedCleanup: false
+          }
+        ]
+      }),
+      worktree: createWorktreeInstance({
+        label: "reset-unsafe-scope"
+      }),
+      providers: createExplicitTestProviders()
+    });
+
+    expect(outcome).toMatchObject({
+      ok: false,
+      refusal: {
+        category: "unsafe_scope"
+      }
+    });
+  });
+
+  it("does not perform reset implicitly during derive-only resolution", () => {
+    const providers = createExplicitTestProviders();
+    const resetResource = vi.spyOn(
+      providers.resources["test-resource-provider-with-reset"],
+      "resetResource"
+    );
+
+    const outcome = resolveSlice01({
+      repository: createValidRepositoryConfiguration({
+        resources: [
+          {
+            name: "primary-db",
+            provider: "test-resource-provider-with-reset",
+            isolationStrategy: "name-scoped",
+            scopedValidate: false,
+            scopedReset: true,
+            scopedCleanup: false
+          }
+        ]
+      }),
+      worktree: createWorktreeInstance({
+        id: "wt-no-implicit-reset"
+      }),
+      providers
+    });
+
+    expect(outcome.ok).toBe(true);
+    expect(resetResource).not.toHaveBeenCalled();
+  });
+
+  it("returns provider-originated unsafe scope during reset unchanged", () => {
+    const outcome = resetOneResource({
+      repository: createValidRepositoryConfiguration({
+        resources: [
+          {
+            name: "primary-db",
+            provider: "test-resource-provider-with-reset",
+            isolationStrategy: "name-scoped",
+            scopedValidate: false,
+            scopedReset: true,
+            scopedCleanup: false
+          }
+        ]
+      }),
+      worktree: createWorktreeInstance({
+        id: "wt-provider-unsafe-reset"
+      }),
+      providers: createProvidersWithResourceResetRefusal({
+        category: "unsafe_scope",
+        reason: "Provider could not verify owning scope for reset."
+      })
+    });
+
+    expect(outcome).toEqual({
+      ok: false,
+      refusal: {
+        category: "unsafe_scope",
+        reason: "Provider could not verify owning scope for reset."
+      }
+    });
+  });
+
+  it("returns provider-originated provider failure during reset unchanged", () => {
+    const outcome = resetOneResource({
+      repository: createValidRepositoryConfiguration({
+        resources: [
+          {
+            name: "primary-db",
+            provider: "test-resource-provider-with-reset",
+            isolationStrategy: "name-scoped",
+            scopedValidate: false,
+            scopedReset: true,
+            scopedCleanup: false
+          }
+        ]
+      }),
+      worktree: createWorktreeInstance({
+        id: "wt-provider-failure-reset"
+      }),
+      providers: createProvidersWithResourceResetRefusal({
+        category: "provider_failure",
+        reason: "Provider reset failed after safe scope was established."
+      })
+    });
+
+    expect(outcome).toEqual({
+      ok: false,
+      refusal: {
+        category: "provider_failure",
+        reason: "Provider reset failed after safe scope was established."
+      }
+    });
+  });
+});

--- a/tests/contracts/resource-provider.refusal.contract.test.ts
+++ b/tests/contracts/resource-provider.refusal.contract.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { createProvidersWithResourceValidateRefusal } from "@multiverse/providers-testkit";
+import {
+  createProvidersWithResourceResetRefusal,
+  createProvidersWithResourceValidateRefusal
+} from "@multiverse/providers-testkit";
 
 describe("resource provider refusal contract", () => {
   it("may refuse validate with provider failure distinctly from unsafe scope", () => {
@@ -38,6 +41,44 @@ describe("resource provider refusal contract", () => {
     expect(validation).toEqual({
       category: "provider_failure",
       reason: "Provider validation failed after safe scope was established."
+    });
+  });
+
+  it("may refuse reset with provider failure distinctly from unsafe scope", () => {
+    const providers = createProvidersWithResourceResetRefusal({
+      category: "provider_failure",
+      reason: "Provider reset failed after safe scope was established."
+    });
+    const resourceProvider = providers.resources["test-resource-provider-with-reset"];
+
+    if (!resourceProvider.resetResource) {
+      throw new Error("Expected resetResource to be defined.");
+    }
+
+    const reset = resourceProvider.resetResource({
+      resource: {
+        name: "primary-db",
+        provider: "test-resource-provider-with-reset",
+        isolationStrategy: "name-scoped",
+        scopedReset: true,
+        scopedCleanup: false,
+        scopedValidate: false
+      },
+      derived: {
+        resourceName: "primary-db",
+        provider: "test-resource-provider-with-reset",
+        isolationStrategy: "name-scoped",
+        worktreeId: "wt-contract-provider-failure",
+        handle: "primary-db--wt-contract-provider-failure"
+      },
+      worktree: {
+        id: "wt-contract-provider-failure"
+      }
+    });
+
+    expect(reset).toEqual({
+      category: "provider_failure",
+      reason: "Provider reset failed after safe scope was established."
     });
   });
 });

--- a/tests/contracts/resource-provider.reset.contract.test.ts
+++ b/tests/contracts/resource-provider.reset.contract.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+
+import { createExplicitTestProviders } from "@multiverse/providers-testkit";
+
+describe("resource provider reset contract", () => {
+  it("declares reset support explicitly and resets one worktree instance", () => {
+    const providers = createExplicitTestProviders();
+    const resourceProvider = providers.resources["test-resource-provider-with-reset"];
+
+    expect(resourceProvider.capabilities).toEqual({
+      reset: true
+    });
+
+    if (!resourceProvider.resetResource) {
+      throw new Error("Expected resetResource to be defined.");
+    }
+
+    const reset = resourceProvider.resetResource({
+      resource: {
+        name: "primary-db",
+        provider: "test-resource-provider-with-reset",
+        isolationStrategy: "name-scoped",
+        scopedReset: true,
+        scopedCleanup: false,
+        scopedValidate: false
+      },
+      derived: {
+        resourceName: "primary-db",
+        provider: "test-resource-provider-with-reset",
+        isolationStrategy: "name-scoped",
+        worktreeId: "wt-reset-contract",
+        handle: "primary-db--wt-reset-contract"
+      },
+      worktree: {
+        id: "wt-reset-contract"
+      }
+    });
+
+    expect(reset).toEqual({
+      resourceName: "primary-db",
+      provider: "test-resource-provider-with-reset",
+      worktreeId: "wt-reset-contract",
+      capability: "reset"
+    });
+  });
+
+  it("refuses reset when provider-level scope safety cannot be established", () => {
+    const providers = createExplicitTestProviders();
+    const resourceProvider = providers.resources["test-resource-provider-with-reset"];
+
+    if (!resourceProvider.resetResource) {
+      throw new Error("Expected resetResource to be defined.");
+    }
+
+    const reset = resourceProvider.resetResource({
+      resource: {
+        name: "primary-db",
+        provider: "test-resource-provider-with-reset",
+        isolationStrategy: "name-scoped",
+        scopedReset: true,
+        scopedCleanup: false,
+        scopedValidate: false
+      },
+      derived: {
+        resourceName: "primary-db",
+        provider: "test-resource-provider-with-reset",
+        isolationStrategy: "name-scoped",
+        worktreeId: "wt-reset-contract",
+        handle: "primary-db--wt-reset-contract"
+      },
+      worktree: {
+        label: "reset-contract-unsafe-scope"
+      }
+    });
+
+    expect(reset).toMatchObject({
+      category: "unsafe_scope"
+    });
+  });
+});


### PR DESCRIPTION
Summary
- add one explicit scoped reset entry path for the current single-resource model
- extend the resource provider contract and testkit with reset support for one worktree instance
- prove reset refusal behavior and non-implicit destructive behavior through acceptance and contract tests

Scope
- core reset coordination for one resource
- resource provider reset contract surface
- acceptance and contract coverage for reset success and refusal paths
- task documentation for the new slice

Validation
- scripts/codex-env.sh pnpm run check:boundaries
- scripts/codex-env.sh pnpm typecheck
- scripts/codex-env.sh pnpm test:acceptance
- scripts/codex-env.sh pnpm test:contracts
- scripts/codex-env.sh pnpm test:unit

Deferred
- cleanup execution
- endpoint lifecycle behavior
- CLI exposure of the reset path
- broader lifecycle orchestration beyond one explicit reset request
