### PR TITLE
Add thin CLI validation seam

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@multiverse/cli",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "@multiverse/core": "workspace:*",
+    "@multiverse/provider-contracts": "workspace:*"
+  }
+}

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -1,0 +1,109 @@
+import { readFile } from "node:fs/promises";
+import process from "node:process";
+
+import {
+  validateRepositoryConfiguration,
+  validateWorktreeIdentity
+} from "@multiverse/core";
+import type { RepositoryConfiguration } from "@multiverse/provider-contracts";
+
+export interface CliResult {
+  exitCode: number;
+  stdout: string[];
+  stderr: string[];
+}
+
+function success(value: unknown): CliResult {
+  return {
+    exitCode: 0,
+    stdout: [JSON.stringify(value)],
+    stderr: []
+  };
+}
+
+function failure(value: unknown): CliResult {
+  return {
+    exitCode: 1,
+    stdout: [JSON.stringify(value)],
+    stderr: []
+  };
+}
+
+function usage(message: string): CliResult {
+  return {
+    exitCode: 1,
+    stdout: [],
+    stderr: [message]
+  };
+}
+
+function readOption(args: string[], name: string): string | undefined {
+  const index = args.indexOf(name);
+  if (index === -1) {
+    return undefined;
+  }
+
+  return args[index + 1];
+}
+
+async function validateRepositoryFromFile(configPath: string): Promise<CliResult> {
+  const raw = await readFile(configPath, "utf8");
+  const parsed = JSON.parse(raw) as RepositoryConfiguration;
+  const result = validateRepositoryConfiguration(parsed);
+
+  return result.ok ? success(result) : failure(result);
+}
+
+export async function runCli(args: string[]): Promise<CliResult> {
+  const [command] = args;
+
+  if (command === "validate-worktree") {
+    const worktreeId = readOption(args, "--worktree-id");
+
+    if (worktreeId === undefined) {
+      return usage("Missing required option --worktree-id");
+    }
+
+    const result = validateWorktreeIdentity({
+      worktreeId
+    });
+
+    return result.ok ? success(result) : failure(result);
+  }
+
+  if (command === "validate-repository") {
+    const configPath = readOption(args, "--config");
+
+    if (configPath === undefined) {
+      return usage("Missing required option --config");
+    }
+
+    return validateRepositoryFromFile(configPath);
+  }
+
+  return usage(
+    "Usage: multiverse <validate-worktree --worktree-id VALUE | validate-repository --config PATH>"
+  );
+}
+
+async function main(): Promise<void> {
+  const result = await runCli(process.argv.slice(2));
+
+  for (const line of result.stdout) {
+    process.stdout.write(`${line}\n`);
+  }
+
+  for (const line of result.stderr) {
+    process.stderr.write(`${line}\n`);
+  }
+
+  process.exitCode = result.exitCode;
+}
+
+const isMainModule =
+  process.argv[1] !== undefined &&
+  import.meta.url === new URL(`file://${process.argv[1]}`).href;
+
+if (isMainModule) {
+  await main();
+}

--- a/docs/development/tasks/dev-slice-10-task-01.md
+++ b/docs/development/tasks/dev-slice-10-task-01.md
@@ -1,0 +1,60 @@
+# Dev Slice 10 — Task 01
+
+## Title
+
+Add a thin CLI entrypoint for validated application-boundary input
+
+## Objective
+
+Implement the minimum CLI seam that makes current validated boundary behavior tangible without inventing provider loading, runtime wiring, or broader orchestration behavior.
+
+This task should expose already-proven validation paths through `apps/cli` while keeping business rules in core.
+
+## Sources of truth
+
+Ground this task in:
+
+- `docs/adr/0010-pnpm-workspace-monorepo-for-implementation.md`
+- `docs/adr/0011-typescript-nodejs-for-initial-implementation.md`
+- `docs/adr/0009-core-provider-repository-and-application-boundaries-are-explicit.md`
+- `docs/spec/system-boundary.md`
+- `docs/development/repo-map.md`
+- `docs/development/dev-slice-03.md`
+
+## Required outcome
+
+Implement the minimum production change such that:
+
+- `apps/cli` exists as a thin application entrypoint package
+- the CLI can accept raw application input for one already-proven validation path
+- successful validation returns structured output suitable for human or machine use
+- failed validation returns stable structured validation output
+
+## In scope
+
+- a real `apps/cli` workspace package
+- one or two narrow validation-oriented CLI commands
+- tests proving the CLI accepts valid raw input and rejects invalid raw input
+- minimal root script wiring needed to run the CLI during development
+
+## Out of scope
+
+- provider registration or discovery
+- runtime wiring to real provider implementations
+- derive/reset/cleanup CLI orchestration
+- rich CLI UX
+- broad command catalog
+- output formatting beyond what the thin seam needs
+
+## Acceptance criteria
+
+- the CLI validates one raw worktree identity input path
+- the CLI validates one raw repository configuration input path
+- invalid CLI input returns structured validation output without smearing logic into the app layer
+- the CLI package depends on core through workspace package boundaries only
+
+## Safety and boundary expectations
+
+- the CLI remains a thin app layer
+- core retains validation and business-rule ownership
+- the CLI does not invent provider wiring or hidden defaults

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "packageManager": "pnpm@10.33.0",
   "scripts": {
     "check:boundaries": "bash scripts/check-package-boundaries.sh",
+    "cli": "tsx apps/cli/src/index.ts",
     "test": "vitest run",
     "test:acceptance": "vitest run tests/acceptance",
     "test:contracts": "vitest run tests/contracts",
@@ -13,9 +14,11 @@
   },
   "devDependencies": {
     "@multiverse/core": "workspace:*",
+    "@multiverse/cli": "workspace:*",
     "@multiverse/provider-contracts": "workspace:*",
     "@multiverse/providers-testkit": "workspace:*",
     "@types/node": "^24.6.0",
+    "tsx": "^4.20.6",
     "typescript": "^5.9.3",
     "vitest": "^3.2.4"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     devDependencies:
+      '@multiverse/cli':
+        specifier: workspace:*
+        version: link:apps/cli
       '@multiverse/core':
         specifier: workspace:*
         version: link:packages/core
@@ -20,12 +23,24 @@ importers:
       '@types/node':
         specifier: ^24.6.0
         version: 24.12.2
+      tsx:
+        specifier: ^4.20.6
+        version: 4.21.0
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/node@24.12.2)
+        version: 3.2.4(@types/node@24.12.2)(tsx@4.21.0)
+
+  apps/cli:
+    dependencies:
+      '@multiverse/core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@multiverse/provider-contracts':
+        specifier: workspace:*
+        version: link:../../packages/provider-contracts
 
   packages/core:
     dependencies:
@@ -439,6 +454,9 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  get-tsconfig@4.13.7:
+    resolution: {integrity: sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==}
+
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
@@ -473,6 +491,9 @@ packages:
   postcss@8.5.8:
     resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
+
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
   rollup@4.60.1:
     resolution: {integrity: sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==}
@@ -516,6 +537,11 @@ packages:
   tinyspy@4.0.4:
     resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
+
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -781,13 +807,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@24.12.2))':
+  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@24.12.2)(tsx@4.21.0))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@24.12.2)
+      vite: 7.3.1(@types/node@24.12.2)(tsx@4.21.0)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -879,6 +905,10 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
+  get-tsconfig@4.13.7:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
   js-tokens@9.0.1: {}
 
   loupe@3.2.1: {}
@@ -904,6 +934,8 @@ snapshots:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+
+  resolve-pkg-maps@1.0.0: {}
 
   rollup@4.60.1:
     dependencies:
@@ -963,17 +995,24 @@ snapshots:
 
   tinyspy@4.0.4: {}
 
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.7
+      get-tsconfig: 4.13.7
+    optionalDependencies:
+      fsevents: 2.3.3
+
   typescript@5.9.3: {}
 
   undici-types@7.16.0: {}
 
-  vite-node@3.2.4(@types/node@24.12.2):
+  vite-node@3.2.4(@types/node@24.12.2)(tsx@4.21.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.1(@types/node@24.12.2)
+      vite: 7.3.1(@types/node@24.12.2)(tsx@4.21.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -988,7 +1027,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@7.3.1(@types/node@24.12.2):
+  vite@7.3.1(@types/node@24.12.2)(tsx@4.21.0):
     dependencies:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
@@ -999,12 +1038,13 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.12.2
       fsevents: 2.3.3
+      tsx: 4.21.0
 
-  vitest@3.2.4(@types/node@24.12.2):
+  vitest@3.2.4(@types/node@24.12.2)(tsx@4.21.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@24.12.2))
+      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@24.12.2)(tsx@4.21.0))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -1022,8 +1062,8 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.1(@types/node@24.12.2)
-      vite-node: 3.2.4(@types/node@24.12.2)
+      vite: 7.3.1(@types/node@24.12.2)(tsx@4.21.0)
+      vite-node: 3.2.4(@types/node@24.12.2)(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.12.2

--- a/tests/acceptance/dev-slice-10.acceptance.test.ts
+++ b/tests/acceptance/dev-slice-10.acceptance.test.ts
@@ -1,0 +1,181 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { runCli } from "../../apps/cli/src/index";
+
+describe("Development Slice 10 acceptance", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(
+      tempDirs.map((dir) => rm(dir, { recursive: true, force: true }))
+    );
+    tempDirs.length = 0;
+  });
+
+  it("accepts valid raw worktree identity input through the CLI", async () => {
+    const outcome = await runCli([
+      "validate-worktree",
+      "--worktree-id",
+      "wt-cli-valid"
+    ]);
+
+    expect(outcome).toEqual({
+      exitCode: 0,
+      stdout: [
+        JSON.stringify({
+          ok: true,
+          value: {
+            kind: "worktree_identity",
+            value: "wt-cli-valid"
+          }
+        })
+      ],
+      stderr: []
+    });
+  });
+
+  it("rejects invalid raw worktree identity input through the CLI", async () => {
+    const outcome = await runCli([
+      "validate-worktree",
+      "--worktree-id",
+      "   "
+    ]);
+
+    expect(outcome).toEqual({
+      exitCode: 1,
+      stdout: [
+        JSON.stringify({
+          ok: false,
+          errors: [
+            {
+              path: "worktreeId",
+              code: "invalid_value"
+            }
+          ]
+        })
+      ],
+      stderr: []
+    });
+  });
+
+  it("accepts valid raw repository configuration input through the CLI", async () => {
+    const tempDir = await mkdtemp(path.join(tmpdir(), "multiverse-cli-"));
+    tempDirs.push(tempDir);
+    const configPath = path.join(tempDir, "repository.json");
+
+    await writeFile(
+      configPath,
+      JSON.stringify({
+        resources: [
+          {
+            name: "primary-db",
+            provider: "test-resource-provider",
+            isolationStrategy: "name-scoped",
+            scopedValidate: false,
+            scopedReset: false,
+            scopedCleanup: false
+          }
+        ],
+        endpoints: [
+          {
+            name: "app-base-url",
+            role: "application-base-url",
+            provider: "test-endpoint-provider"
+          }
+        ]
+      })
+    );
+
+    const outcome = await runCli([
+      "validate-repository",
+      "--config",
+      configPath
+    ]);
+
+    expect(outcome).toEqual({
+      exitCode: 0,
+      stdout: [
+        JSON.stringify({
+          ok: true,
+          value: {
+            resources: [
+              {
+                name: "primary-db",
+                provider: "test-resource-provider",
+                isolationStrategy: "name-scoped",
+                scopedValidate: false,
+                scopedReset: false,
+                scopedCleanup: false
+              }
+            ],
+            endpoints: [
+              {
+                name: "app-base-url",
+                role: "application-base-url",
+                provider: "test-endpoint-provider"
+              }
+            ]
+          }
+        })
+      ],
+      stderr: []
+    });
+  });
+
+  it("rejects invalid raw repository configuration input through the CLI", async () => {
+    const tempDir = await mkdtemp(path.join(tmpdir(), "multiverse-cli-"));
+    tempDirs.push(tempDir);
+    const configPath = path.join(tempDir, "repository.json");
+
+    await writeFile(
+      configPath,
+      JSON.stringify({
+        resources: [
+          {
+            name: "primary-db",
+            isolationStrategy: "name-scoped",
+            scopedValidate: false,
+            scopedReset: false,
+            scopedCleanup: false
+          }
+        ],
+        endpoints: [
+          {
+            name: "app-base-url",
+            provider: "test-endpoint-provider"
+          }
+        ]
+      })
+    );
+
+    const outcome = await runCli([
+      "validate-repository",
+      "--config",
+      configPath
+    ]);
+
+    expect(outcome).toEqual({
+      exitCode: 1,
+      stdout: [
+        JSON.stringify({
+          ok: false,
+          errors: [
+            {
+              path: "resources[0].provider",
+              code: "required"
+            },
+            {
+              path: "endpoints[0].role",
+              code: "required"
+            }
+          ]
+        })
+      ],
+      stderr: []
+    });
+  });
+});


### PR DESCRIPTION
Summary
- add a real apps/cli workspace package as a thin application entrypoint
- expose two honest validation-oriented commands: validate-worktree and validate-repository
- keep business rules in core and avoid inventing provider loading or broader orchestration in the CLI layer

Scope
- apps/cli package and entrypoint
- root cli script and tsx runtime wiring for development
- acceptance coverage for valid and invalid raw worktree and repository input
- task doc for the slice

Validation
- scripts/codex-env.sh pnpm install --config.confirmModulesPurge=false
- scripts/codex-env.sh pnpm run check:boundaries
- scripts/codex-env.sh pnpm typecheck
- scripts/codex-env.sh pnpm test:acceptance
- scripts/codex-env.sh pnpm test:contracts
- scripts/codex-env.sh pnpm test:unit

Deferred
- provider registration or loading in the CLI
- derive/reset/cleanup CLI orchestration
- richer CLI UX and human-oriented formatting
- sample app or sample repo trialing
