### PR TITLE
Add explicit CLI reset command

### DIFF
--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -4,6 +4,7 @@ import process from "node:process";
 import { pathToFileURL } from "node:url";
 
 import {
+  resetOneResource,
   resolveSlice01,
   validateRepositoryConfiguration,
   validateWorktreeIdentity
@@ -124,6 +125,37 @@ async function deriveFromFiles(input: {
   worktreeId: string;
   providersModulePath: string;
 }): Promise<CliResult> {
+  return executeOperationFromFiles({
+    ...input,
+    operation: resolveSlice01
+  });
+}
+
+async function resetFromFiles(input: {
+  configPath: string;
+  worktreeId: string;
+  providersModulePath: string;
+}): Promise<CliResult> {
+  return executeOperationFromFiles({
+    ...input,
+    operation: resetOneResource
+  });
+}
+
+async function executeOperationFromFiles(input: {
+  configPath: string;
+  worktreeId: string;
+  providersModulePath: string;
+  operation: (input: {
+    repository: RepositoryConfiguration;
+    worktree: {
+      id: string;
+    };
+    providers: ProviderRegistry;
+  }) => {
+    ok: boolean;
+  };
+}): Promise<CliResult> {
   const parsed = await readRepositoryConfiguration(input.configPath);
   const providers = await loadProviderRegistry(input.providersModulePath);
 
@@ -131,7 +163,7 @@ async function deriveFromFiles(input: {
     return providers;
   }
 
-  const result = resolveSlice01({
+  const result = input.operation({
     repository: parsed,
     worktree: {
       id: input.worktreeId
@@ -187,6 +219,29 @@ async function handleDerive(args: string[]): Promise<CliResult> {
   });
 }
 
+async function handleReset(args: string[]): Promise<CliResult> {
+  const configPath = readRequiredOption(args, "--config");
+  if (isCliResult(configPath)) {
+    return configPath;
+  }
+
+  const worktreeId = readRequiredOption(args, "--worktree-id");
+  if (isCliResult(worktreeId)) {
+    return worktreeId;
+  }
+
+  const providersModulePath = readRequiredOption(args, "--providers");
+  if (isCliResult(providersModulePath)) {
+    return providersModulePath;
+  }
+
+  return resetFromFiles({
+    configPath,
+    worktreeId,
+    providersModulePath
+  });
+}
+
 export async function runCli(args: string[]): Promise<CliResult> {
   const [command] = args;
 
@@ -202,8 +257,12 @@ export async function runCli(args: string[]): Promise<CliResult> {
     return handleDerive(args);
   }
 
+  if (command === "reset") {
+    return handleReset(args);
+  }
+
   return usage(
-    "Usage: multiverse <validate-worktree --worktree-id VALUE | validate-repository --config PATH | derive --config PATH --worktree-id VALUE --providers MODULE>"
+    "Usage: multiverse <validate-worktree --worktree-id VALUE | validate-repository --config PATH | derive --config PATH --worktree-id VALUE --providers MODULE | reset --config PATH --worktree-id VALUE --providers MODULE>"
   );
 }
 

--- a/tests/acceptance/dev-slice-11.acceptance.test.ts
+++ b/tests/acceptance/dev-slice-11.acceptance.test.ts
@@ -1,0 +1,221 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { runCli } from "../../apps/cli/src/index";
+
+describe("Development Slice 11 acceptance", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(
+      tempDirs.map((dir) => rm(dir, { recursive: true, force: true }))
+    );
+    tempDirs.length = 0;
+  });
+
+  const providersModulePath = fileURLToPath(
+    new URL("./fixtures/explicit-test-providers.ts", import.meta.url)
+  );
+
+  async function writeRepositoryConfig(config: unknown): Promise<string> {
+    const tempDir = await mkdtemp(path.join(tmpdir(), "multiverse-cli-"));
+    tempDirs.push(tempDir);
+    const configPath = path.join(tempDir, "repository.json");
+
+    await writeFile(configPath, JSON.stringify(config));
+
+    return configPath;
+  }
+
+  it("executes one explicit scoped reset through the CLI", async () => {
+    const configPath = await writeRepositoryConfig({
+      resources: [
+        {
+          name: "primary-db",
+          provider: "test-resource-provider-with-reset",
+          isolationStrategy: "name-scoped",
+          scopedValidate: false,
+          scopedReset: true,
+          scopedCleanup: false
+        }
+      ],
+      endpoints: [
+        {
+          name: "app-base-url",
+          role: "application-base-url",
+          provider: "test-endpoint-provider"
+        }
+      ]
+    });
+
+    const outcome = await runCli([
+      "reset",
+      "--config",
+      configPath,
+      "--worktree-id",
+      "wt-cli-reset",
+      "--providers",
+      providersModulePath
+    ]);
+
+    expect(outcome).toEqual({
+      exitCode: 0,
+      stdout: [
+        JSON.stringify({
+          ok: true,
+          resourcePlans: [
+            {
+              resourceName: "primary-db",
+              provider: "test-resource-provider-with-reset",
+              isolationStrategy: "name-scoped",
+              worktreeId: "wt-cli-reset",
+              handle: "primary-db--wt-cli-reset"
+            }
+          ],
+          resourceResets: [
+            {
+              resourceName: "primary-db",
+              provider: "test-resource-provider-with-reset",
+              worktreeId: "wt-cli-reset",
+              capability: "reset"
+            }
+          ]
+        })
+      ],
+      stderr: []
+    });
+  });
+
+  it("requires an explicit providers module for reset", async () => {
+    const configPath = await writeRepositoryConfig({
+      resources: [
+        {
+          name: "primary-db",
+          provider: "test-resource-provider-with-reset",
+          isolationStrategy: "name-scoped",
+          scopedValidate: false,
+          scopedReset: true,
+          scopedCleanup: false
+        }
+      ],
+      endpoints: [
+        {
+          name: "app-base-url",
+          role: "application-base-url",
+          provider: "test-endpoint-provider"
+        }
+      ]
+    });
+
+    const outcome = await runCli([
+      "reset",
+      "--config",
+      configPath,
+      "--worktree-id",
+      "wt-cli-reset"
+    ]);
+
+    expect(outcome).toEqual({
+      exitCode: 1,
+      stdout: [],
+      stderr: ["Missing required option --providers"]
+    });
+  });
+
+  it("returns unsupported reset capability unchanged through the CLI", async () => {
+    const configPath = await writeRepositoryConfig({
+      resources: [
+        {
+          name: "primary-db",
+          provider: "test-resource-provider",
+          isolationStrategy: "name-scoped",
+          scopedValidate: false,
+          scopedReset: true,
+          scopedCleanup: false
+        }
+      ],
+      endpoints: [
+        {
+          name: "app-base-url",
+          role: "application-base-url",
+          provider: "test-endpoint-provider"
+        }
+      ]
+    });
+
+    const outcome = await runCli([
+      "reset",
+      "--config",
+      configPath,
+      "--worktree-id",
+      "wt-cli-reset-unsupported",
+      "--providers",
+      providersModulePath
+    ]);
+
+    expect(outcome).toEqual({
+      exitCode: 1,
+      stdout: [
+        JSON.stringify({
+          ok: false,
+          refusal: {
+            category: "unsupported_capability",
+            reason:
+              'Resource provider "test-resource-provider" does not support reset.'
+          }
+        })
+      ],
+      stderr: []
+    });
+  });
+
+  it("returns unsafe reset scope unchanged through the CLI", async () => {
+    const configPath = await writeRepositoryConfig({
+      resources: [
+        {
+          name: "primary-db",
+          provider: "test-resource-provider-with-reset",
+          isolationStrategy: "name-scoped",
+          scopedValidate: false,
+          scopedReset: true,
+          scopedCleanup: false
+        }
+      ],
+      endpoints: [
+        {
+          name: "app-base-url",
+          role: "application-base-url",
+          provider: "test-endpoint-provider"
+        }
+      ]
+    });
+
+    const outcome = await runCli([
+      "reset",
+      "--config",
+      configPath,
+      "--worktree-id",
+      "   ",
+      "--providers",
+      providersModulePath
+    ]);
+
+    expect(outcome).toEqual({
+      exitCode: 1,
+      stdout: [
+        JSON.stringify({
+          ok: false,
+          refusal: {
+            category: "unsafe_scope",
+            reason: "Safe worktree scope cannot be determined."
+          }
+        })
+      ],
+      stderr: []
+    });
+  });
+});


### PR DESCRIPTION
Closes #26

Summary:
- add a thin reset CLI command that reuses the explicit provider-module boundary seam
- keep provider loading in the app layer and delegate reset behavior to core
- add acceptance coverage for successful reset, missing providers input, unsupported capability, and unsafe scope

Scope:
- apps/cli reset command wiring and shared file-backed operation helper
- tests/acceptance/dev-slice-11.acceptance.test.ts

Validation:
- scripts/codex-env.sh pnpm exec vitest run tests/acceptance/dev-slice-11.acceptance.test.ts
- scripts/codex-env.sh pnpm typecheck
- scripts/codex-env.sh pnpm run check:boundaries
- scripts/codex-env.sh pnpm test:acceptance

Deferred:
- no cleanup CLI command in this PR
- no provider discovery or implicit provider wiring