### PR TITLE
Remove 1-resource/1-endpoint limit from derive (dev-slice-18)

### DIFF
--- a/docs/development/dev-slice-18.md
+++ b/docs/development/dev-slice-18.md
@@ -1,0 +1,79 @@
+# Dev Slice 18 — Multi-Resource and Multi-Endpoint Derive
+
+## Status
+
+Implemented on `main`
+
+## Intent
+
+Remove the artificial 1-resource-and-1-endpoint limit from core derive orchestration.
+
+The repository spec declares no count constraint — every declared resource and endpoint must be managed, but the tool does not limit how many may be declared. The 1-of-each enforcement was an early implementation boundary introduced to keep the initial slices narrow.
+
+Real applications declare multiple resources (primary database, cache, search index) and potentially multiple endpoints. Without this change, the tool cannot serve a representative real-world application.
+
+## Business truth grounding
+
+From `docs/spec/repository-configuration.md`:
+- "In 1.0, every managed resource must be declared explicitly" — no count limit stated
+- "A managed resource is omitted from declaration" is a validity failure — but zero or many are not disallowed
+
+From `docs/spec/safety-and-refusal.md`:
+- "In 1.0, the tool does not use best-effort behavior when safety is ambiguous"
+- If any declared resource or endpoint cannot be derived safely, the whole operation fails
+
+## Slice objective
+
+Update the core derive path such that:
+
+1. `deriveOne` accepts a repository configuration with any number of resources and endpoints
+2. all declared resources are derived and all declared endpoints are derived in one call
+3. if any resource or endpoint fails to derive (refusal), the whole operation returns that refusal
+4. successful result contains all derived resource plans and all endpoint mappings (already array-typed)
+5. a repository with zero resources and zero endpoints derives successfully with empty arrays
+
+## Refusal semantics for multi-resource derive
+
+Fail-fast: the first refusal encountered during derivation stops the operation and is returned.
+
+This is consistent with the spec: the tool refuses rather than guessing, and does not return partial results when any declared object cannot be safely scoped.
+
+## Evaluation order — intentional 1.0 behavior
+
+Resources are evaluated before endpoints, both in declaration order.
+
+This ordering is intentional and defined:
+
+1. All resources are derived in declaration order (fail-fast on first refusal).
+2. All endpoints are derived in declaration order (fail-fast on first refusal).
+
+Callers may rely on this order. A refusal from resource index N will always precede any endpoint evaluation. This makes refusal output predictable and testable.
+
+## Scope
+
+- `packages/core/src/orchestration.ts` — remove 1-of-each count enforcement, iterate all resources and endpoints
+- `packages/provider-contracts/src/index.ts` — remove `resourceCountReason`/`endpointCountReason` from `ResolvedSliceDeclarations` if present, result type shape unchanged
+- `packages/core/src/index.ts` — update `deriveOne` to pass through without count reasons
+- `tests/acceptance/dev-slice-18.acceptance.test.ts`
+- slice and task docs
+
+## Out of scope
+
+- multi-resource reset or cleanup (those remain single-resource in 1.0)
+- count validation rules (the spec does not prescribe a minimum count)
+- CLI changes
+- provider changes
+
+## Acceptance criteria
+
+- a repository with 2 resources and 1 endpoint derives all 3 objects successfully
+- a repository with 1 resource and 2 endpoints derives all 3 objects successfully
+- if the second resource fails to derive, the operation returns that refusal (fail-fast)
+- if the second endpoint fails to derive, the operation returns that refusal (fail-fast)
+- resources are evaluated before endpoints (evaluation order is intentional)
+- a repository with 0 resources and 0 endpoints derives successfully with empty arrays
+- all existing 120 tests remain green
+
+## Definition of done
+
+This slice is done when `deriveOne` handles any number of declared resources and endpoints, fail-fast refusal semantics are proven by tests, and all existing tests remain green.

--- a/docs/development/tasks/dev-slice-18-task-01.md
+++ b/docs/development/tasks/dev-slice-18-task-01.md
@@ -1,0 +1,39 @@
+# Dev Slice 18 — Task 01
+
+## Title
+
+Remove the 1-resource/1-endpoint limit from core derive orchestration
+
+## Sources of truth
+
+- `docs/spec/repository-configuration.md`
+- `docs/spec/safety-and-refusal.md`
+- `docs/development/dev-slice-18.md`
+
+## In scope
+
+- `packages/core/src/orchestration.ts`
+- `packages/core/src/index.ts`
+- `tests/acceptance/dev-slice-18.acceptance.test.ts`
+- slice and task docs
+
+## Out of scope
+
+- multi-resource reset or cleanup
+- CLI changes
+- provider changes
+- existing test modifications (all 120 must stay green)
+
+## Acceptance criteria
+
+- 2 resources + 1 endpoint → all derived successfully
+- 1 resource + 2 endpoints → all derived successfully
+- 2nd resource refusal → fail-fast, operation returns that refusal
+- 0 resources + 0 endpoints → succeeds with empty arrays
+- all existing 120 tests remain green
+
+## Key implementation note
+
+The `resolveSliceDeclarations` function in orchestration.ts currently enforces `repository.resources.length !== 1` and `repository.endpoints.length !== 1`. Remove this enforcement and instead iterate all declared resources and endpoints.
+
+The `resourceCountReason` and `endpointCountReason` parameters throughout the call chain can be removed once the count check is gone.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -13,6 +13,7 @@ import type {
 } from "@multiverse/provider-contracts";
 import { invalidConfiguration, isFailureOutcome, isRefusal, unsupportedCapability } from "./refusals";
 import {
+  resolveAndDeriveAll,
   resolveSlicePreflight,
   resolveSliceExecution,
   type ResolvedSliceExecution
@@ -118,21 +119,7 @@ export function deriveOne(input: {
   worktree: WorktreeInstanceInput;
   providers: ProviderRegistry;
 }): DeriveOneResult {
-  const execution = resolveSliceExecution({
-    ...input,
-    resourceCountReason: "Slice 01 requires exactly one declared managed resource.",
-    endpointCountReason: "Slice 01 requires exactly one declared managed endpoint."
-  });
-
-  if (isFailureOutcome(execution)) {
-    return execution;
-  }
-
-  return {
-    ok: true,
-    resourcePlans: [execution.derived.resourcePlan],
-    endpointMappings: [execution.derived.endpointMapping]
-  };
+  return resolveAndDeriveAll(input);
 }
 
 export function deriveAndValidateOne(input: {

--- a/packages/core/src/orchestration.ts
+++ b/packages/core/src/orchestration.ts
@@ -253,3 +253,72 @@ function deriveSliceValues(
     endpointMapping
   };
 }
+
+export function resolveAndDeriveAll(input: {
+  repository: RepositoryConfiguration;
+  worktree: WorktreeInstanceInput;
+  providers: ProviderRegistry;
+}): { ok: true; resourcePlans: DerivedResourcePlan[]; endpointMappings: DerivedEndpointMapping[] } | FailureResult {
+  const resolvedWorktree = requireResolvedWorktree(input.worktree);
+  if (isFailureOutcome(resolvedWorktree)) {
+    return resolvedWorktree;
+  }
+
+  const repoValidation = withValidatedRepositoryConfiguration(
+    input.repository,
+    (repository) => repository
+  );
+  if (!repoValidation.ok) {
+    return invalidConfiguration("Repository configuration is invalid.");
+  }
+
+  const repo = repoValidation.value;
+  const resourcePlans: DerivedResourcePlan[] = [];
+  const endpointMappings: DerivedEndpointMapping[] = [];
+
+  for (const resourceDecl of repo.resources) {
+    const resourceProvider = input.providers.resources[resourceDecl.provider];
+    if (!resourceProvider) {
+      return invalidConfiguration(
+        `No resource provider is registered for "${resourceDecl.provider}".`
+      );
+    }
+
+    const capabilityCheck = validateCapabilityIntent({
+      resource: resourceDecl,
+      provider: resourceProvider
+    });
+    if (isFailureOutcome(capabilityCheck)) {
+      return capabilityCheck;
+    }
+
+    const plan = resourceProvider.deriveResource({
+      resource: resourceDecl,
+      worktree: resolvedWorktree
+    });
+    if (isRefusal(plan)) {
+      return { ok: false, refusal: plan };
+    }
+    resourcePlans.push(plan);
+  }
+
+  for (const endpointDecl of repo.endpoints) {
+    const endpointProvider = input.providers.endpoints[endpointDecl.provider];
+    if (!endpointProvider) {
+      return invalidConfiguration(
+        `No endpoint provider is registered for "${endpointDecl.provider}".`
+      );
+    }
+
+    const mapping = endpointProvider.deriveEndpoint({
+      endpoint: endpointDecl,
+      worktree: resolvedWorktree
+    });
+    if (isRefusal(mapping)) {
+      return { ok: false, refusal: mapping };
+    }
+    endpointMappings.push(mapping);
+  }
+
+  return { ok: true, resourcePlans, endpointMappings };
+}

--- a/tests/acceptance/dev-slice-18.acceptance.test.ts
+++ b/tests/acceptance/dev-slice-18.acceptance.test.ts
@@ -1,0 +1,266 @@
+import { describe, it, expect } from "vitest";
+import { deriveOne } from "@multiverse/core";
+import { createNameScopedProvider } from "@multiverse/provider-name-scoped";
+import { createLocalPortProvider } from "@multiverse/provider-local-port";
+import { createProvidersWithResourceDeriveRefusal } from "@multiverse/providers-testkit";
+
+describe("dev-slice-18: multi-resource and multi-endpoint derive", () => {
+  const nameScopedProvider = createNameScopedProvider();
+  const localPortProvider = createLocalPortProvider({ basePort: 9000 });
+
+  function makeProviders() {
+    return {
+      resources: { "name-scoped": nameScopedProvider },
+      endpoints: { "local-port": localPortProvider }
+    };
+  }
+
+  it("derives all resources and endpoints when multiple resources are declared", () => {
+    const result = deriveOne({
+      repository: {
+        resources: [
+          {
+            name: "primary-db",
+            provider: "name-scoped",
+            isolationStrategy: "name-scoped" as const,
+            scopedValidate: false,
+            scopedReset: false,
+            scopedCleanup: false
+          },
+          {
+            name: "cache",
+            provider: "name-scoped",
+            isolationStrategy: "name-scoped" as const,
+            scopedValidate: false,
+            scopedReset: false,
+            scopedCleanup: false
+          }
+        ],
+        endpoints: [
+          {
+            name: "app-base-url",
+            role: "application-base-url",
+            provider: "local-port"
+          }
+        ]
+      },
+      worktree: { id: "feature-login" },
+      providers: makeProviders()
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.resourcePlans).toHaveLength(2);
+    expect(result.resourcePlans[0].resourceName).toBe("primary-db");
+    expect(result.resourcePlans[0].handle).toBe("primary-db_feature-login");
+    expect(result.resourcePlans[1].resourceName).toBe("cache");
+    expect(result.resourcePlans[1].handle).toBe("cache_feature-login");
+    expect(result.endpointMappings).toHaveLength(1);
+  });
+
+  it("derives all resources and endpoints when multiple endpoints are declared", () => {
+    const result = deriveOne({
+      repository: {
+        resources: [
+          {
+            name: "primary-db",
+            provider: "name-scoped",
+            isolationStrategy: "name-scoped" as const,
+            scopedValidate: false,
+            scopedReset: false,
+            scopedCleanup: false
+          }
+        ],
+        endpoints: [
+          {
+            name: "app-base-url",
+            role: "application-base-url",
+            provider: "local-port"
+          },
+          {
+            name: "admin-url",
+            role: "admin-base-url",
+            provider: "local-port"
+          }
+        ]
+      },
+      worktree: { id: "feature-login" },
+      providers: makeProviders()
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.resourcePlans).toHaveLength(1);
+    expect(result.endpointMappings).toHaveLength(2);
+    expect(result.endpointMappings[0].endpointName).toBe("app-base-url");
+    expect(result.endpointMappings[1].endpointName).toBe("admin-url");
+  });
+
+  it("returns refusal fail-fast when the second resource fails to derive", () => {
+    const providers = {
+      resources: {
+        "name-scoped": nameScopedProvider,
+        "failing-provider": createProvidersWithResourceDeriveRefusal({
+          category: "provider_failure",
+          reason: "Second resource failed."
+        }).resources["test-resource-provider"]
+      },
+      endpoints: { "local-port": localPortProvider }
+    };
+
+    const result = deriveOne({
+      repository: {
+        resources: [
+          {
+            name: "primary-db",
+            provider: "name-scoped",
+            isolationStrategy: "name-scoped" as const,
+            scopedValidate: false,
+            scopedReset: false,
+            scopedCleanup: false
+          },
+          {
+            name: "cache",
+            provider: "failing-provider",
+            isolationStrategy: "name-scoped" as const,
+            scopedValidate: false,
+            scopedReset: false,
+            scopedCleanup: false
+          }
+        ],
+        endpoints: [
+          {
+            name: "app-base-url",
+            role: "application-base-url",
+            provider: "local-port"
+          }
+        ]
+      },
+      worktree: { id: "feature-login" },
+      providers
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+
+    expect(result.refusal.category).toBe("provider_failure");
+  });
+
+  it("returns resource refusal before any endpoint is evaluated", () => {
+    // The endpoint provider would panic if called — proves endpoints are never reached
+    const endpointProviderThatMustNotBeCalled = {
+      deriveEndpoint(): never {
+        throw new Error("Endpoint provider was called — resource refusal did not stop evaluation.");
+      }
+    };
+
+    const result = deriveOne({
+      repository: {
+        resources: [
+          {
+            name: "failing-db",
+            provider: "failing-resource",
+            isolationStrategy: "name-scoped" as const,
+            scopedValidate: false,
+            scopedReset: false,
+            scopedCleanup: false
+          }
+        ],
+        endpoints: [
+          {
+            name: "app-base-url",
+            role: "application-base-url",
+            provider: "guarded-endpoint"
+          }
+        ]
+      },
+      worktree: { id: "feature-login" },
+      providers: {
+        resources: {
+          "failing-resource": createProvidersWithResourceDeriveRefusal({
+            category: "unsafe_scope",
+            reason: "Resource failed before endpoint evaluation."
+          }).resources["test-resource-provider"]
+        },
+        endpoints: {
+          "guarded-endpoint": endpointProviderThatMustNotBeCalled
+        }
+      }
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+
+    expect(result.refusal.category).toBe("unsafe_scope");
+  });
+
+  it("returns refusal fail-fast when an endpoint fails to derive", () => {
+    const failingEndpointProvider = {
+      deriveEndpoint(): never {
+        return {
+          category: "provider_failure",
+          reason: "Endpoint derivation failed."
+        } as never;
+      }
+    };
+
+    const result = deriveOne({
+      repository: {
+        resources: [
+          {
+            name: "primary-db",
+            provider: "name-scoped",
+            isolationStrategy: "name-scoped" as const,
+            scopedValidate: false,
+            scopedReset: false,
+            scopedCleanup: false
+          }
+        ],
+        endpoints: [
+          {
+            name: "app-base-url",
+            role: "application-base-url",
+            provider: "local-port"
+          },
+          {
+            name: "failing-endpoint",
+            role: "secondary-url",
+            provider: "failing-endpoint-provider"
+          }
+        ]
+      },
+      worktree: { id: "feature-login" },
+      providers: {
+        resources: { "name-scoped": nameScopedProvider },
+        endpoints: {
+          "local-port": localPortProvider,
+          "failing-endpoint-provider": failingEndpointProvider
+        }
+      }
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+
+    expect(result.refusal.category).toBe("provider_failure");
+  });
+
+  it("succeeds with empty arrays when no resources or endpoints are declared", () => {
+    const result = deriveOne({
+      repository: {
+        resources: [],
+        endpoints: []
+      },
+      worktree: { id: "feature-login" },
+      providers: makeProviders()
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    expect(result.resourcePlans).toHaveLength(0);
+    expect(result.endpointMappings).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

Removes the artificial 1-resource-and-1-endpoint limit from `deriveOne`, which was an early implementation boundary with no basis in the repository spec.

Adds `resolveAndDeriveAll()` to core orchestration: iterates all declared resources then all endpoints in declaration order, fail-fast on first refusal.

## Evaluation order — intentional 1.0 behavior

Resources are evaluated before endpoints, both in declaration order. A resource refusal stops the operation before any endpoint is evaluated. This is documented in the slice doc and backed by acceptance coverage.

## Scope

- `packages/core/src/orchestration.ts` — new `resolveAndDeriveAll()`
- `packages/core/src/index.ts` — `deriveOne` delegates to `resolveAndDeriveAll`
- `tests/acceptance/dev-slice-18.acceptance.test.ts` — 6 new tests

`reset`/`cleanup` retain single-resource semantics unchanged. `deriveAndValidateOne` deferred to a follow-up slice.

## Validation

- `pnpm typecheck` — clean
- `pnpm test` — 27 files, 126 tests, all passing (120 existing + 6 new)

## Acceptance tests cover

- 2 resources + 1 endpoint → all derived
- 1 resource + 2 endpoints → all derived
- resource fail-fast: second resource refusal stops operation
- evaluation-order proof: resource refusal prevents endpoint provider from being called at all
- endpoint fail-fast: second endpoint refusal stops operation
- 0 resources + 0 endpoints → empty arrays

Closes #45