### PR TITLE
Consolidate isFailure* type guards in core (#38)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -11,7 +11,7 @@ import type {
   ResourceValidation,
   WorktreeInstanceInput
 } from "@multiverse/provider-contracts";
-import { invalidConfiguration, isRefusal, unsupportedCapability } from "./refusals";
+import { invalidConfiguration, isFailureOutcome, isRefusal, unsupportedCapability } from "./refusals";
 import {
   resolveSlicePreflight,
   resolveSliceExecution,
@@ -30,21 +30,6 @@ export {
   validateRepositoryConfiguration,
   withValidatedRepositoryConfiguration
 } from "./repository-configuration";
-
-function isFailureOutcome(
-  value: ResolvedSliceExecution | Extract<DeriveOneResult, { ok: false }>
-): value is Extract<DeriveOneResult, { ok: false }> {
-  return "ok" in value && value.ok === false;
-}
-
-function isFailureResult(value: unknown): value is Extract<DeriveOneResult, { ok: false }> {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    "ok" in value &&
-    value.ok === false
-  );
-}
 
 function validateResourcePlan(input: {
   provider: ResolvedSliceExecution["providers"]["resource"];
@@ -208,7 +193,7 @@ export function resetOneResource(input: {
     endpointCountReason: "Reset requires exactly one declared managed endpoint."
   });
 
-  if (isFailureResult(preflight)) {
+  if (isFailureOutcome(preflight)) {
     return preflight;
   }
 
@@ -237,7 +222,7 @@ export function resetOneResource(input: {
     worktree: preflight.worktree
   });
 
-  if (isFailureResult(reset)) {
+  if (isFailureOutcome(reset)) {
     return reset;
   }
 
@@ -266,7 +251,7 @@ export function cleanupOneResource(input: {
     endpointCountReason: "Cleanup requires exactly one declared managed endpoint."
   });
 
-  if (isFailureResult(preflight)) {
+  if (isFailureOutcome(preflight)) {
     return preflight;
   }
 
@@ -295,7 +280,7 @@ export function cleanupOneResource(input: {
     worktree: preflight.worktree
   });
 
-  if (isFailureResult(cleanup)) {
+  if (isFailureOutcome(cleanup)) {
     return cleanup;
   }
 

--- a/packages/core/src/orchestration.ts
+++ b/packages/core/src/orchestration.ts
@@ -17,6 +17,7 @@ import {
 } from "./repository-configuration";
 import {
   invalidConfiguration,
+  isFailureOutcome,
   isRefusal,
   unsupportedCapability,
   unsafeScope,
@@ -53,15 +54,6 @@ export interface ResolvedSliceDerivedValues {
 
 export interface ResolvedSliceExecution extends ResolvedSlicePreflight {
   derived: ResolvedSliceDerivedValues;
-}
-
-function isFailureOutcome(value: unknown): value is FailureResult {
-  return (
-    typeof value === "object" &&
-    value !== null &&
-    "ok" in value &&
-    value.ok === false
-  );
 }
 
 export function resolveSlicePreflight(input: {

--- a/packages/core/src/refusals.ts
+++ b/packages/core/src/refusals.ts
@@ -38,6 +38,15 @@ export function unsupportedCapability(
   };
 }
 
+export function isFailureOutcome(value: unknown): value is FailureResult {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "ok" in value &&
+    (value as { ok: unknown }).ok === false
+  );
+}
+
 export function isRefusal(value: unknown): value is Refusal {
   return (
     typeof value === "object" &&


### PR DESCRIPTION
## Summary

Adds `isFailureOutcome(value: unknown): value is FailureResult` to `refusals.ts` as the single shared guard, then removes the two duplicate local definitions that existed across `orchestration.ts` and `index.ts` (which had slightly different signatures doing the same thing).

## Scope

- `packages/core/src/refusals.ts` — add exported `isFailureOutcome`
- `packages/core/src/orchestration.ts` — remove local definition, import from refusals
- `packages/core/src/index.ts` — remove two local definitions (`isFailureOutcome` + `isFailureResult`), use imported guard

## Validation

- `pnpm typecheck` — clean
- `pnpm test` — 24 files, 100 tests, all passing

No behavior change.

Closes #38