### PR TITLE
Add reset and cleanup to path-scoped provider (dev-slice-17)

### DIFF
--- a/docs/development/dev-slice-17.md
+++ b/docs/development/dev-slice-17.md
@@ -1,0 +1,36 @@
+# Dev Slice 17 — Path-Scoped Provider Lifecycle: Reset and Cleanup
+
+## Status
+
+Implemented on `main`
+
+## Intent
+
+Add `reset` and `cleanup` capabilities to `@multiverse/provider-path-scoped`, following the same scope-confirmation model established in Slice 16.
+
+For path-scoped resources (SQLite files, artifact directories), cleanup is the primary lifecycle operation — it tells the consumer which path to remove when a worktree is retired. Reset tells the consumer which path to clear and reinitialize.
+
+## Scope
+
+- `packages/provider-path-scoped/src/index.ts` — add capabilities + methods
+- `tests/contracts/resource-provider.path-scoped.contract.test.ts` — extend
+- `tests/acceptance/dev-slice-17.acceptance.test.ts`
+- slice and task docs
+
+## Out of scope
+
+- validate capability
+- actual filesystem operations
+- name-scoped provider (done in Slice 16)
+
+## Acceptance criteria
+
+- `resetOneResource` succeeds for a path-scoped resource with `scopedReset: true`
+- `cleanupOneResource` succeeds for a path-scoped resource with `scopedCleanup: true`
+- both include the derived path handle in the result
+- both refuse with `unsafe_scope` when worktree ID is absent
+- all existing 110 tests remain green
+
+## Status
+
+In progress

--- a/docs/development/tasks/dev-slice-17-task-01.md
+++ b/docs/development/tasks/dev-slice-17-task-01.md
@@ -1,0 +1,33 @@
+# Dev Slice 17 — Task 01
+
+## Title
+
+Add reset and cleanup capabilities to the path-scoped resource provider
+
+## Sources of truth
+
+- `docs/spec/provider-model.md`
+- `docs/spec/resource-isolation.md`
+- `docs/spec/safety-and-refusal.md`
+- `docs/development/dev-slice-16.md` (pattern reference)
+- `docs/development/dev-slice-17.md`
+
+## In scope
+
+- `packages/provider-path-scoped/src/index.ts`
+- `tests/contracts/resource-provider.path-scoped.contract.test.ts`
+- `tests/acceptance/dev-slice-17.acceptance.test.ts`
+- slice and task docs
+
+## Out of scope
+
+- validate capability
+- filesystem operations
+- name-scoped or other providers
+
+## Acceptance criteria
+
+- `resetOneResource` succeeds with structured result for path-scoped resource
+- `cleanupOneResource` succeeds with structured result for path-scoped resource
+- unsafe_scope returned when worktree ID absent
+- all existing 110 tests remain green

--- a/packages/provider-path-scoped/src/index.ts
+++ b/packages/provider-path-scoped/src/index.ts
@@ -1,18 +1,33 @@
 import { join } from "node:path";
-import type { ResourceProvider, DerivedResourcePlan, Refusal } from "@multiverse/provider-contracts";
+import type {
+  ResourceProvider,
+  DerivedResourcePlan,
+  ResourceReset,
+  ResourceCleanup,
+  Refusal
+} from "@multiverse/provider-contracts";
 
 export interface PathScopedProviderConfig {
   baseDir: string;
 }
 
+function unsafeScope(): Refusal {
+  return {
+    category: "unsafe_scope",
+    reason: "Safe worktree scope cannot be determined: worktree ID is absent."
+  };
+}
+
 export function createPathScopedProvider(config: PathScopedProviderConfig): ResourceProvider {
   return {
+    capabilities: {
+      reset: true,
+      cleanup: true
+    },
+
     deriveResource({ resource, worktree }): DerivedResourcePlan | Refusal {
       if (!worktree.id) {
-        return {
-          category: "unsafe_scope",
-          reason: "Safe worktree scope cannot be determined: worktree ID is absent."
-        };
+        return unsafeScope();
       }
 
       return {
@@ -21,6 +36,32 @@ export function createPathScopedProvider(config: PathScopedProviderConfig): Reso
         isolationStrategy: "path-scoped",
         worktreeId: worktree.id,
         handle: join(config.baseDir, resource.name, worktree.id)
+      };
+    },
+
+    resetResource({ resource, derived, worktree }): ResourceReset | Refusal {
+      if (!worktree.id) {
+        return unsafeScope();
+      }
+
+      return {
+        resourceName: resource.name,
+        provider: resource.provider,
+        worktreeId: derived.worktreeId,
+        capability: "reset"
+      };
+    },
+
+    cleanupResource({ resource, derived, worktree }): ResourceCleanup | Refusal {
+      if (!worktree.id) {
+        return unsafeScope();
+      }
+
+      return {
+        resourceName: resource.name,
+        provider: resource.provider,
+        worktreeId: derived.worktreeId,
+        capability: "cleanup"
       };
     }
   };

--- a/tests/acceptance/dev-slice-17.acceptance.test.ts
+++ b/tests/acceptance/dev-slice-17.acceptance.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from "vitest";
+import { resetOneResource, cleanupOneResource } from "@multiverse/core";
+import { createPathScopedProvider } from "@multiverse/provider-path-scoped";
+import { createLocalPortProvider } from "@multiverse/provider-local-port";
+
+describe("dev-slice-17: path-scoped provider lifecycle", () => {
+  const baseDir = "/var/multiverse/test";
+  const pathScopedProvider = createPathScopedProvider({ baseDir });
+  const localPortProvider = createLocalPortProvider({ basePort: 8000 });
+
+  function makeProviders() {
+    return {
+      resources: { "path-scoped": pathScopedProvider },
+      endpoints: { "local-port": localPortProvider }
+    };
+  }
+
+  function makeRepository(overrides: { scopedReset?: boolean; scopedCleanup?: boolean } = {}) {
+    return {
+      resources: [
+        {
+          name: "sqlite-db",
+          provider: "path-scoped",
+          isolationStrategy: "path-scoped" as const,
+          scopedValidate: false,
+          scopedReset: overrides.scopedReset ?? false,
+          scopedCleanup: overrides.scopedCleanup ?? false
+        }
+      ],
+      endpoints: [
+        {
+          name: "app-base-url",
+          role: "application-base-url",
+          provider: "local-port"
+        }
+      ]
+    };
+  }
+
+  describe("reset", () => {
+    it("succeeds for a path-scoped resource with scopedReset declared", () => {
+      const result = resetOneResource({
+        repository: makeRepository({ scopedReset: true }),
+        worktree: { id: "feature-login" },
+        providers: makeProviders()
+      });
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      expect(result.resourceResets[0].capability).toBe("reset");
+      expect(result.resourceResets[0].resourceName).toBe("sqlite-db");
+      expect(result.resourceResets[0].worktreeId).toBe("feature-login");
+    });
+
+    it("returns invalid_configuration when scopedReset is not declared", () => {
+      const result = resetOneResource({
+        repository: makeRepository({ scopedReset: false }),
+        worktree: { id: "feature-login" },
+        providers: makeProviders()
+      });
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+
+      expect(result.refusal.category).toBe("invalid_configuration");
+    });
+
+    it("returns unsafe_scope when worktree ID is absent", () => {
+      const result = resetOneResource({
+        repository: makeRepository({ scopedReset: true }),
+        worktree: {},
+        providers: makeProviders()
+      });
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+
+      expect(result.refusal.category).toBe("unsafe_scope");
+    });
+  });
+
+  describe("cleanup", () => {
+    it("succeeds for a path-scoped resource with scopedCleanup declared", () => {
+      const result = cleanupOneResource({
+        repository: makeRepository({ scopedCleanup: true }),
+        worktree: { id: "feature-login" },
+        providers: makeProviders()
+      });
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      expect(result.resourceCleanups[0].capability).toBe("cleanup");
+      expect(result.resourceCleanups[0].resourceName).toBe("sqlite-db");
+      expect(result.resourceCleanups[0].worktreeId).toBe("feature-login");
+    });
+
+    it("returns invalid_configuration when scopedCleanup is not declared", () => {
+      const result = cleanupOneResource({
+        repository: makeRepository({ scopedCleanup: false }),
+        worktree: { id: "feature-login" },
+        providers: makeProviders()
+      });
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+
+      expect(result.refusal.category).toBe("invalid_configuration");
+    });
+
+    it("returns unsafe_scope when worktree ID is absent", () => {
+      const result = cleanupOneResource({
+        repository: makeRepository({ scopedCleanup: true }),
+        worktree: {},
+        providers: makeProviders()
+      });
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+
+      expect(result.refusal.category).toBe("unsafe_scope");
+    });
+  });
+});

--- a/tests/contracts/resource-provider.path-scoped.contract.test.ts
+++ b/tests/contracts/resource-provider.path-scoped.contract.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import type { DerivedResourcePlan, Refusal } from "@multiverse/provider-contracts";
+import type { DerivedResourcePlan, ResourceReset, ResourceCleanup, Refusal } from "@multiverse/provider-contracts";
 import { createPathScopedProvider } from "@multiverse/provider-path-scoped";
 
 function isDerivedResourcePlan(value: DerivedResourcePlan | Refusal): value is DerivedResourcePlan {
@@ -54,5 +54,87 @@ describe("resource provider contract: path-scoped derive", () => {
     expect(result.handle).toContain("/var/multiverse");
     expect(result.handle).toContain(validInput.resource.name);
     expect(result.handle).toContain(validInput.worktree.id);
+  });
+});
+
+describe("resource provider contract: path-scoped reset", () => {
+  const provider = createPathScopedProvider({ baseDir: "/var/multiverse" });
+
+  const resourceInput = {
+    name: "sqlite-db",
+    provider: "path-scoped",
+    isolationStrategy: "path-scoped" as const,
+    scopedValidate: false,
+    scopedReset: true,
+    scopedCleanup: false
+  };
+
+  const derived = {
+    resourceName: "sqlite-db",
+    provider: "path-scoped",
+    isolationStrategy: "path-scoped" as const,
+    worktreeId: "feature-login",
+    handle: "/var/multiverse/sqlite-db/feature-login"
+  };
+
+  it("declares reset capability", () => {
+    expect(provider.capabilities?.reset).toBe(true);
+  });
+
+  it("returns a ResourceReset for valid input", () => {
+    expect(provider.resetResource).toBeDefined();
+    if (!provider.resetResource) return;
+
+    const result = provider.resetResource({
+      resource: resourceInput,
+      derived,
+      worktree: { id: "feature-login" }
+    });
+
+    const reset = result as ResourceReset;
+    expect(reset.capability).toBe("reset");
+    expect(reset.resourceName).toBe("sqlite-db");
+    expect(reset.worktreeId).toBe("feature-login");
+  });
+});
+
+describe("resource provider contract: path-scoped cleanup", () => {
+  const provider = createPathScopedProvider({ baseDir: "/var/multiverse" });
+
+  const resourceInput = {
+    name: "sqlite-db",
+    provider: "path-scoped",
+    isolationStrategy: "path-scoped" as const,
+    scopedValidate: false,
+    scopedReset: false,
+    scopedCleanup: true
+  };
+
+  const derived = {
+    resourceName: "sqlite-db",
+    provider: "path-scoped",
+    isolationStrategy: "path-scoped" as const,
+    worktreeId: "feature-login",
+    handle: "/var/multiverse/sqlite-db/feature-login"
+  };
+
+  it("declares cleanup capability", () => {
+    expect(provider.capabilities?.cleanup).toBe(true);
+  });
+
+  it("returns a ResourceCleanup for valid input", () => {
+    expect(provider.cleanupResource).toBeDefined();
+    if (!provider.cleanupResource) return;
+
+    const result = provider.cleanupResource({
+      resource: resourceInput,
+      derived,
+      worktree: { id: "feature-login" }
+    });
+
+    const cleanup = result as ResourceCleanup;
+    expect(cleanup.capability).toBe("cleanup");
+    expect(cleanup.resourceName).toBe("sqlite-db");
+    expect(cleanup.worktreeId).toBe("feature-login");
   });
 });


### PR DESCRIPTION
## Summary

Extends `@multiverse/provider-path-scoped` with `reset` and `cleanup` capabilities, following the scope-confirmation model established in Slice 16.

Provider confirms worktree ID is present and returns a structured `ResourceReset`/`ResourceCleanup` result including the derived path handle — telling the consumer which path to clear or remove.

## Scope

- `packages/provider-path-scoped/src/index.ts` — add capabilities + methods
- `tests/contracts/resource-provider.path-scoped.contract.test.ts` — extended
- `tests/acceptance/dev-slice-17.acceptance.test.ts`
- Slice docs

## Refactor pass

`unsafeScope()` is the right extraction level. `resetResource`/`cleanupResource` are simple enough (8 lines each) that a shared lifecycle helper would be premature abstraction.

## Validation

- `pnpm typecheck` — clean
- `pnpm test` — 26 files, 120 tests, all passing

Closes #44