### PR TITLE
Add explicit CLI cleanup command

### DIFF
--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -4,6 +4,7 @@ import process from "node:process";
 import { pathToFileURL } from "node:url";
 
 import {
+  cleanupOneResource,
   resetOneResource,
   resolveSlice01,
   validateRepositoryConfiguration,
@@ -142,6 +143,17 @@ async function resetFromFiles(input: {
   });
 }
 
+async function cleanupFromFiles(input: {
+  configPath: string;
+  worktreeId: string;
+  providersModulePath: string;
+}): Promise<CliResult> {
+  return executeOperationFromFiles({
+    ...input,
+    operation: cleanupOneResource
+  });
+}
+
 async function executeOperationFromFiles(input: {
   configPath: string;
   worktreeId: string;
@@ -242,6 +254,29 @@ async function handleReset(args: string[]): Promise<CliResult> {
   });
 }
 
+async function handleCleanup(args: string[]): Promise<CliResult> {
+  const configPath = readRequiredOption(args, "--config");
+  if (isCliResult(configPath)) {
+    return configPath;
+  }
+
+  const worktreeId = readRequiredOption(args, "--worktree-id");
+  if (isCliResult(worktreeId)) {
+    return worktreeId;
+  }
+
+  const providersModulePath = readRequiredOption(args, "--providers");
+  if (isCliResult(providersModulePath)) {
+    return providersModulePath;
+  }
+
+  return cleanupFromFiles({
+    configPath,
+    worktreeId,
+    providersModulePath
+  });
+}
+
 export async function runCli(args: string[]): Promise<CliResult> {
   const [command] = args;
 
@@ -261,8 +296,12 @@ export async function runCli(args: string[]): Promise<CliResult> {
     return handleReset(args);
   }
 
+  if (command === "cleanup") {
+    return handleCleanup(args);
+  }
+
   return usage(
-    "Usage: multiverse <validate-worktree --worktree-id VALUE | validate-repository --config PATH | derive --config PATH --worktree-id VALUE --providers MODULE | reset --config PATH --worktree-id VALUE --providers MODULE>"
+    "Usage: multiverse <validate-worktree --worktree-id VALUE | validate-repository --config PATH | derive --config PATH --worktree-id VALUE --providers MODULE | reset --config PATH --worktree-id VALUE --providers MODULE | cleanup --config PATH --worktree-id VALUE --providers MODULE>"
   );
 }
 

--- a/tests/acceptance/dev-slice-12.acceptance.test.ts
+++ b/tests/acceptance/dev-slice-12.acceptance.test.ts
@@ -1,0 +1,268 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { runCli } from "../../apps/cli/src/index";
+
+describe("Development Slice 12 acceptance", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(
+      tempDirs.map((dir) => rm(dir, { recursive: true, force: true }))
+    );
+    tempDirs.length = 0;
+  });
+
+  const providersModulePath = fileURLToPath(
+    new URL("./fixtures/explicit-test-providers.ts", import.meta.url)
+  );
+
+  async function writeRepositoryConfig(config: unknown): Promise<string> {
+    const tempDir = await mkdtemp(path.join(tmpdir(), "multiverse-cli-"));
+    tempDirs.push(tempDir);
+    const configPath = path.join(tempDir, "repository.json");
+
+    await writeFile(configPath, JSON.stringify(config));
+
+    return configPath;
+  }
+
+  it("executes one explicit scoped cleanup through the CLI", async () => {
+    const configPath = await writeRepositoryConfig({
+      resources: [
+        {
+          name: "primary-db",
+          provider: "test-resource-provider-with-cleanup",
+          isolationStrategy: "name-scoped",
+          scopedValidate: false,
+          scopedReset: false,
+          scopedCleanup: true
+        }
+      ],
+      endpoints: [
+        {
+          name: "app-base-url",
+          role: "application-base-url",
+          provider: "test-endpoint-provider"
+        }
+      ]
+    });
+
+    const outcome = await runCli([
+      "cleanup",
+      "--config",
+      configPath,
+      "--worktree-id",
+      "wt-cli-cleanup",
+      "--providers",
+      providersModulePath
+    ]);
+
+    expect(outcome).toEqual({
+      exitCode: 0,
+      stdout: [
+        JSON.stringify({
+          ok: true,
+          resourcePlans: [
+            {
+              resourceName: "primary-db",
+              provider: "test-resource-provider-with-cleanup",
+              isolationStrategy: "name-scoped",
+              worktreeId: "wt-cli-cleanup",
+              handle: "primary-db--wt-cli-cleanup"
+            }
+          ],
+          resourceCleanups: [
+            {
+              resourceName: "primary-db",
+              provider: "test-resource-provider-with-cleanup",
+              worktreeId: "wt-cli-cleanup",
+              capability: "cleanup"
+            }
+          ]
+        })
+      ],
+      stderr: []
+    });
+  });
+
+  it("requires an explicit providers module for cleanup", async () => {
+    const configPath = await writeRepositoryConfig({
+      resources: [
+        {
+          name: "primary-db",
+          provider: "test-resource-provider-with-cleanup",
+          isolationStrategy: "name-scoped",
+          scopedValidate: false,
+          scopedReset: false,
+          scopedCleanup: true
+        }
+      ],
+      endpoints: [
+        {
+          name: "app-base-url",
+          role: "application-base-url",
+          provider: "test-endpoint-provider"
+        }
+      ]
+    });
+
+    const outcome = await runCli([
+      "cleanup",
+      "--config",
+      configPath,
+      "--worktree-id",
+      "wt-cli-cleanup"
+    ]);
+
+    expect(outcome).toEqual({
+      exitCode: 1,
+      stdout: [],
+      stderr: ["Missing required option --providers"]
+    });
+  });
+
+  it("returns unsupported cleanup capability unchanged through the CLI", async () => {
+    const configPath = await writeRepositoryConfig({
+      resources: [
+        {
+          name: "primary-db",
+          provider: "test-resource-provider",
+          isolationStrategy: "name-scoped",
+          scopedValidate: false,
+          scopedReset: false,
+          scopedCleanup: true
+        }
+      ],
+      endpoints: [
+        {
+          name: "app-base-url",
+          role: "application-base-url",
+          provider: "test-endpoint-provider"
+        }
+      ]
+    });
+
+    const outcome = await runCli([
+      "cleanup",
+      "--config",
+      configPath,
+      "--worktree-id",
+      "wt-cli-cleanup-unsupported",
+      "--providers",
+      providersModulePath
+    ]);
+
+    expect(outcome).toEqual({
+      exitCode: 1,
+      stdout: [
+        JSON.stringify({
+          ok: false,
+          refusal: {
+            category: "unsupported_capability",
+            reason:
+              'Resource provider "test-resource-provider" does not support cleanup.'
+          }
+        })
+      ],
+      stderr: []
+    });
+  });
+
+  it("returns invalid cleanup intent unchanged through the CLI", async () => {
+    const configPath = await writeRepositoryConfig({
+      resources: [
+        {
+          name: "primary-db",
+          provider: "test-resource-provider-with-cleanup",
+          isolationStrategy: "name-scoped",
+          scopedValidate: false,
+          scopedReset: false,
+          scopedCleanup: false
+        }
+      ],
+      endpoints: [
+        {
+          name: "app-base-url",
+          role: "application-base-url",
+          provider: "test-endpoint-provider"
+        }
+      ]
+    });
+
+    const outcome = await runCli([
+      "cleanup",
+      "--config",
+      configPath,
+      "--worktree-id",
+      "wt-cli-cleanup-not-intended",
+      "--providers",
+      providersModulePath
+    ]);
+
+    expect(outcome).toEqual({
+      exitCode: 1,
+      stdout: [
+        JSON.stringify({
+          ok: false,
+          refusal: {
+            category: "invalid_configuration",
+            reason:
+              'Resource "primary-db" does not declare scoped cleanup intent.'
+          }
+        })
+      ],
+      stderr: []
+    });
+  });
+
+  it("returns unsafe cleanup scope unchanged through the CLI", async () => {
+    const configPath = await writeRepositoryConfig({
+      resources: [
+        {
+          name: "primary-db",
+          provider: "test-resource-provider-with-cleanup",
+          isolationStrategy: "name-scoped",
+          scopedValidate: false,
+          scopedReset: false,
+          scopedCleanup: true
+        }
+      ],
+      endpoints: [
+        {
+          name: "app-base-url",
+          role: "application-base-url",
+          provider: "test-endpoint-provider"
+        }
+      ]
+    });
+
+    const outcome = await runCli([
+      "cleanup",
+      "--config",
+      configPath,
+      "--worktree-id",
+      "   ",
+      "--providers",
+      providersModulePath
+    ]);
+
+    expect(outcome).toEqual({
+      exitCode: 1,
+      stdout: [
+        JSON.stringify({
+          ok: false,
+          refusal: {
+            category: "unsafe_scope",
+            reason: "Safe worktree scope cannot be determined."
+          }
+        })
+      ],
+      stderr: []
+    });
+  });
+});


### PR DESCRIPTION
Closes #27

Summary:
- add a thin cleanup CLI command that reuses the explicit provider-module boundary seam
- keep provider loading in the app layer and delegate cleanup behavior to core
- add acceptance coverage for successful cleanup, missing providers input, unsupported capability, invalid cleanup intent, and unsafe scope

Scope:
- apps/cli cleanup command wiring on top of the shared file-backed operation helper
- tests/acceptance/dev-slice-12.acceptance.test.ts

Validation:
- scripts/codex-env.sh pnpm exec vitest run tests/acceptance/dev-slice-12.acceptance.test.ts
- scripts/codex-env.sh pnpm typecheck
- scripts/codex-env.sh pnpm run check:boundaries
- scripts/codex-env.sh pnpm test:acceptance

Deferred:
- no additional CLI commands beyond cleanup in this PR
- no provider discovery or implicit provider wiring