### PR TITLE
Add explicit CLI provider wiring for derive

### DIFF
--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -1,16 +1,30 @@
 import { readFile } from "node:fs/promises";
+import path from "node:path";
 import process from "node:process";
+import { pathToFileURL } from "node:url";
 
 import {
+  resolveSlice01,
   validateRepositoryConfiguration,
   validateWorktreeIdentity
 } from "@multiverse/core";
-import type { RepositoryConfiguration } from "@multiverse/provider-contracts";
+import type {
+  ProviderRegistry,
+  RepositoryConfiguration
+} from "@multiverse/provider-contracts";
 
 export interface CliResult {
   exitCode: number;
   stdout: string[];
   stderr: string[];
+}
+
+function isCliResult(value: unknown): value is CliResult {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "exitCode" in value
+  );
 }
 
 function success(value: unknown): CliResult {
@@ -46,43 +60,150 @@ function readOption(args: string[], name: string): string | undefined {
   return args[index + 1];
 }
 
+function readRequiredOption(
+  args: string[],
+  name: string
+): string | CliResult {
+  const value = readOption(args, name);
+
+  if (value === undefined) {
+    return usage(`Missing required option ${name}`);
+  }
+
+  return value;
+}
+
 async function validateRepositoryFromFile(configPath: string): Promise<CliResult> {
-  const raw = await readFile(configPath, "utf8");
-  const parsed = JSON.parse(raw) as RepositoryConfiguration;
+  const parsed = await readRepositoryConfiguration(configPath);
   const result = validateRepositoryConfiguration(parsed);
 
   return result.ok ? success(result) : failure(result);
+}
+
+async function readRepositoryConfiguration(
+  configPath: string
+): Promise<RepositoryConfiguration> {
+  const raw = await readFile(configPath, "utf8");
+  return JSON.parse(raw) as RepositoryConfiguration;
+}
+
+function isProviderRegistry(value: unknown): value is ProviderRegistry {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "resources" in value &&
+    "endpoints" in value &&
+    typeof value.resources === "object" &&
+    value.resources !== null &&
+    typeof value.endpoints === "object" &&
+    value.endpoints !== null
+  );
+}
+
+async function loadProviderRegistry(
+  providersModulePath: string
+): Promise<ProviderRegistry | CliResult> {
+  const moduleUrl = pathToFileURL(path.resolve(providersModulePath)).href;
+  const moduleExports = (await import(moduleUrl)) as {
+    default?: unknown;
+    providers?: unknown;
+  };
+  const candidate = moduleExports.providers ?? moduleExports.default;
+
+  if (!isProviderRegistry(candidate)) {
+    return usage(
+      'Providers module must export a ProviderRegistry as named export "providers" or default export'
+    );
+  }
+
+  return candidate;
+}
+
+async function deriveFromFiles(input: {
+  configPath: string;
+  worktreeId: string;
+  providersModulePath: string;
+}): Promise<CliResult> {
+  const parsed = await readRepositoryConfiguration(input.configPath);
+  const providers = await loadProviderRegistry(input.providersModulePath);
+
+  if ("exitCode" in providers) {
+    return providers;
+  }
+
+  const result = resolveSlice01({
+    repository: parsed,
+    worktree: {
+      id: input.worktreeId
+    },
+    providers
+  });
+
+  return result.ok ? success(result) : failure(result);
+}
+
+async function handleValidateWorktree(args: string[]): Promise<CliResult> {
+  const worktreeId = readRequiredOption(args, "--worktree-id");
+  if (isCliResult(worktreeId)) {
+    return worktreeId;
+  }
+
+  const result = validateWorktreeIdentity({
+    worktreeId
+  });
+
+  return result.ok ? success(result) : failure(result);
+}
+
+async function handleValidateRepository(args: string[]): Promise<CliResult> {
+  const configPath = readRequiredOption(args, "--config");
+  if (isCliResult(configPath)) {
+    return configPath;
+  }
+
+  return validateRepositoryFromFile(configPath);
+}
+
+async function handleDerive(args: string[]): Promise<CliResult> {
+  const configPath = readRequiredOption(args, "--config");
+  if (isCliResult(configPath)) {
+    return configPath;
+  }
+
+  const worktreeId = readRequiredOption(args, "--worktree-id");
+  if (isCliResult(worktreeId)) {
+    return worktreeId;
+  }
+
+  const providersModulePath = readRequiredOption(args, "--providers");
+  if (isCliResult(providersModulePath)) {
+    return providersModulePath;
+  }
+
+  return deriveFromFiles({
+    configPath,
+    worktreeId,
+    providersModulePath
+  });
 }
 
 export async function runCli(args: string[]): Promise<CliResult> {
   const [command] = args;
 
   if (command === "validate-worktree") {
-    const worktreeId = readOption(args, "--worktree-id");
-
-    if (worktreeId === undefined) {
-      return usage("Missing required option --worktree-id");
-    }
-
-    const result = validateWorktreeIdentity({
-      worktreeId
-    });
-
-    return result.ok ? success(result) : failure(result);
+    return handleValidateWorktree(args);
   }
 
   if (command === "validate-repository") {
-    const configPath = readOption(args, "--config");
+    return handleValidateRepository(args);
+  }
 
-    if (configPath === undefined) {
-      return usage("Missing required option --config");
-    }
-
-    return validateRepositoryFromFile(configPath);
+  if (command === "derive") {
+    return handleDerive(args);
   }
 
   return usage(
-    "Usage: multiverse <validate-worktree --worktree-id VALUE | validate-repository --config PATH>"
+    "Usage: multiverse <validate-worktree --worktree-id VALUE | validate-repository --config PATH | derive --config PATH --worktree-id VALUE --providers MODULE>"
   );
 }
 

--- a/tests/acceptance/dev-slice-10.acceptance.test.ts
+++ b/tests/acceptance/dev-slice-10.acceptance.test.ts
@@ -1,6 +1,7 @@
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 import { afterEach, describe, expect, it } from "vitest";
 
@@ -15,6 +16,10 @@ describe("Development Slice 10 acceptance", () => {
     );
     tempDirs.length = 0;
   });
+
+  const providersModulePath = fileURLToPath(
+    new URL("./fixtures/explicit-test-providers.ts", import.meta.url)
+  );
 
   it("accepts valid raw worktree identity input through the CLI", async () => {
     const outcome = await runCli([
@@ -176,6 +181,116 @@ describe("Development Slice 10 acceptance", () => {
         })
       ],
       stderr: []
+    });
+  });
+
+  it("derives one explicit scoped resource plan and endpoint mapping through the CLI", async () => {
+    const tempDir = await mkdtemp(path.join(tmpdir(), "multiverse-cli-"));
+    tempDirs.push(tempDir);
+    const configPath = path.join(tempDir, "repository.json");
+
+    await writeFile(
+      configPath,
+      JSON.stringify({
+        resources: [
+          {
+            name: "primary-db",
+            provider: "test-resource-provider",
+            isolationStrategy: "name-scoped",
+            scopedValidate: false,
+            scopedReset: false,
+            scopedCleanup: false
+          }
+        ],
+        endpoints: [
+          {
+            name: "app-base-url",
+            role: "application-base-url",
+            provider: "test-endpoint-provider"
+          }
+        ]
+      })
+    );
+
+    const outcome = await runCli([
+      "derive",
+      "--config",
+      configPath,
+      "--worktree-id",
+      "wt-cli-derive",
+      "--providers",
+      providersModulePath
+    ]);
+
+    expect(outcome).toEqual({
+      exitCode: 0,
+      stdout: [
+        JSON.stringify({
+          ok: true,
+          resourcePlans: [
+            {
+              resourceName: "primary-db",
+              provider: "test-resource-provider",
+              isolationStrategy: "name-scoped",
+              worktreeId: "wt-cli-derive",
+              handle: "primary-db--wt-cli-derive"
+            }
+          ],
+          endpointMappings: [
+            {
+              endpointName: "app-base-url",
+              provider: "test-endpoint-provider",
+              role: "application-base-url",
+              worktreeId: "wt-cli-derive",
+              address: "http://wt-cli-derive.local/app-base-url"
+            }
+          ]
+        })
+      ],
+      stderr: []
+    });
+  });
+
+  it("requires an explicit providers module for derive instead of falling back implicitly", async () => {
+    const tempDir = await mkdtemp(path.join(tmpdir(), "multiverse-cli-"));
+    tempDirs.push(tempDir);
+    const configPath = path.join(tempDir, "repository.json");
+
+    await writeFile(
+      configPath,
+      JSON.stringify({
+        resources: [
+          {
+            name: "primary-db",
+            provider: "test-resource-provider",
+            isolationStrategy: "name-scoped",
+            scopedValidate: false,
+            scopedReset: false,
+            scopedCleanup: false
+          }
+        ],
+        endpoints: [
+          {
+            name: "app-base-url",
+            role: "application-base-url",
+            provider: "test-endpoint-provider"
+          }
+        ]
+      })
+    );
+
+    const outcome = await runCli([
+      "derive",
+      "--config",
+      configPath,
+      "--worktree-id",
+      "wt-cli-derive"
+    ]);
+
+    expect(outcome).toEqual({
+      exitCode: 1,
+      stdout: [],
+      stderr: ["Missing required option --providers"]
     });
   });
 });

--- a/tests/acceptance/fixtures/explicit-test-providers.ts
+++ b/tests/acceptance/fixtures/explicit-test-providers.ts
@@ -1,0 +1,3 @@
+import { createExplicitTestProviders } from "@multiverse/providers-testkit";
+
+export const providers = createExplicitTestProviders();


### PR DESCRIPTION
Summary:
- add a thin CLI derive command that requires an explicit provider module path
- keep provider loading in the app boundary and pass the registry into core resolveSlice01
- add acceptance coverage for successful derive and refusal when --providers is omitted

Scope:
- apps/cli derive command and command-handler cleanup
- acceptance fixture for explicit test providers
- dev-slice-10 acceptance coverage for derive

Validation:
- scripts/codex-env.sh pnpm exec vitest run tests/acceptance/dev-slice-10.acceptance.test.ts
- scripts/codex-env.sh pnpm typecheck
- scripts/codex-env.sh pnpm run check:boundaries
- scripts/codex-env.sh pnpm test:acceptance

Deferred:
- no provider discovery or implicit registry loading
- no reset or cleanup CLI orchestration