### PR TITLE
Rename slice-named public API to semantic names (#35)

### DIFF
--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -6,7 +6,7 @@ import { pathToFileURL } from "node:url";
 import {
   cleanupOneResource,
   resetOneResource,
-  resolveSlice01,
+  deriveOne,
   validateRepositoryConfiguration,
   validateWorktreeIdentity
 } from "@multiverse/core";
@@ -128,7 +128,7 @@ async function deriveFromFiles(input: {
 }): Promise<CliResult> {
   return executeOperationFromFiles({
     ...input,
-    operation: resolveSlice01
+    operation: deriveOne
   });
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,11 +1,11 @@
 import type {
   CleanupOneResourceResult,
+  DeriveAndValidateOneResult,
+  DeriveOneResult,
   ProviderRegistry,
   Refusal,
   ResourceCleanup,
   ResetOneResourceResult,
-  ResolveSlice01Result,
-  ResolveSlice02Result,
   RepositoryConfiguration,
   ResourceReset,
   ResourceValidation,
@@ -32,12 +32,12 @@ export {
 } from "./repository-configuration";
 
 function isFailureOutcome(
-  value: ResolvedSliceExecution | Extract<ResolveSlice01Result, { ok: false }>
-): value is Extract<ResolveSlice01Result, { ok: false }> {
+  value: ResolvedSliceExecution | Extract<DeriveOneResult, { ok: false }>
+): value is Extract<DeriveOneResult, { ok: false }> {
   return "ok" in value && value.ok === false;
 }
 
-function isFailureResult(value: unknown): value is Extract<ResolveSlice01Result, { ok: false }> {
+function isFailureResult(value: unknown): value is Extract<DeriveOneResult, { ok: false }> {
   return (
     typeof value === "object" &&
     value !== null &&
@@ -128,11 +128,11 @@ function cleanupResourcePlan(input: {
   });
 }
 
-export function resolveSlice01(input: {
+export function deriveOne(input: {
   repository: RepositoryConfiguration;
   worktree: WorktreeInstanceInput;
   providers: ProviderRegistry;
-}): ResolveSlice01Result {
+}): DeriveOneResult {
   const execution = resolveSliceExecution({
     ...input,
     resourceCountReason: "Slice 01 requires exactly one declared managed resource.",
@@ -150,11 +150,11 @@ export function resolveSlice01(input: {
   };
 }
 
-export function resolveSlice02(input: {
+export function deriveAndValidateOne(input: {
   repository: RepositoryConfiguration;
   worktree: WorktreeInstanceInput;
   providers: ProviderRegistry;
-}): ResolveSlice02Result {
+}): DeriveAndValidateOneResult {
   const execution = resolveSliceExecution({
     ...input,
     resourceCountReason: "Slice 02 requires exactly one declared managed resource.",

--- a/packages/core/src/refusals.ts
+++ b/packages/core/src/refusals.ts
@@ -1,10 +1,10 @@
 import type {
   Refusal,
-  ResolveSlice01Result,
-  ResolveSlice02Result
+  DeriveOneResult,
+  DeriveAndValidateOneResult
 } from "@multiverse/provider-contracts";
 
-export type FailureResult = Extract<ResolveSlice01Result, { ok: false }>;
+export type FailureResult = Extract<DeriveOneResult, { ok: false }>;
 
 export function invalidConfiguration(reason: string): FailureResult {
   return {
@@ -28,7 +28,7 @@ export function unsafeScope(reason: string): FailureResult {
 
 export function unsupportedCapability(
   reason: string
-): Extract<ResolveSlice02Result, { ok: false }> {
+): Extract<DeriveAndValidateOneResult, { ok: false }> {
   return {
     ok: false,
     refusal: {

--- a/packages/provider-contracts/src/index.ts
+++ b/packages/provider-contracts/src/index.ts
@@ -170,7 +170,7 @@ export interface ProviderRegistry {
   endpoints: Record<string, EndpointProvider>;
 }
 
-export type ResolveSlice01Result =
+export type DeriveOneResult =
   | {
       ok: true;
       resourcePlans: DerivedResourcePlan[];
@@ -181,7 +181,7 @@ export type ResolveSlice01Result =
       refusal: Refusal;
     };
 
-export type ResolveSlice02Result =
+export type DeriveAndValidateOneResult =
   | {
       ok: true;
       resourcePlans: DerivedResourcePlan[];

--- a/tests/acceptance/dev-slice-01.acceptance.test.ts
+++ b/tests/acceptance/dev-slice-01.acceptance.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { resolveSlice01 } from "@multiverse/core";
+import { deriveOne } from "@multiverse/core";
 import {
   createExplicitTestProviders,
   createValidRepositoryConfiguration,
@@ -9,7 +9,7 @@ import {
 
 describe("Development Slice 01 acceptance", () => {
   it("resolves successfully for a valid declared worktree instance", () => {
-    const outcome = resolveSlice01({
+    const outcome = deriveOne({
       repository: createValidRepositoryConfiguration(),
       worktree: createWorktreeInstance({
         id: "wt-feature-a",
@@ -52,14 +52,14 @@ describe("Development Slice 01 acceptance", () => {
     });
     const providers = createExplicitTestProviders();
 
-    const first = resolveSlice01({ repository, worktree, providers });
-    const second = resolveSlice01({ repository, worktree, providers });
+    const first = deriveOne({ repository, worktree, providers });
+    const second = deriveOne({ repository, worktree, providers });
 
     expect(first).toEqual(second);
   });
 
   it("resolves successfully for the reserved main worktree identity", () => {
-    const outcome = resolveSlice01({
+    const outcome = deriveOne({
       repository: createValidRepositoryConfiguration(),
       worktree: createWorktreeInstance({
         id: "main",
@@ -86,7 +86,7 @@ describe("Development Slice 01 acceptance", () => {
     const repository = createValidRepositoryConfiguration();
     const providers = createExplicitTestProviders();
 
-    const first = resolveSlice01({
+    const first = deriveOne({
       repository,
       worktree: createWorktreeInstance({
         id: "wt-first",
@@ -95,7 +95,7 @@ describe("Development Slice 01 acceptance", () => {
       }),
       providers
     });
-    const second = resolveSlice01({
+    const second = deriveOne({
       repository,
       worktree: createWorktreeInstance({
         id: "wt-second",
@@ -117,7 +117,7 @@ describe("Development Slice 01 acceptance", () => {
   });
 
   it("refuses when provider assignment is missing", () => {
-    const outcome = resolveSlice01({
+    const outcome = deriveOne({
       repository: createValidRepositoryConfiguration({
         resources: [
           {
@@ -144,7 +144,7 @@ describe("Development Slice 01 acceptance", () => {
   });
 
   it("refuses when required declaration data is invalid or missing", () => {
-    const outcome = resolveSlice01({
+    const outcome = deriveOne({
       repository: createValidRepositoryConfiguration({
         endpoints: [
           {
@@ -169,7 +169,7 @@ describe("Development Slice 01 acceptance", () => {
   });
 
   it("refuses when safe scope is ambiguous or unsafe", () => {
-    const outcome = resolveSlice01({
+    const outcome = deriveOne({
       repository: createValidRepositoryConfiguration(),
       worktree: {
         label: "ambiguous-scope",
@@ -197,7 +197,7 @@ describe("Development Slice 01 acceptance", () => {
       "deriveEndpoint"
     );
 
-    const outcome = resolveSlice01({
+    const outcome = deriveOne({
       repository: createValidRepositoryConfiguration(),
       worktree: createWorktreeInstance({
         id: "   ",

--- a/tests/acceptance/dev-slice-02.acceptance.test.ts
+++ b/tests/acceptance/dev-slice-02.acceptance.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { resolveSlice02 } from "@multiverse/core";
+import { deriveAndValidateOne } from "@multiverse/core";
 import {
   createExplicitTestProviders,
   createValidRepositoryConfiguration,
@@ -9,7 +9,7 @@ import {
 
 describe("Development Slice 02 acceptance", () => {
   it("accepts an explicitly supported validate capability request", () => {
-    const outcome = resolveSlice02({
+    const outcome = deriveAndValidateOne({
       repository: createValidRepositoryConfiguration({
         resources: [
           {
@@ -55,7 +55,7 @@ describe("Development Slice 02 acceptance", () => {
       "deriveResource"
     );
 
-    const outcome = resolveSlice02({
+    const outcome = deriveAndValidateOne({
       repository: createValidRepositoryConfiguration({
         resources: [
           {
@@ -85,7 +85,7 @@ describe("Development Slice 02 acceptance", () => {
   });
 
   it("refuses validation when safe scope cannot be established", () => {
-    const outcome = resolveSlice02({
+    const outcome = deriveAndValidateOne({
       repository: createValidRepositoryConfiguration({
         resources: [
           {
@@ -120,7 +120,7 @@ describe("Development Slice 02 acceptance", () => {
       "deriveResource"
     );
 
-    const outcome = resolveSlice02({
+    const outcome = deriveAndValidateOne({
       repository: createValidRepositoryConfiguration({
         resources: [
           {
@@ -155,7 +155,7 @@ describe("Development Slice 02 acceptance", () => {
       "deriveResource"
     );
 
-    const outcome = resolveSlice02({
+    const outcome = deriveAndValidateOne({
       repository: createValidRepositoryConfiguration({
         resources: [
           {

--- a/tests/acceptance/dev-slice-04.acceptance.test.ts
+++ b/tests/acceptance/dev-slice-04.acceptance.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { resolveSlice01 } from "@multiverse/core";
+import { deriveOne } from "@multiverse/core";
 import {
   createExplicitTestProviders,
   createValidRepositoryConfiguration,
@@ -9,7 +9,7 @@ import {
 
 describe("Development Slice 04 acceptance", () => {
   it("accepts valid raw repository configuration through the current orchestration path", () => {
-    const outcome = resolveSlice01({
+    const outcome = deriveOne({
       repository: createValidRepositoryConfiguration(),
       worktree: createWorktreeInstance({
         id: "wt-valid-raw-repository"
@@ -21,7 +21,7 @@ describe("Development Slice 04 acceptance", () => {
   });
 
   it("rejects a resource missing a provider", () => {
-    const outcome = resolveSlice01({
+    const outcome = deriveOne({
       repository: createValidRepositoryConfiguration({
         resources: [
           {
@@ -48,7 +48,7 @@ describe("Development Slice 04 acceptance", () => {
   });
 
   it("rejects a resource missing a primary isolation strategy", () => {
-    const outcome = resolveSlice01({
+    const outcome = deriveOne({
       repository: createValidRepositoryConfiguration({
         resources: [
           {
@@ -75,7 +75,7 @@ describe("Development Slice 04 acceptance", () => {
   });
 
   it("rejects an endpoint missing a role", () => {
-    const outcome = resolveSlice01({
+    const outcome = deriveOne({
       repository: createValidRepositoryConfiguration({
         endpoints: [
           {
@@ -109,7 +109,7 @@ describe("Development Slice 04 acceptance", () => {
       "deriveEndpoint"
     );
 
-    const outcome = resolveSlice01({
+    const outcome = deriveOne({
       repository: createValidRepositoryConfiguration({
         endpoints: [
           {

--- a/tests/acceptance/dev-slice-05.acceptance.test.ts
+++ b/tests/acceptance/dev-slice-05.acceptance.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { resolveSlice01 } from "@multiverse/core";
+import { deriveOne } from "@multiverse/core";
 import {
   createExplicitTestProviders,
   createValidRepositoryConfiguration,
@@ -9,7 +9,7 @@ import {
 
 describe("Development Slice 05 acceptance", () => {
   it("accepts valid raw endpoint declarations through the current orchestration path", () => {
-    const outcome = resolveSlice01({
+    const outcome = deriveOne({
       repository: createValidRepositoryConfiguration(),
       worktree: createWorktreeInstance({
         id: "wt-valid-endpoint-declaration"
@@ -21,7 +21,7 @@ describe("Development Slice 05 acceptance", () => {
   });
 
   it("rejects an endpoint missing a name", () => {
-    const outcome = resolveSlice01({
+    const outcome = deriveOne({
       repository: createValidRepositoryConfiguration({
         endpoints: [
           {
@@ -45,7 +45,7 @@ describe("Development Slice 05 acceptance", () => {
   });
 
   it("rejects an endpoint missing a role", () => {
-    const outcome = resolveSlice01({
+    const outcome = deriveOne({
       repository: createValidRepositoryConfiguration({
         endpoints: [
           {
@@ -69,7 +69,7 @@ describe("Development Slice 05 acceptance", () => {
   });
 
   it("rejects an endpoint missing a provider", () => {
-    const outcome = resolveSlice01({
+    const outcome = deriveOne({
       repository: createValidRepositoryConfiguration({
         endpoints: [
           {
@@ -99,7 +99,7 @@ describe("Development Slice 05 acceptance", () => {
       "deriveEndpoint"
     );
 
-    const outcome = resolveSlice01({
+    const outcome = deriveOne({
       repository: createValidRepositoryConfiguration({
         endpoints: [
           {

--- a/tests/acceptance/dev-slice-06.acceptance.test.ts
+++ b/tests/acceptance/dev-slice-06.acceptance.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { resolveSlice01, resolveSlice02 } from "@multiverse/core";
+import { deriveOne, deriveAndValidateOne } from "@multiverse/core";
 import {
   createProvidersWithEndpointDeriveRefusal,
   createProvidersWithResourceDeriveRefusal,
@@ -11,7 +11,7 @@ import {
 
 describe("Development Slice 06 acceptance", () => {
   it("returns provider-originated unsafe scope during derive unchanged", () => {
-    const outcome = resolveSlice01({
+    const outcome = deriveOne({
       repository: createValidRepositoryConfiguration(),
       worktree: createWorktreeInstance({
         id: "wt-provider-unsafe-derive"
@@ -32,7 +32,7 @@ describe("Development Slice 06 acceptance", () => {
   });
 
   it("returns provider-originated provider failure during derive unchanged", () => {
-    const outcome = resolveSlice01({
+    const outcome = deriveOne({
       repository: createValidRepositoryConfiguration(),
       worktree: createWorktreeInstance({
         id: "wt-provider-failure-derive"
@@ -53,7 +53,7 @@ describe("Development Slice 06 acceptance", () => {
   });
 
   it("returns provider-originated unsafe scope during validate unchanged", () => {
-    const outcome = resolveSlice02({
+    const outcome = deriveAndValidateOne({
       repository: createValidRepositoryConfiguration({
         resources: [
           {
@@ -85,7 +85,7 @@ describe("Development Slice 06 acceptance", () => {
   });
 
   it("returns provider-originated provider failure during validate unchanged", () => {
-    const outcome = resolveSlice02({
+    const outcome = deriveAndValidateOne({
       repository: createValidRepositoryConfiguration({
         resources: [
           {

--- a/tests/acceptance/dev-slice-08.acceptance.test.ts
+++ b/tests/acceptance/dev-slice-08.acceptance.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { resetOneResource, resolveSlice01 } from "@multiverse/core";
+import { resetOneResource, deriveOne } from "@multiverse/core";
 import {
   createExplicitTestProviders,
   createProvidersWithResourceResetRefusal,
@@ -156,7 +156,7 @@ describe("Development Slice 08 acceptance", () => {
       "resetResource"
     );
 
-    const outcome = resolveSlice01({
+    const outcome = deriveOne({
       repository: createValidRepositoryConfiguration({
         resources: [
           {

--- a/tests/acceptance/dev-slice-09.acceptance.test.ts
+++ b/tests/acceptance/dev-slice-09.acceptance.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { cleanupOneResource, resolveSlice01 } from "@multiverse/core";
+import { cleanupOneResource, deriveOne } from "@multiverse/core";
 import {
   createExplicitTestProviders,
   createProvidersWithResourceCleanupRefusal,
@@ -156,7 +156,7 @@ describe("Development Slice 09 acceptance", () => {
       "cleanupResource"
     );
 
-    const outcome = resolveSlice01({
+    const outcome = deriveOne({
       repository: createValidRepositoryConfiguration({
         resources: [
           {

--- a/tests/acceptance/dev-slice-13.acceptance.test.ts
+++ b/tests/acceptance/dev-slice-13.acceptance.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { resolveSlice01 } from "@multiverse/core";
+import { deriveOne } from "@multiverse/core";
 import { createLocalPortProvider } from "@multiverse/provider-local-port";
 import { createExplicitTestProviders } from "@multiverse/providers-testkit";
 
@@ -37,7 +37,7 @@ describe("dev-slice-13: local port endpoint provider", () => {
   };
 
   it("derives a local HTTP address for a valid worktree instance", () => {
-    const result = resolveSlice01({
+    const result = deriveOne({
       repository,
       worktree: { id: "feature-login" },
       providers: makeProviders()
@@ -51,7 +51,7 @@ describe("dev-slice-13: local port endpoint provider", () => {
   });
 
   it("derives an address with port in the configured base port range", () => {
-    const result = resolveSlice01({
+    const result = deriveOne({
       repository,
       worktree: { id: "feature-login" },
       providers: makeProviders()
@@ -68,13 +68,13 @@ describe("dev-slice-13: local port endpoint provider", () => {
   });
 
   it("derives the same address for the same worktree ID on repeated calls", () => {
-    const first = resolveSlice01({
+    const first = deriveOne({
       repository,
       worktree: { id: "feature-payments" },
       providers: makeProviders()
     });
 
-    const second = resolveSlice01({
+    const second = deriveOne({
       repository,
       worktree: { id: "feature-payments" },
       providers: makeProviders()
@@ -88,13 +88,13 @@ describe("dev-slice-13: local port endpoint provider", () => {
   });
 
   it("derives distinct addresses for distinct worktree IDs", () => {
-    const resultA = resolveSlice01({
+    const resultA = deriveOne({
       repository,
       worktree: { id: "worktree-a" },
       providers: makeProviders()
     });
 
-    const resultB = resolveSlice01({
+    const resultB = deriveOne({
       repository,
       worktree: { id: "worktree-b" },
       providers: makeProviders()
@@ -108,7 +108,7 @@ describe("dev-slice-13: local port endpoint provider", () => {
   });
 
   it("returns a refusal when worktree ID is absent", () => {
-    const result = resolveSlice01({
+    const result = deriveOne({
       repository,
       worktree: {},
       providers: makeProviders()


### PR DESCRIPTION
## Summary

Renames the four slice-implementation-named symbols in the public API to names that communicate intent.

| Before | After |
|---|---|
| `resolveSlice01` | `deriveOne` |
| `resolveSlice02` | `deriveAndValidateOne` |
| `ResolveSlice01Result` | `DeriveOneResult` |
| `ResolveSlice02Result` | `DeriveAndValidateOneResult` |

## Scope

- `packages/provider-contracts/src/index.ts` — type definitions
- `packages/core/src/refusals.ts` — import and alias
- `packages/core/src/index.ts` — function exports
- `apps/cli/src/index.ts` — consumer
- 8 acceptance test files

## Validation

- `pnpm typecheck` — clean
- `pnpm test` — 20 files, 85 tests, all passing

No behavior change.

Closes #35