### PR TITLE
Add reset and cleanup to name-scoped provider (dev-slice-16)

### DIFF
--- a/docs/development/dev-slice-16.md
+++ b/docs/development/dev-slice-16.md
@@ -1,0 +1,67 @@
+# Dev Slice 16 — Name-Scoped Provider Lifecycle: Reset and Cleanup
+
+## Status
+
+Implemented on `main`
+
+## Intent
+
+Add `reset` and `cleanup` capabilities to `@multiverse/provider-name-scoped`.
+
+Without these, the `reset` and `cleanup` CLI commands return `unsupported_capability` even when a resource declares `scopedReset: true` or `scopedCleanup: true`. This makes the two destructive lifecycle commands useless against real name-scoped resources and breaks the 1.0 guarantee that reset and cleanup are available when declared.
+
+## Why this slice next
+
+The name-scoped provider is the most common resource type (databases, schemas, queues). Reset and cleanup are the two operations developers use most during active development — reset to reinitialize a worktree's database, cleanup to tear it down when done.
+
+Making these work on the first concrete resource provider closes the loop on the full lifecycle for the most common use case.
+
+## Provider lifecycle contract for 1.0
+
+For the name-scoped provider, reset and cleanup are scope-confirmation operations:
+
+- the provider verifies the worktree ID is present
+- the provider returns a structured confirmation (`ResourceReset` or `ResourceCleanup`) with the resource name, provider, worktree ID, and capability
+- the derived handle identifies what the consumer should act on (drop and recreate the database, delete the schema, etc.)
+- the provider does not perform the actual database operation — that is the responsibility of the consuming application or a future technology-specific provider layer
+
+This is correct for 1.0: the tool's job is to determine safe scope and return structured results. Execution of the destructive action belongs to the consumer.
+
+## Slice objective
+
+Extend `@multiverse/provider-name-scoped` such that:
+
+1. the provider declares `reset: true` and `cleanup: true` in its capabilities
+2. `resetResource` returns a `ResourceReset` when the worktree ID is present
+3. `cleanupResource` returns a `ResourceCleanup` when the worktree ID is present
+4. both refuse with `unsafe_scope` when the worktree ID is absent
+5. contract tests cover the new capabilities
+6. acceptance tests prove end-to-end reset and cleanup through the CLI path
+
+## Scope
+
+- `packages/provider-name-scoped/src/index.ts` — add capabilities + methods
+- `tests/contracts/resource-provider.name-scoped.contract.test.ts` — extend with reset + cleanup tests
+- `tests/acceptance/dev-slice-16.acceptance.test.ts`
+- slice and task docs
+
+## Out of scope
+
+- actual database operations (drop, recreate, delete)
+- validate capability
+- path-scoped lifecycle (Slice 17)
+- CLI changes
+- core changes
+
+## Acceptance criteria
+
+- `resetOneResource` succeeds for a name-scoped resource with `scopedReset: true`
+- `cleanupOneResource` succeeds for a name-scoped resource with `scopedCleanup: true`
+- `resetOneResource` returns `unsupported_capability` when provider lacks reset (existing behavior, must stay green)
+- `cleanupOneResource` returns `unsupported_capability` when provider lacks cleanup (existing behavior, must stay green)
+- unsafe_scope is returned when worktree ID is absent for reset or cleanup
+- all existing 100 tests remain green
+
+## Definition of done
+
+This slice is done when `@multiverse/provider-name-scoped` declares and implements reset and cleanup, and tests prove the full lifecycle path works end-to-end.

--- a/docs/development/tasks/dev-slice-16-task-01.md
+++ b/docs/development/tasks/dev-slice-16-task-01.md
@@ -1,0 +1,34 @@
+# Dev Slice 16 — Task 01
+
+## Title
+
+Add reset and cleanup capabilities to the name-scoped resource provider
+
+## Sources of truth
+
+- `docs/adr/0008-unsafe-operations-are-refused-in-1-0.md`
+- `docs/spec/provider-model.md`
+- `docs/spec/resource-isolation.md`
+- `docs/spec/safety-and-refusal.md`
+- `docs/development/dev-slice-16.md`
+
+## In scope
+
+- `packages/provider-name-scoped/src/index.ts`
+- `tests/contracts/resource-provider.name-scoped.contract.test.ts`
+- `tests/acceptance/dev-slice-16.acceptance.test.ts`
+- slice and task docs
+
+## Out of scope
+
+- validate capability
+- actual database operations
+- path-scoped provider
+- CLI or core changes
+
+## Acceptance criteria
+
+- `resetOneResource` succeeds with `{ ok: true, resourceResets: [...] }` for a name-scoped resource
+- `cleanupOneResource` succeeds with `{ ok: true, resourceCleanups: [...] }` for a name-scoped resource
+- both refuse with `unsafe_scope` when worktree ID is absent
+- all existing 100 tests remain green

--- a/packages/provider-name-scoped/src/index.ts
+++ b/packages/provider-name-scoped/src/index.ts
@@ -1,13 +1,28 @@
-import type { ResourceProvider, DerivedResourcePlan, Refusal } from "@multiverse/provider-contracts";
+import type {
+  ResourceProvider,
+  DerivedResourcePlan,
+  ResourceReset,
+  ResourceCleanup,
+  Refusal
+} from "@multiverse/provider-contracts";
+
+function unsafeScope(): Refusal {
+  return {
+    category: "unsafe_scope",
+    reason: "Safe worktree scope cannot be determined: worktree ID is absent."
+  };
+}
 
 export function createNameScopedProvider(): ResourceProvider {
   return {
+    capabilities: {
+      reset: true,
+      cleanup: true
+    },
+
     deriveResource({ resource, worktree }): DerivedResourcePlan | Refusal {
       if (!worktree.id) {
-        return {
-          category: "unsafe_scope",
-          reason: "Safe worktree scope cannot be determined: worktree ID is absent."
-        };
+        return unsafeScope();
       }
 
       return {
@@ -16,6 +31,32 @@ export function createNameScopedProvider(): ResourceProvider {
         isolationStrategy: "name-scoped",
         worktreeId: worktree.id,
         handle: `${resource.name}_${worktree.id}`
+      };
+    },
+
+    resetResource({ resource, derived, worktree }): ResourceReset | Refusal {
+      if (!worktree.id) {
+        return unsafeScope();
+      }
+
+      return {
+        resourceName: resource.name,
+        provider: resource.provider,
+        worktreeId: derived.worktreeId,
+        capability: "reset"
+      };
+    },
+
+    cleanupResource({ resource, derived, worktree }): ResourceCleanup | Refusal {
+      if (!worktree.id) {
+        return unsafeScope();
+      }
+
+      return {
+        resourceName: resource.name,
+        provider: resource.provider,
+        worktreeId: derived.worktreeId,
+        capability: "cleanup"
       };
     }
   };

--- a/tests/acceptance/dev-slice-16.acceptance.test.ts
+++ b/tests/acceptance/dev-slice-16.acceptance.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from "vitest";
+import { resetOneResource, cleanupOneResource } from "@multiverse/core";
+import { createNameScopedProvider } from "@multiverse/provider-name-scoped";
+import { createLocalPortProvider } from "@multiverse/provider-local-port";
+
+describe("dev-slice-16: name-scoped provider lifecycle", () => {
+  const nameScopedProvider = createNameScopedProvider();
+  const localPortProvider = createLocalPortProvider({ basePort: 7000 });
+
+  function makeProviders() {
+    return {
+      resources: { "name-scoped": nameScopedProvider },
+      endpoints: { "local-port": localPortProvider }
+    };
+  }
+
+  function makeRepository(overrides: { scopedReset?: boolean; scopedCleanup?: boolean } = {}) {
+    return {
+      resources: [
+        {
+          name: "primary-db",
+          provider: "name-scoped",
+          isolationStrategy: "name-scoped" as const,
+          scopedValidate: false,
+          scopedReset: overrides.scopedReset ?? false,
+          scopedCleanup: overrides.scopedCleanup ?? false
+        }
+      ],
+      endpoints: [
+        {
+          name: "app-base-url",
+          role: "application-base-url",
+          provider: "local-port"
+        }
+      ]
+    };
+  }
+
+  describe("reset", () => {
+    it("succeeds for a name-scoped resource with scopedReset declared", () => {
+      const result = resetOneResource({
+        repository: makeRepository({ scopedReset: true }),
+        worktree: { id: "feature-login" },
+        providers: makeProviders()
+      });
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      expect(result.resourceResets[0].capability).toBe("reset");
+      expect(result.resourceResets[0].resourceName).toBe("primary-db");
+      expect(result.resourceResets[0].worktreeId).toBe("feature-login");
+    });
+
+    it("returns invalid_configuration when scopedReset is not declared", () => {
+      const result = resetOneResource({
+        repository: makeRepository({ scopedReset: false }),
+        worktree: { id: "feature-login" },
+        providers: makeProviders()
+      });
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+
+      expect(result.refusal.category).toBe("invalid_configuration");
+    });
+
+    it("returns unsafe_scope when worktree ID is absent", () => {
+      const result = resetOneResource({
+        repository: makeRepository({ scopedReset: true }),
+        worktree: {},
+        providers: makeProviders()
+      });
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+
+      expect(result.refusal.category).toBe("unsafe_scope");
+    });
+  });
+
+  describe("cleanup", () => {
+    it("succeeds for a name-scoped resource with scopedCleanup declared", () => {
+      const result = cleanupOneResource({
+        repository: makeRepository({ scopedCleanup: true }),
+        worktree: { id: "feature-login" },
+        providers: makeProviders()
+      });
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      expect(result.resourceCleanups[0].capability).toBe("cleanup");
+      expect(result.resourceCleanups[0].resourceName).toBe("primary-db");
+      expect(result.resourceCleanups[0].worktreeId).toBe("feature-login");
+    });
+
+    it("returns invalid_configuration when scopedCleanup is not declared", () => {
+      const result = cleanupOneResource({
+        repository: makeRepository({ scopedCleanup: false }),
+        worktree: { id: "feature-login" },
+        providers: makeProviders()
+      });
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+
+      expect(result.refusal.category).toBe("invalid_configuration");
+    });
+
+    it("returns unsafe_scope when worktree ID is absent", () => {
+      const result = cleanupOneResource({
+        repository: makeRepository({ scopedCleanup: true }),
+        worktree: {},
+        providers: makeProviders()
+      });
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+
+      expect(result.refusal.category).toBe("unsafe_scope");
+    });
+  });
+});

--- a/tests/contracts/resource-provider.name-scoped.contract.test.ts
+++ b/tests/contracts/resource-provider.name-scoped.contract.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import type { DerivedResourcePlan, Refusal } from "@multiverse/provider-contracts";
+import type { DerivedResourcePlan, ResourceReset, ResourceCleanup, Refusal } from "@multiverse/provider-contracts";
 import { createNameScopedProvider } from "@multiverse/provider-name-scoped";
 
 function isDerivedResourcePlan(value: DerivedResourcePlan | Refusal): value is DerivedResourcePlan {
@@ -53,5 +53,87 @@ describe("resource provider contract: name-scoped derive", () => {
 
     expect(result.handle).toContain(validInput.resource.name);
     expect(result.handle).toContain(validInput.worktree.id);
+  });
+});
+
+describe("resource provider contract: name-scoped reset", () => {
+  const provider = createNameScopedProvider();
+
+  const resourceInput = {
+    name: "primary-db",
+    provider: "name-scoped",
+    isolationStrategy: "name-scoped" as const,
+    scopedValidate: false,
+    scopedReset: true,
+    scopedCleanup: false
+  };
+
+  const derived = {
+    resourceName: "primary-db",
+    provider: "name-scoped",
+    isolationStrategy: "name-scoped" as const,
+    worktreeId: "feature-login",
+    handle: "primary-db_feature-login"
+  };
+
+  it("declares reset capability", () => {
+    expect(provider.capabilities?.reset).toBe(true);
+  });
+
+  it("returns a ResourceReset for valid input", () => {
+    expect(provider.resetResource).toBeDefined();
+    if (!provider.resetResource) return;
+
+    const result = provider.resetResource({
+      resource: resourceInput,
+      derived,
+      worktree: { id: "feature-login" }
+    });
+
+    const reset = result as ResourceReset;
+    expect(reset.capability).toBe("reset");
+    expect(reset.resourceName).toBe("primary-db");
+    expect(reset.worktreeId).toBe("feature-login");
+  });
+});
+
+describe("resource provider contract: name-scoped cleanup", () => {
+  const provider = createNameScopedProvider();
+
+  const resourceInput = {
+    name: "primary-db",
+    provider: "name-scoped",
+    isolationStrategy: "name-scoped" as const,
+    scopedValidate: false,
+    scopedReset: false,
+    scopedCleanup: true
+  };
+
+  const derived = {
+    resourceName: "primary-db",
+    provider: "name-scoped",
+    isolationStrategy: "name-scoped" as const,
+    worktreeId: "feature-login",
+    handle: "primary-db_feature-login"
+  };
+
+  it("declares cleanup capability", () => {
+    expect(provider.capabilities?.cleanup).toBe(true);
+  });
+
+  it("returns a ResourceCleanup for valid input", () => {
+    expect(provider.cleanupResource).toBeDefined();
+    if (!provider.cleanupResource) return;
+
+    const result = provider.cleanupResource({
+      resource: resourceInput,
+      derived,
+      worktree: { id: "feature-login" }
+    });
+
+    const cleanup = result as ResourceCleanup;
+    expect(cleanup.capability).toBe("cleanup");
+    expect(cleanup.resourceName).toBe("primary-db");
+    expect(cleanup.worktreeId).toBe("feature-login");
   });
 });


### PR DESCRIPTION
## Summary

Extends `@multiverse/provider-name-scoped` with `reset` and `cleanup` capabilities.

Without this, `resetOneResource` and `cleanupOneResource` returned `unsupported_capability` for name-scoped resources even when `scopedReset`/`scopedCleanup` were declared — making the destructive lifecycle commands useless against real resources.

The provider confirms safe scope (worktree ID present) and returns a structured `ResourceReset`/`ResourceCleanup` result with the derived handle. Actual database operations (drop, recreate, etc.) are the consumer's responsibility — the provider's role is scope confirmation and structured output.

## Scope

- `packages/provider-name-scoped/src/index.ts` — add `reset`/`cleanup` capabilities and methods
- `tests/contracts/resource-provider.name-scoped.contract.test.ts` — extended with reset + cleanup contract tests
- `tests/acceptance/dev-slice-16.acceptance.test.ts` — new acceptance tests

## Validation

- `pnpm typecheck` — clean
- `pnpm test` — 25 files, 110 tests, all passing

Closes #43