### PR TITLE
Sync development docs for Slice 04

### DIFF
--- a/docs/development/dev-slice-04-scenario-map.md
+++ b/docs/development/dev-slice-04-scenario-map.md
@@ -1,0 +1,89 @@
+# Dev Slice 04 — Scenario Map
+
+## Slice theme
+
+Validated repository configuration at the core boundary
+
+## Scenario goal
+
+Demonstrate that raw repository declarations are not trusted by orchestration until they pass explicit validation.
+
+The scenario set for this slice is intentionally narrow.
+It proves admission of trusted repository declarations, not every future configuration rule.
+
+## Primary feature area
+
+### Feature area A — Boundary validation for repository configuration
+
+This feature area proves that the current single-resource, single-endpoint path can validate raw repository configuration before orchestration begins.
+
+## Scenario groups
+
+### Group A1 — Accept valid raw repository configuration
+
+#### Scenario A1.1
+
+Given raw repository configuration containing one valid declared resource and one valid declared endpoint  
+When the configuration is validated through the current orchestration path  
+Then orchestration receives a trusted repository representation
+
+### Group A2 — Reject malformed repository declarations
+
+#### Scenario A2.1
+
+Given raw repository configuration with a resource missing its provider  
+When the configuration is validated  
+Then validation fails as invalid configuration
+
+#### Scenario A2.2
+
+Given raw repository configuration with a resource missing its primary isolation strategy  
+When the configuration is validated  
+Then validation fails as invalid configuration
+
+#### Scenario A2.3
+
+Given raw repository configuration with an endpoint missing its intended role  
+When the configuration is validated  
+Then validation fails as invalid configuration
+
+### Group A3 — Preserve boundary/orchestration separation
+
+#### Scenario A3.1
+
+Given invalid raw repository configuration  
+When boundary validation fails  
+Then provider orchestration is not invoked
+
+#### Scenario A3.2
+
+Given valid raw repository configuration  
+When boundary validation succeeds  
+Then downstream orchestration receives only trusted repository declarations
+
+## Recommended test layering
+
+### Acceptance / behavior tests
+
+Use these to prove:
+
+- valid raw repository configuration is accepted through the current orchestration path
+- invalid raw repository configuration is refused before orchestration
+- provider-facing orchestration does not run on invalid raw configuration
+
+### Unit tests
+
+Use these to prove:
+
+- structured validation output for missing required resource and endpoint fields
+- trusted repository representation returned by the validation seam
+
+## Minimum viable scenario set
+
+The leanest proof set for this slice is:
+
+1. valid raw repository configuration is accepted
+2. a resource missing its provider is rejected
+3. a resource missing its isolation strategy is rejected
+4. an endpoint missing its role is rejected
+5. invalid raw repository configuration does not invoke orchestration

--- a/docs/development/dev-slice-04.md
+++ b/docs/development/dev-slice-04.md
@@ -1,0 +1,101 @@
+# Dev Slice 04 — Validated Repository Configuration at the Core Boundary
+
+## Status
+
+Implemented on `main`
+
+## Intent
+
+Establish the first trusted admission seam for repository configuration so raw repository declarations are validated before orchestration uses them as trusted core inputs.
+
+This slice extends the validated-boundary work introduced in Slice 03 by moving from one validated worktree value to one validated repository declaration model.
+
+The goal is to prove that repository declarations remain explicit business inputs while malformed raw configuration is refused before provider orchestration begins.
+
+## Why this slice after Slice 03
+
+Slice 03 established that raw application input must not enter the core model unvalidated.
+
+The next immediate trust boundary is the repository configuration itself.
+
+Before capability coordination, lifecycle operations, and CLI-driven orchestration can be extended safely, the system needs a trusted representation of:
+
+- declared resources
+- declared endpoints
+- required core fields such as provider assignment, intended role, and primary isolation strategy
+
+Without this seam, later orchestration slices would need to reason about malformed declaration shapes while coordinating business behavior.
+
+## Slice objective
+
+Implement the repository-configuration validation seam such that:
+
+1. raw repository configuration may enter through the current orchestration path
+2. validation occurs before trusted repository declarations are used downstream
+3. valid raw configuration becomes a trusted repository representation
+4. invalid raw configuration returns structured validation errors
+5. downstream orchestration is not invoked when repository validation fails
+
+## Scope
+
+This slice includes:
+
+- a validated repository-configuration representation
+- structured boundary validation errors for missing required declaration fields
+- acceptance coverage proving valid raw configuration is accepted through the current orchestration path
+- acceptance coverage proving invalid raw configuration is refused before orchestration
+- focused unit coverage for the repository-configuration validation seam
+
+## Out of scope
+
+This slice does not include:
+
+- provider execution redesign
+- capability intent coordination
+- reset or cleanup execution
+- CLI UX work
+- configuration discovery or serialization format decisions
+- broad error-taxonomy expansion beyond the current structured validation output
+
+## Architectural stance
+
+This slice reinforces the same boundary rule as Slice 03:
+
+> raw boundary declarations are not trusted core declarations
+
+Repository configuration is still the business declaration surface, but raw configuration objects are not treated as trusted until they pass explicit validation.
+
+The core may coordinate only validated declarations.
+
+## Targeted declaration rules
+
+The first repository-configuration seam should prove validation of required business fields for the current single-resource, single-endpoint path.
+
+The in-scope required rules are:
+
+- a resource must declare a provider
+- a resource must declare a primary isolation strategy
+- an endpoint must declare a role
+- invalid raw repository configuration must not reach provider orchestration
+
+Do not broaden this slice into full configuration-file or loading behavior.
+
+## Acceptance criteria
+
+- valid raw repository configuration is accepted through the current orchestration path
+- a resource missing its provider is refused as invalid configuration
+- a resource missing its primary isolation strategy is refused as invalid configuration
+- an endpoint missing its role is refused as invalid configuration
+- orchestration is not invoked for invalid raw repository configuration
+- successful validation yields a trusted repository representation for downstream use
+
+## Expected artifacts
+
+- repository-configuration validation seam in core
+- structured repository validation error output
+- acceptance tests for valid and invalid raw repository configuration
+- focused unit tests for the repository-configuration boundary
+
+## Definition of done
+
+This slice is done when the repo contains a narrow, test-proven path that admits raw repository declarations into the trusted core model only through structured validation, and refuses malformed declaration shapes before orchestration begins.

--- a/docs/development/implementation-strategy.md
+++ b/docs/development/implementation-strategy.md
@@ -8,7 +8,7 @@ The goal is to begin with a small, behavior-proving slice that exercises the cor
 
 ## Current Phase
 
-Multiverse is transitioning from design-first specification into behavior-first implementation.
+Multiverse has moved from design-first specification into behavior-first implementation through a sequence of narrow slices.
 
 The implementation approach is:
 
@@ -32,9 +32,9 @@ Early slices should follow Node.js and TypeScript conventions for package struct
 
 Cross-runtime portability is not an implicit goal of the initial implementation. Do not introduce runtime-neutral abstractions unless a later decision explicitly requires them.
 
-## First Slice Objective
+## Initial Slice Objective
 
-The first executable slice should prove that the tool can:
+The initial executable slice was intended to prove that the tool can:
 
 - evaluate a valid repository configuration
 - recognize a worktree instance
@@ -42,7 +42,7 @@ The first executable slice should prove that the tool can:
 - derive one declared endpoint mapping
 - refuse when safe ownership or valid declaration cannot be established
 
-## Recommended First Slice
+## Initial Recommended Slice
 
 ### Slice name
 
@@ -50,7 +50,7 @@ Resolve one worktree instance into one isolated resource plan and one endpoint m
 
 ### Why this slice
 
-This slice exercises the most important business boundaries early:
+This slice exercised the most important business boundaries early:
 
 - worktree identity
 - declarative repository configuration
@@ -59,9 +59,9 @@ This slice exercises the most important business boundaries early:
 - endpoint isolation
 - refusal behavior
 
-It is small enough to implement quickly and meaningful enough to prove the architecture is real.
+It was small enough to implement quickly and meaningful enough to prove the architecture is real.
 
-## In Scope for the First Slice
+## In Scope for the Initial Slice
 
 - one repository
 - one machine
@@ -73,7 +73,7 @@ It is small enough to implement quickly and meaningful enough to prove the archi
 - different derived values for different worktree instances
 - refusal for invalid configuration or unsafe scope
 
-## Out of Scope for the First Slice
+## Out of Scope for the Initial Slice
 
 - provider inference
 - managed object inference
@@ -102,16 +102,32 @@ Do not create new packages for speculative reuse or abstract neatness.
 
 A new package should be introduced only when a real responsibility boundary or dependency-direction need requires it.
 
-## Expected Deliverables for the First Slice
+## Expected Deliverables for the Initial Slice
 
 - executable acceptance tests for the selected in-scope behavior
 - minimal provider contract tests required by the slice
 - minimal production code needed to satisfy those tests
 - no speculative abstractions beyond the current slice
 
+## Current Progress Note
+
+The repository has progressed beyond the initial slice-planning stage.
+
+Current `main` includes implemented slices covering:
+
+- one-worktree deterministic derive orchestration
+- validated worktree identity admission
+- validated repository-configuration admission
+- explicit capability-intent refusal behavior
+- refusal propagation from providers
+- explicit reset and cleanup core paths
+- thin CLI validation plus explicit provider-wired derive, reset, and cleanup commands
+
+The purpose of this document is still to preserve implementation posture and first-phase boundaries, not to serve as the complete change log for every later slice.
+
 ## Refusal Requirements
 
-Refusal must be present in the first implementation slice.
+Refusal must be present from the first implementation slice onward.
 
 At minimum, the slice should refuse when:
 

--- a/docs/development/tasks/dev-slice-04-doc-sync-task-01.md
+++ b/docs/development/tasks/dev-slice-04-doc-sync-task-01.md
@@ -1,0 +1,44 @@
+# Dev Slice 04 Docs Sync — Task 01
+
+## Title
+
+Sync the development docs with the already-implemented Slice 04 repository-configuration validation seam
+
+## Objective
+
+Add the missing development documentation for the Slice 04 repository-configuration boundary work that already exists on `main`, and refresh the visibly stale parts of `docs/development/implementation-strategy.md` so the development docs no longer imply the repo is still only at the first-slice planning stage.
+
+## In Scope
+
+- add `docs/development/dev-slice-04.md`
+- add `docs/development/dev-slice-04-scenario-map.md`
+- update `docs/development/implementation-strategy.md` only where the current wording is plainly stale
+- align the new docs to the behavior already proven by:
+  - `tests/acceptance/dev-slice-04.acceptance.test.ts`
+  - `tests/unit/repository-configuration-boundary.test.ts`
+
+## Out of Scope
+
+- broad README refresh
+- retroactive rewriting of slices `01` to `03`
+- new product behavior
+- new acceptance or unit tests
+- documentation for later slices beyond what is required to stop Slice 04 drift
+
+## Source Documents
+
+- `docs/adr/0007-repository-configuration-is-explicit-in-1-0.md`
+- `docs/spec/repository-configuration.md`
+- `docs/spec/system-boundary.md`
+- `docs/scenarios/system-boundary.scenarios.md`
+- `tests/acceptance/dev-slice-04.acceptance.test.ts`
+- `tests/unit/repository-configuration-boundary.test.ts`
+- issue `#16`
+
+## Acceptance Criteria
+
+- the repo contains a development-slice doc for Slice 04
+- the repo contains a paired Slice 04 scenario map
+- the docs reflect repository-configuration validation as already implemented on `main`
+- `docs/development/implementation-strategy.md` no longer reads as though only the initial first slice is relevant
+- the update remains narrow and does not attempt a repo-wide documentation rewrite


### PR DESCRIPTION
Closes #16

Summary:
- add the missing Slice 04 development doc and paired scenario map
- add a narrow task doc for the docs-sync work itself
- refresh the visibly stale parts of implementation-strategy so it no longer reads like the repo is still only at first-slice planning

Scope:
- docs/development/dev-slice-04.md
- docs/development/dev-slice-04-scenario-map.md
- docs/development/tasks/dev-slice-04-doc-sync-task-01.md
- docs/development/implementation-strategy.md

Validation:
- docs-only change

Deferred:
- no broader repo-wide docs rewrite
- no retroactive documentation for later slices in this PR