### PR TITLE
Implement explicit scoped cleanup

### DIFF
--- a/docs/development/tasks/dev-slice-09-task-01.md
+++ b/docs/development/tasks/dev-slice-09-task-01.md
@@ -1,0 +1,68 @@
+# Dev Slice 09 — Task 01
+
+## Title
+
+Execute one explicit scoped resource cleanup for one worktree instance, or refuse
+
+## Objective
+
+Implement the minimum production path that proves a destructive cleanup operation can be requested explicitly for one worktree instance while preserving refusal-first safety behavior.
+
+This task introduces one explicit cleanup operation for the current single-resource path.
+
+## Sources of truth
+
+Ground this task in:
+
+- `docs/adr/0005-providers-implement-isolation-contracts.md`
+- `docs/adr/0008-unsafe-operations-are-refused-in-1-0.md`
+- `docs/spec/provider-model.md`
+- `docs/spec/resource-isolation.md`
+- `docs/spec/repository-configuration.md`
+- `docs/spec/safety-and-refusal.md`
+- `docs/scenarios/provider-model.scenarios.md`
+- `docs/scenarios/resource-isolation.scenarios.md`
+- `docs/scenarios/safety-and-refusal.scenarios.md`
+- `docs/scenarios/system-boundary.scenarios.md`
+
+## Required outcome
+
+Implement the minimum production change such that:
+
+- the core can request one explicit scoped cleanup for one declared resource
+- cleanup is accepted only when repository intent and provider support both allow it
+- cleanup refuses when safe worktree scope cannot be established
+- cleanup does not guess, fall back, or silently proceed when scope is unsafe
+
+## In scope
+
+- one explicit cleanup entry path in the core
+- one resource provider cleanup contract surface
+- acceptance coverage for explicit cleanup happy path and refusal paths
+- provider contract tests needed for cleanup behavior
+- bounded refactor of the touched orchestration path if needed
+
+## Out of scope
+
+- reset execution changes beyond preserving existing behavior
+- endpoint validation or lifecycle behavior
+- multiple-resource orchestration
+- CLI UX
+- broad runtime orchestration
+- speculative lifecycle abstractions beyond the needs of cleanup
+
+## Acceptance criteria
+
+- an explicitly supported scoped cleanup request succeeds for one worktree instance
+- unsupported cleanup intent is refused as `unsupported_capability`
+- cleanup without explicit repository intent is refused as `invalid_configuration`
+- unsafe scope for cleanup is refused as `unsafe_scope`
+- cleanup remains explicit and is not performed during derive-only paths
+- the implementation preserves the current core/provider/configuration boundaries
+
+## Safety and boundary expectations
+
+- destructive operations require safe scope determination before execution
+- no cleanup action may execute implicitly
+- provider-specific cleanup behavior remains in provider code
+- the core coordinates the cleanup request and preserves refusal categories

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,8 @@
 import type {
+  CleanupOneResourceResult,
   ProviderRegistry,
   Refusal,
+  ResourceCleanup,
   ResetOneResourceResult,
   ResolveSlice01Result,
   ResolveSlice02Result,
@@ -91,6 +93,35 @@ function resetResourcePlan(input: {
   }
 
   return input.provider.resetResource({
+    resource: input.resource,
+    derived: input.derived,
+    worktree: input.worktree
+  });
+}
+
+function cleanupResourcePlan(input: {
+  provider: ResolvedSliceExecution["providers"]["resource"];
+  resource: ResolvedSliceExecution["declarations"]["resource"];
+  derived: ResolvedSliceExecution["derived"]["resourcePlan"];
+  worktree: {
+    id?: string;
+    label?: string;
+    branch?: string;
+  };
+}): ResourceCleanup | Refusal | Extract<CleanupOneResourceResult, { ok: false }> {
+  if (!input.resource.scopedCleanup) {
+    return invalidConfiguration(
+      `Resource "${input.resource.name}" does not declare scoped cleanup intent.`
+    );
+  }
+
+  if (!input.provider.capabilities?.cleanup || !input.provider.cleanupResource) {
+    return unsupportedCapability(
+      `Resource provider "${input.resource.provider}" does not support cleanup.`
+    );
+  }
+
+  return input.provider.cleanupResource({
     resource: input.resource,
     derived: input.derived,
     worktree: input.worktree
@@ -221,5 +252,63 @@ export function resetOneResource(input: {
     ok: true,
     resourcePlans: [resourcePlan],
     resourceResets: [reset]
+  };
+}
+
+export function cleanupOneResource(input: {
+  repository: RepositoryConfiguration;
+  worktree: WorktreeInstanceInput;
+  providers: ProviderRegistry;
+}): CleanupOneResourceResult {
+  const preflight = resolveSlicePreflight({
+    ...input,
+    resourceCountReason: "Cleanup requires exactly one declared managed resource.",
+    endpointCountReason: "Cleanup requires exactly one declared managed endpoint."
+  });
+
+  if (isFailureResult(preflight)) {
+    return preflight;
+  }
+
+  if (!preflight.declarations.resource.scopedCleanup) {
+    return invalidConfiguration(
+      `Resource "${preflight.declarations.resource.name}" does not declare scoped cleanup intent.`
+    );
+  }
+
+  const resourcePlan = preflight.providers.resource.deriveResource({
+    resource: preflight.declarations.resource,
+    worktree: preflight.worktree
+  });
+
+  if (isRefusal(resourcePlan)) {
+    return {
+      ok: false,
+      refusal: resourcePlan
+    };
+  }
+
+  const cleanup = cleanupResourcePlan({
+    provider: preflight.providers.resource,
+    resource: preflight.declarations.resource,
+    derived: resourcePlan,
+    worktree: preflight.worktree
+  });
+
+  if (isFailureResult(cleanup)) {
+    return cleanup;
+  }
+
+  if (isRefusal(cleanup)) {
+    return {
+      ok: false,
+      refusal: cleanup
+    };
+  }
+
+  return {
+    ok: true,
+    resourcePlans: [resourcePlan],
+    resourceCleanups: [cleanup]
   };
 }

--- a/packages/provider-contracts/src/index.ts
+++ b/packages/provider-contracts/src/index.ts
@@ -76,6 +76,13 @@ export interface ResourceReset {
   capability: "reset";
 }
 
+export interface ResourceCleanup {
+  resourceName: string;
+  provider: string;
+  worktreeId: string;
+  capability: "cleanup";
+}
+
 export interface ResourceProvider {
   capabilities?: ProviderCapabilities;
   deriveResource(input: {
@@ -125,6 +132,22 @@ export interface ResourceProvider {
       branch?: string;
     };
   }): ResourceReset | Refusal;
+  cleanupResource?(input: {
+    resource: {
+      name: string;
+      provider: string;
+      isolationStrategy: IsolationStrategy;
+      scopedValidate: boolean;
+      scopedReset: boolean;
+      scopedCleanup: boolean;
+    };
+    derived: DerivedResourcePlan;
+    worktree: {
+      id?: string;
+      label?: string;
+      branch?: string;
+    };
+  }): ResourceCleanup | Refusal;
 }
 
 export interface EndpointProvider {
@@ -175,6 +198,17 @@ export type ResetOneResourceResult =
       ok: true;
       resourcePlans: DerivedResourcePlan[];
       resourceResets: ResourceReset[];
+    }
+  | {
+      ok: false;
+      refusal: Refusal;
+    };
+
+export type CleanupOneResourceResult =
+  | {
+      ok: true;
+      resourcePlans: DerivedResourcePlan[];
+      resourceCleanups: ResourceCleanup[];
     }
   | {
       ok: false;

--- a/packages/providers-testkit/src/index.ts
+++ b/packages/providers-testkit/src/index.ts
@@ -1,4 +1,5 @@
 import type {
+  ResourceCleanup,
   DerivedResourcePlan,
   ProviderRegistry,
   Refusal,
@@ -76,6 +77,26 @@ function resetScopedResource(input: {
   };
 }
 
+function cleanupScopedResource(input: {
+  resource: {
+    name: string;
+    provider: string;
+  };
+  derived: DerivedResourcePlan;
+  worktree: WorktreeInstanceInput;
+}): ResourceCleanup | Refusal {
+  if (!input.worktree.id) {
+    return unsafeScope("Safe worktree scope cannot be determined.");
+  }
+
+  return {
+    resourceName: input.resource.name,
+    provider: input.resource.provider,
+    worktreeId: input.derived.worktreeId,
+    capability: "cleanup"
+  };
+}
+
 export function createExplicitTestProviders(): ProviderRegistry {
   return {
     resources: {
@@ -109,6 +130,24 @@ export function createExplicitTestProviders(): ProviderRegistry {
         },
         resetResource({ resource, derived, worktree }) {
           return resetScopedResource({
+            resource,
+            derived,
+            worktree
+          });
+        }
+      },
+      "test-resource-provider-with-cleanup": {
+        capabilities: {
+          cleanup: true
+        },
+        deriveResource({ resource, worktree }) {
+          return deriveScopedResource({
+            resource,
+            worktree
+          });
+        },
+        cleanupResource({ resource, derived, worktree }) {
+          return cleanupScopedResource({
             resource,
             derived,
             worktree
@@ -196,6 +235,21 @@ export function createProvidersWithResourceResetRefusal(
   providers.resources["test-resource-provider-with-reset"] = {
     ...providers.resources["test-resource-provider-with-reset"],
     resetResource() {
+      return refusal;
+    }
+  };
+
+  return providers;
+}
+
+export function createProvidersWithResourceCleanupRefusal(
+  refusal: Refusal
+): ProviderRegistry {
+  const providers = createExplicitTestProviders();
+
+  providers.resources["test-resource-provider-with-cleanup"] = {
+    ...providers.resources["test-resource-provider-with-cleanup"],
+    cleanupResource() {
       return refusal;
     }
   };

--- a/tests/acceptance/dev-slice-09.acceptance.test.ts
+++ b/tests/acceptance/dev-slice-09.acceptance.test.ts
@@ -1,0 +1,245 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { cleanupOneResource, resolveSlice01 } from "@multiverse/core";
+import {
+  createExplicitTestProviders,
+  createProvidersWithResourceCleanupRefusal,
+  createValidRepositoryConfiguration,
+  createWorktreeInstance
+} from "@multiverse/providers-testkit";
+
+describe("Development Slice 09 acceptance", () => {
+  it("executes one explicit scoped cleanup when cleanup is supported", () => {
+    const outcome = cleanupOneResource({
+      repository: createValidRepositoryConfiguration({
+        resources: [
+          {
+            name: "primary-db",
+            provider: "test-resource-provider-with-cleanup",
+            isolationStrategy: "name-scoped",
+            scopedValidate: false,
+            scopedReset: false,
+            scopedCleanup: true
+          }
+        ]
+      }),
+      worktree: createWorktreeInstance({
+        id: "wt-cleanup-supported"
+      }),
+      providers: createExplicitTestProviders()
+    });
+
+    expect(outcome).toEqual({
+      ok: true,
+      resourcePlans: [
+        {
+          resourceName: "primary-db",
+          provider: "test-resource-provider-with-cleanup",
+          isolationStrategy: "name-scoped",
+          worktreeId: "wt-cleanup-supported",
+          handle: "primary-db--wt-cleanup-supported"
+        }
+      ],
+      resourceCleanups: [
+        {
+          resourceName: "primary-db",
+          provider: "test-resource-provider-with-cleanup",
+          worktreeId: "wt-cleanup-supported",
+          capability: "cleanup"
+        }
+      ]
+    });
+  });
+
+  it("refuses unsupported cleanup intent explicitly", () => {
+    const providers = createExplicitTestProviders();
+    const deriveResource = vi.spyOn(
+      providers.resources["test-resource-provider"],
+      "deriveResource"
+    );
+
+    const outcome = cleanupOneResource({
+      repository: createValidRepositoryConfiguration({
+        resources: [
+          {
+            name: "primary-db",
+            provider: "test-resource-provider",
+            isolationStrategy: "name-scoped",
+            scopedValidate: false,
+            scopedReset: false,
+            scopedCleanup: true
+          }
+        ]
+      }),
+      worktree: createWorktreeInstance({
+        id: "wt-cleanup-unsupported"
+      }),
+      providers
+    });
+
+    expect(outcome).toMatchObject({
+      ok: false,
+      refusal: {
+        category: "unsupported_capability"
+      }
+    });
+    expect(deriveResource).not.toHaveBeenCalled();
+  });
+
+  it("refuses cleanup when repository intent does not enable scoped cleanup", () => {
+    const providers = createExplicitTestProviders();
+    const deriveResource = vi.spyOn(
+      providers.resources["test-resource-provider-with-cleanup"],
+      "deriveResource"
+    );
+
+    const outcome = cleanupOneResource({
+      repository: createValidRepositoryConfiguration({
+        resources: [
+          {
+            name: "primary-db",
+            provider: "test-resource-provider-with-cleanup",
+            isolationStrategy: "name-scoped",
+            scopedValidate: false,
+            scopedReset: false,
+            scopedCleanup: false
+          }
+        ]
+      }),
+      worktree: createWorktreeInstance({
+        id: "wt-cleanup-not-intended"
+      }),
+      providers
+    });
+
+    expect(outcome).toMatchObject({
+      ok: false,
+      refusal: {
+        category: "invalid_configuration"
+      }
+    });
+    expect(deriveResource).not.toHaveBeenCalled();
+  });
+
+  it("refuses cleanup when safe scope cannot be established", () => {
+    const outcome = cleanupOneResource({
+      repository: createValidRepositoryConfiguration({
+        resources: [
+          {
+            name: "primary-db",
+            provider: "test-resource-provider-with-cleanup",
+            isolationStrategy: "name-scoped",
+            scopedValidate: false,
+            scopedReset: false,
+            scopedCleanup: true
+          }
+        ]
+      }),
+      worktree: createWorktreeInstance({
+        label: "cleanup-unsafe-scope"
+      }),
+      providers: createExplicitTestProviders()
+    });
+
+    expect(outcome).toMatchObject({
+      ok: false,
+      refusal: {
+        category: "unsafe_scope"
+      }
+    });
+  });
+
+  it("does not perform cleanup implicitly during derive-only resolution", () => {
+    const providers = createExplicitTestProviders();
+    const cleanupResource = vi.spyOn(
+      providers.resources["test-resource-provider-with-cleanup"],
+      "cleanupResource"
+    );
+
+    const outcome = resolveSlice01({
+      repository: createValidRepositoryConfiguration({
+        resources: [
+          {
+            name: "primary-db",
+            provider: "test-resource-provider-with-cleanup",
+            isolationStrategy: "name-scoped",
+            scopedValidate: false,
+            scopedReset: false,
+            scopedCleanup: true
+          }
+        ]
+      }),
+      worktree: createWorktreeInstance({
+        id: "wt-no-implicit-cleanup"
+      }),
+      providers
+    });
+
+    expect(outcome.ok).toBe(true);
+    expect(cleanupResource).not.toHaveBeenCalled();
+  });
+
+  it("returns provider-originated unsafe scope during cleanup unchanged", () => {
+    const outcome = cleanupOneResource({
+      repository: createValidRepositoryConfiguration({
+        resources: [
+          {
+            name: "primary-db",
+            provider: "test-resource-provider-with-cleanup",
+            isolationStrategy: "name-scoped",
+            scopedValidate: false,
+            scopedReset: false,
+            scopedCleanup: true
+          }
+        ]
+      }),
+      worktree: createWorktreeInstance({
+        id: "wt-provider-unsafe-cleanup"
+      }),
+      providers: createProvidersWithResourceCleanupRefusal({
+        category: "unsafe_scope",
+        reason: "Provider could not verify owning scope for cleanup."
+      })
+    });
+
+    expect(outcome).toEqual({
+      ok: false,
+      refusal: {
+        category: "unsafe_scope",
+        reason: "Provider could not verify owning scope for cleanup."
+      }
+    });
+  });
+
+  it("returns provider-originated provider failure during cleanup unchanged", () => {
+    const outcome = cleanupOneResource({
+      repository: createValidRepositoryConfiguration({
+        resources: [
+          {
+            name: "primary-db",
+            provider: "test-resource-provider-with-cleanup",
+            isolationStrategy: "name-scoped",
+            scopedValidate: false,
+            scopedReset: false,
+            scopedCleanup: true
+          }
+        ]
+      }),
+      worktree: createWorktreeInstance({
+        id: "wt-provider-failure-cleanup"
+      }),
+      providers: createProvidersWithResourceCleanupRefusal({
+        category: "provider_failure",
+        reason: "Provider cleanup failed after safe scope was established."
+      })
+    });
+
+    expect(outcome).toEqual({
+      ok: false,
+      refusal: {
+        category: "provider_failure",
+        reason: "Provider cleanup failed after safe scope was established."
+      }
+    });
+  });
+});

--- a/tests/contracts/resource-provider.cleanup.contract.test.ts
+++ b/tests/contracts/resource-provider.cleanup.contract.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createExplicitTestProviders,
+  createProvidersWithResourceCleanupRefusal
+} from "@multiverse/providers-testkit";
+
+describe("resource provider cleanup contract", () => {
+  it("declares cleanup support explicitly and cleans up one worktree instance", () => {
+    const providers = createExplicitTestProviders();
+    const resourceProvider = providers.resources["test-resource-provider-with-cleanup"];
+
+    expect(resourceProvider.capabilities).toEqual({
+      cleanup: true
+    });
+
+    if (!resourceProvider.cleanupResource) {
+      throw new Error("Expected cleanupResource to be defined.");
+    }
+
+    const cleanup = resourceProvider.cleanupResource({
+      resource: {
+        name: "primary-db",
+        provider: "test-resource-provider-with-cleanup",
+        isolationStrategy: "name-scoped",
+        scopedReset: false,
+        scopedCleanup: true,
+        scopedValidate: false
+      },
+      derived: {
+        resourceName: "primary-db",
+        provider: "test-resource-provider-with-cleanup",
+        isolationStrategy: "name-scoped",
+        worktreeId: "wt-cleanup-contract",
+        handle: "primary-db--wt-cleanup-contract"
+      },
+      worktree: {
+        id: "wt-cleanup-contract"
+      }
+    });
+
+    expect(cleanup).toEqual({
+      resourceName: "primary-db",
+      provider: "test-resource-provider-with-cleanup",
+      worktreeId: "wt-cleanup-contract",
+      capability: "cleanup"
+    });
+  });
+
+  it("refuses cleanup when provider-level scope safety cannot be established", () => {
+    const providers = createExplicitTestProviders();
+    const resourceProvider = providers.resources["test-resource-provider-with-cleanup"];
+
+    if (!resourceProvider.cleanupResource) {
+      throw new Error("Expected cleanupResource to be defined.");
+    }
+
+    const cleanup = resourceProvider.cleanupResource({
+      resource: {
+        name: "primary-db",
+        provider: "test-resource-provider-with-cleanup",
+        isolationStrategy: "name-scoped",
+        scopedReset: false,
+        scopedCleanup: true,
+        scopedValidate: false
+      },
+      derived: {
+        resourceName: "primary-db",
+        provider: "test-resource-provider-with-cleanup",
+        isolationStrategy: "name-scoped",
+        worktreeId: "wt-cleanup-contract",
+        handle: "primary-db--wt-cleanup-contract"
+      },
+      worktree: {
+        label: "cleanup-contract-unsafe-scope"
+      }
+    });
+
+    expect(cleanup).toMatchObject({
+      category: "unsafe_scope"
+    });
+  });
+
+  it("may refuse cleanup with provider failure distinctly from unsafe scope", () => {
+    const providers = createProvidersWithResourceCleanupRefusal({
+      category: "provider_failure",
+      reason: "Provider cleanup failed after safe scope was established."
+    });
+    const resourceProvider = providers.resources["test-resource-provider-with-cleanup"];
+
+    if (!resourceProvider.cleanupResource) {
+      throw new Error("Expected cleanupResource to be defined.");
+    }
+
+    const cleanup = resourceProvider.cleanupResource({
+      resource: {
+        name: "primary-db",
+        provider: "test-resource-provider-with-cleanup",
+        isolationStrategy: "name-scoped",
+        scopedReset: false,
+        scopedCleanup: true,
+        scopedValidate: false
+      },
+      derived: {
+        resourceName: "primary-db",
+        provider: "test-resource-provider-with-cleanup",
+        isolationStrategy: "name-scoped",
+        worktreeId: "wt-cleanup-provider-failure",
+        handle: "primary-db--wt-cleanup-provider-failure"
+      },
+      worktree: {
+        id: "wt-cleanup-provider-failure"
+      }
+    });
+
+    expect(cleanup).toEqual({
+      category: "provider_failure",
+      reason: "Provider cleanup failed after safe scope was established."
+    });
+  });
+});


### PR DESCRIPTION
Summary
- add one explicit scoped cleanup path for the current single-resource model
- refuse unsupported cleanup intent, missing cleanup intent, and unsafe cleanup scope before destructive action proceeds
- preserve provider-originated refusal categories during cleanup and prove cleanup does not execute implicitly during derive-only flows

Scope
- cleanup contract surface in provider-contracts
- cleanup coordination in core
- cleanup support in providers-testkit
- acceptance and contract coverage for the cleanup slice
- task doc for the slice

Validation
- scripts/codex-env.sh pnpm run check:boundaries
- scripts/codex-env.sh pnpm typecheck
- scripts/codex-env.sh pnpm test:acceptance
- scripts/codex-env.sh pnpm test:contracts
- scripts/codex-env.sh pnpm test:unit

Deferred
- CLI entrypoint over the now-proven derive, validate, reset, and cleanup paths
- sample app or sample repo trialing
- lint-based replacement for the temporary boundary guard script
