### PR TITLE
Remove 1-resource/1-endpoint limit from derive and validate (dev-slice-20)

### DIFF
--- a/docs/development/dev-slice-20.md
+++ b/docs/development/dev-slice-20.md
@@ -1,0 +1,58 @@
+# Dev Slice 20 — Multi-Resource Derive and Validate
+
+## Status
+
+Implemented on `main`
+
+## Intent
+
+Remove the artificial 1-resource/1-endpoint limit from `deriveAndValidateOne`.
+
+`deriveAndValidateOne` still routes through `resolveSliceExecution`, which enforces exactly-1-resource and exactly-1-endpoint via `resolveSliceDeclarations`. Both constraints are wrong for a function whose job is to derive all declared resources and endpoints and then validate the ones that declare the capability.
+
+## Business truth grounding
+
+From `docs/spec/repository-configuration.md`:
+- No count constraint is stated for managed resources or endpoints.
+
+From `docs/spec/safety-and-refusal.md`:
+- "In 1.0, the tool does not use best-effort behavior when safety is ambiguous."
+- If any declared resource declares a capability intent that the provider cannot fulfill, the whole operation fails before any derivation.
+
+## Slice objective
+
+Update the derive+validate path such that:
+
+1. All declared resources are derived in declaration order (fail-fast on first derive refusal).
+2. All declared endpoints are derived in declaration order (fail-fast on first derive refusal).
+3. For each resource that declares `scopedValidate: true`, the provider's `validateResource` is called immediately after its `deriveResource` (fail-fast on first validation refusal).
+4. Resources that do not declare `scopedValidate: true` are derived but not validated — this is not a refusal.
+5. If no resources declare `scopedValidate: true`, `deriveAndValidateOne` still succeeds with an empty `resourceValidations` array (unlike reset/cleanup, validate is supplemental and not required).
+6. Capability pre-flight check: if any resource declares a capability intent (`scopedValidate`, `scopedReset`, or `scopedCleanup`) that its provider cannot fulfill, the operation refuses before any derivation.
+
+## Scope
+
+- `packages/core/src/orchestration.ts` — add `resolveAndDeriveAllWithValidation`; remove dead `resolveSlicePreflight`, `resolveSliceExecution`, and their helpers
+- `packages/core/src/index.ts` — update `deriveAndValidateOne` to use new path; remove dead `validateResourcePlan` helper
+- `tests/acceptance/dev-slice-20.acceptance.test.ts`
+- slice and task docs
+
+## Out of scope
+
+- CLI changes
+- Provider changes
+- Existing test modifications (all 137 must stay green)
+
+## Acceptance criteria
+
+- A repository with 2 resources both declaring `scopedValidate: true` → both derived and validated, `resourceValidations` has 2 entries
+- A repository with 2 resources where only 1 declares `scopedValidate: true` → only that resource validated, `resourceValidations` has 1 entry
+- A repository with 2 resources and none declare `scopedValidate: true` → succeeds, `resourceValidations` is empty
+- If the second resource's validation refuses → fail-fast, operation returns that refusal
+- A repository with 2 resources and 2 endpoints → `resourcePlans` has 2, `endpointMappings` has 2
+- A repository with 2 resources and 0 endpoints → still succeeds (endpoint count not enforced)
+- All existing 137 tests remain green
+
+## Definition of done
+
+This slice is done when `deriveAndValidateOne` handles any number of declared resources and endpoints, the old single-resource orchestration functions are removed, and all existing and new tests pass.

--- a/docs/development/tasks/dev-slice-20-task-01.md
+++ b/docs/development/tasks/dev-slice-20-task-01.md
@@ -1,0 +1,47 @@
+# Dev Slice 20 — Task 01
+
+## Title
+
+Remove the 1-resource/1-endpoint limit from core derive and validate orchestration
+
+## Sources of truth
+
+- `docs/spec/repository-configuration.md`
+- `docs/spec/safety-and-refusal.md`
+- `docs/development/dev-slice-20.md`
+
+## In scope
+
+- `packages/core/src/orchestration.ts`
+- `packages/core/src/index.ts`
+- `tests/acceptance/dev-slice-20.acceptance.test.ts`
+- slice and task docs
+
+## Out of scope
+
+- CLI changes
+- Provider changes
+- Existing test modifications (all 137 must stay green)
+
+## Acceptance criteria
+
+- 2 resources with `scopedValidate: true` → both validated, `resourceValidations` has 2 entries
+- 2 resources, only 1 with `scopedValidate: true` → `resourceValidations` has 1 entry
+- 2 resources, none with `scopedValidate: true` → succeeds with empty `resourceValidations`
+- 2nd resource validation refusal → fail-fast, operation returns that refusal
+- 2 resources + 2 endpoints → `resourcePlans` has 2, `endpointMappings` has 2
+- 0 endpoints in repository → still succeeds
+- All existing 137 tests remain green
+
+## Key implementation note
+
+Add `resolveAndDeriveAllWithValidation` to `orchestration.ts`. This function:
+1. Validates worktree identity
+2. Validates repository configuration
+3. For each resource in declaration order: checks capability pre-flight, derives, and (if `scopedValidate: true`) validates — fail-fast on any refusal
+4. For each endpoint in declaration order: derives — fail-fast on any refusal
+5. Returns all plans, mappings, and validations
+
+Update `deriveAndValidateOne` in `index.ts` to call the new function.
+
+Remove dead code: `resolveSlicePreflight`, `resolveSliceExecution`, `resolveSliceDeclarations`, `resolveSliceProviders`, their associated interfaces, and the `validateResourcePlan` helper in `index.ts`.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,19 +3,15 @@ import type {
   DeriveAndValidateOneResult,
   DeriveOneResult,
   ProviderRegistry,
-  Refusal,
   ResetOneResourceResult,
   RepositoryConfiguration,
-  ResourceValidation,
   WorktreeInstanceInput
 } from "@multiverse/provider-contracts";
-import { isFailureOutcome, isRefusal, unsupportedCapability } from "./refusals";
 import {
   resolveAndDeriveAll,
+  resolveAndDeriveAllWithValidation,
   resolveAndResetAll,
-  resolveAndCleanupAll,
-  resolveSliceExecution,
-  type ResolvedSliceExecution
+  resolveAndCleanupAll
 } from "./orchestration";
 
 export {
@@ -31,30 +27,6 @@ export {
   withValidatedRepositoryConfiguration
 } from "./repository-configuration";
 
-function validateResourcePlan(input: {
-  provider: ResolvedSliceExecution["providers"]["resource"];
-  resource: ResolvedSliceExecution["declarations"]["resource"];
-  derived: ResolvedSliceExecution["derived"]["resourcePlan"];
-  worktree: {
-    id?: string;
-    label?: string;
-    branch?: string;
-  };
-}): ResourceValidation | Refusal {
-  if (!input.provider.capabilities?.validate || !input.provider.validateResource) {
-    return {
-      category: "unsupported_capability",
-      reason: `Resource provider "${input.resource.provider}" does not support validate.`
-    };
-  }
-
-  return input.provider.validateResource({
-    resource: input.resource,
-    derived: input.derived,
-    worktree: input.worktree
-  });
-}
-
 export function deriveOne(input: {
   repository: RepositoryConfiguration;
   worktree: WorktreeInstanceInput;
@@ -68,46 +40,7 @@ export function deriveAndValidateOne(input: {
   worktree: WorktreeInstanceInput;
   providers: ProviderRegistry;
 }): DeriveAndValidateOneResult {
-  const execution = resolveSliceExecution({
-    ...input,
-    resourceCountReason: "Slice 02 requires exactly one declared managed resource.",
-    endpointCountReason: "Slice 02 requires exactly one declared managed endpoint."
-  });
-
-  if (isFailureOutcome(execution)) {
-    return execution;
-  }
-
-  const resourceValidations: ResourceValidation[] = [];
-
-  if (execution.declarations.resource.scopedValidate) {
-    const validation = validateResourcePlan({
-      provider: execution.providers.resource,
-      resource: execution.declarations.resource,
-      derived: execution.derived.resourcePlan,
-      worktree: execution.worktree
-    });
-
-    if (isRefusal(validation)) {
-      if (validation.category === "unsupported_capability") {
-        return unsupportedCapability(validation.reason);
-      }
-
-      return {
-        ok: false,
-        refusal: validation
-      };
-    }
-
-    resourceValidations.push(validation);
-  }
-
-  return {
-    ok: true,
-    resourcePlans: [execution.derived.resourcePlan],
-    endpointMappings: [execution.derived.endpointMapping],
-    resourceValidations
-  };
+  return resolveAndDeriveAllWithValidation(input);
 }
 
 export function resetOneResource(input: {

--- a/packages/core/src/orchestration.ts
+++ b/packages/core/src/orchestration.ts
@@ -1,22 +1,17 @@
 import type {
   CleanupOneResourceResult,
+  DeriveAndValidateOneResult,
   DerivedEndpointMapping,
   DerivedResourcePlan,
-  EndpointProvider,
   ProviderRegistry,
   RepositoryConfiguration,
   ResourceCleanup,
-  ResourceProvider,
   ResourceReset,
+  ResourceValidation,
   ResetOneResourceResult,
   WorktreeInstanceInput
 } from "@multiverse/provider-contracts";
 import {
-  type ValidatedEndpointDeclaration,
-  type ValidatedResourceDeclaration
-} from "./declarations";
-import {
-  type ValidatedRepositoryConfiguration,
   withValidatedRepositoryConfiguration
 } from "./repository-configuration";
 import {
@@ -33,106 +28,6 @@ export interface ResolvedWorktree {
   id: string;
   label?: string;
   branch?: string;
-}
-
-export interface ResolvedSliceProviders {
-  resource: ResourceProvider;
-  endpoint: EndpointProvider;
-}
-
-export interface ResolvedSliceDeclarations {
-  resource: ValidatedResourceDeclaration;
-  endpoint: ValidatedEndpointDeclaration;
-}
-
-export interface ResolvedSlicePreflight {
-  worktree: ResolvedWorktree;
-  declarations: ResolvedSliceDeclarations;
-  providers: ResolvedSliceProviders;
-}
-
-export interface ResolvedSliceDerivedValues {
-  resourcePlan: DerivedResourcePlan;
-  endpointMapping: DerivedEndpointMapping;
-}
-
-export interface ResolvedSliceExecution extends ResolvedSlicePreflight {
-  derived: ResolvedSliceDerivedValues;
-}
-
-export function resolveSlicePreflight(input: {
-  repository: RepositoryConfiguration;
-  worktree: WorktreeInstanceInput;
-  providers: ProviderRegistry;
-  resourceCountReason: string;
-  endpointCountReason: string;
-}): ResolvedSlicePreflight | FailureResult {
-  const resolvedWorktree = requireResolvedWorktree(input.worktree);
-  if (isFailureOutcome(resolvedWorktree)) {
-    return resolvedWorktree;
-  }
-
-  const repositoryValidation = withValidatedRepositoryConfiguration(
-    input.repository,
-    (repository) => repository
-  );
-  if (!repositoryValidation.ok) {
-    return invalidConfiguration("Repository configuration is invalid.");
-  }
-
-  const declarations = resolveSliceDeclarations({
-    repository: repositoryValidation.value,
-    resourceCountReason: input.resourceCountReason,
-    endpointCountReason: input.endpointCountReason
-  });
-  if (isFailureOutcome(declarations)) {
-    return declarations;
-  }
-
-  const resolvedProviders = resolveSliceProviders({
-    providers: input.providers,
-    declarations
-  });
-  if (isFailureOutcome(resolvedProviders)) {
-    return resolvedProviders;
-  }
-
-  const capabilityIntent = validateCapabilityIntent({
-    resource: declarations.resource,
-    provider: resolvedProviders.resource
-  });
-  if (isFailureOutcome(capabilityIntent)) {
-    return capabilityIntent;
-  }
-
-  return {
-    worktree: resolvedWorktree,
-    declarations,
-    providers: resolvedProviders
-  };
-}
-
-export function resolveSliceExecution(input: {
-  repository: RepositoryConfiguration;
-  worktree: WorktreeInstanceInput;
-  providers: ProviderRegistry;
-  resourceCountReason: string;
-  endpointCountReason: string;
-}): ResolvedSliceExecution | FailureResult {
-  const preflight = resolveSlicePreflight(input);
-  if (isFailureOutcome(preflight)) {
-    return preflight;
-  }
-
-  const derived = deriveSliceValues(preflight);
-  if (isFailureOutcome(derived)) {
-    return derived;
-  }
-
-  return {
-    ...preflight,
-    derived
-  };
 }
 
 function requireResolvedWorktree(
@@ -153,56 +48,20 @@ function requireResolvedWorktree(
   };
 }
 
-function resolveSliceDeclarations(input: {
-  repository: ValidatedRepositoryConfiguration;
-  resourceCountReason: string;
-  endpointCountReason: string;
-}): ResolvedSliceDeclarations | FailureResult {
-  const { repository, resourceCountReason, endpointCountReason } = input;
-
-  if (repository.resources.length !== 1) {
-    return invalidConfiguration(resourceCountReason);
-  }
-
-  if (repository.endpoints.length !== 1) {
-    return invalidConfiguration(endpointCountReason);
-  }
-
-  return {
-    resource: repository.resources[0],
-    endpoint: repository.endpoints[0]
-  };
-}
-
-function resolveSliceProviders(input: {
-  providers: ProviderRegistry;
-  declarations: ResolvedSliceDeclarations;
-}): ResolvedSliceProviders | FailureResult {
-  const { providers, declarations } = input;
-
-  const resourceProvider = providers.resources[declarations.resource.provider];
-  if (!resourceProvider) {
-    return invalidConfiguration(
-      `No resource provider is registered for "${declarations.resource.provider}".`
-    );
-  }
-
-  const endpointProvider = providers.endpoints[declarations.endpoint.provider];
-  if (!endpointProvider) {
-    return invalidConfiguration(
-      `No endpoint provider is registered for "${declarations.endpoint.provider}".`
-    );
-  }
-
-  return {
-    resource: resourceProvider,
-    endpoint: endpointProvider
-  };
-}
-
 function validateCapabilityIntent(input: {
-  resource: ValidatedResourceDeclaration;
-  provider: ResourceProvider;
+  resource: {
+    provider: string;
+    scopedValidate: boolean;
+    scopedReset: boolean;
+    scopedCleanup: boolean;
+  };
+  provider: {
+    capabilities?: {
+      validate?: true;
+      reset?: true;
+      cleanup?: true;
+    };
+  };
 }): void | FailureResult {
   const { resource, provider } = input;
 
@@ -223,39 +82,6 @@ function validateCapabilityIntent(input: {
       `Resource provider "${resource.provider}" does not support cleanup.`
     );
   }
-}
-
-function deriveSliceValues(
-  input: ResolvedSlicePreflight
-): ResolvedSliceDerivedValues | FailureResult {
-  const resourcePlan = input.providers.resource.deriveResource({
-    resource: input.declarations.resource,
-    worktree: input.worktree
-  });
-
-  if (isRefusal(resourcePlan)) {
-    return {
-      ok: false,
-      refusal: resourcePlan
-    };
-  }
-
-  const endpointMapping = input.providers.endpoint.deriveEndpoint({
-    endpoint: input.declarations.endpoint,
-    worktree: input.worktree
-  });
-
-  if (isRefusal(endpointMapping)) {
-    return {
-      ok: false,
-      refusal: endpointMapping
-    };
-  }
-
-  return {
-    resourcePlan,
-    endpointMapping
-  };
 }
 
 export function resolveAndDeriveAll(input: {
@@ -325,6 +151,92 @@ export function resolveAndDeriveAll(input: {
   }
 
   return { ok: true, resourcePlans, endpointMappings };
+}
+
+export function resolveAndDeriveAllWithValidation(input: {
+  repository: RepositoryConfiguration;
+  worktree: WorktreeInstanceInput;
+  providers: ProviderRegistry;
+}): DeriveAndValidateOneResult {
+  const resolvedWorktree = requireResolvedWorktree(input.worktree);
+  if (isFailureOutcome(resolvedWorktree)) {
+    return resolvedWorktree;
+  }
+
+  const repoValidation = withValidatedRepositoryConfiguration(
+    input.repository,
+    (repository) => repository
+  );
+  if (!repoValidation.ok) {
+    return invalidConfiguration("Repository configuration is invalid.");
+  }
+
+  const repo = repoValidation.value;
+  const resourcePlans: DerivedResourcePlan[] = [];
+  const endpointMappings: DerivedEndpointMapping[] = [];
+  const resourceValidations: ResourceValidation[] = [];
+
+  for (const resourceDecl of repo.resources) {
+    const resourceProvider = input.providers.resources[resourceDecl.provider];
+    if (!resourceProvider) {
+      return invalidConfiguration(
+        `No resource provider is registered for "${resourceDecl.provider}".`
+      );
+    }
+
+    const capabilityCheck = validateCapabilityIntent({
+      resource: resourceDecl,
+      provider: resourceProvider
+    });
+    if (isFailureOutcome(capabilityCheck)) {
+      return capabilityCheck;
+    }
+
+    const plan = resourceProvider.deriveResource({
+      resource: resourceDecl,
+      worktree: resolvedWorktree
+    });
+    if (isRefusal(plan)) {
+      return { ok: false, refusal: plan };
+    }
+    resourcePlans.push(plan);
+
+    if (resourceDecl.scopedValidate) {
+      if (!resourceProvider.capabilities?.validate || !resourceProvider.validateResource) {
+        return { ok: false, refusal: { category: "unsupported_capability", reason: `Resource provider "${resourceDecl.provider}" does not support validate.` } };
+      }
+
+      const validation = resourceProvider.validateResource({
+        resource: resourceDecl,
+        derived: plan,
+        worktree: resolvedWorktree
+      });
+      if (isRefusal(validation)) {
+        return { ok: false, refusal: validation };
+      }
+      resourceValidations.push(validation);
+    }
+  }
+
+  for (const endpointDecl of repo.endpoints) {
+    const endpointProvider = input.providers.endpoints[endpointDecl.provider];
+    if (!endpointProvider) {
+      return invalidConfiguration(
+        `No endpoint provider is registered for "${endpointDecl.provider}".`
+      );
+    }
+
+    const mapping = endpointProvider.deriveEndpoint({
+      endpoint: endpointDecl,
+      worktree: resolvedWorktree
+    });
+    if (isRefusal(mapping)) {
+      return { ok: false, refusal: mapping };
+    }
+    endpointMappings.push(mapping);
+  }
+
+  return { ok: true, resourcePlans, endpointMappings, resourceValidations };
 }
 
 export function resolveAndResetAll(input: {

--- a/tests/acceptance/dev-slice-20.acceptance.test.ts
+++ b/tests/acceptance/dev-slice-20.acceptance.test.ts
@@ -1,0 +1,285 @@
+import { describe, it, expect } from "vitest";
+import { deriveAndValidateOne } from "@multiverse/core";
+import { createNameScopedProvider } from "@multiverse/provider-name-scoped";
+
+describe("dev-slice-20: multi-resource derive and validate", () => {
+  const nameScopedProvider = createNameScopedProvider();
+  const validateCapableProvider = {
+    capabilities: { validate: true as const },
+    deriveResource(input: { resource: { name: string; provider: string; isolationStrategy: "name-scoped" | "path-scoped" | "process-scoped" }; worktree: { id: string } }) {
+      return {
+        resourceName: input.resource.name,
+        provider: input.resource.provider,
+        isolationStrategy: input.resource.isolationStrategy,
+        worktreeId: input.worktree.id,
+        handle: `${input.resource.name}_${input.worktree.id}`
+      };
+    },
+    validateResource(input: { resource: { name: string; provider: string }; derived: { worktreeId: string } }) {
+      return {
+        resourceName: input.resource.name,
+        provider: input.resource.provider,
+        worktreeId: input.derived.worktreeId,
+        capability: "validate" as const
+      };
+    }
+  };
+
+  function makeTwoResourceRepository(overrides: {
+    firstScopedValidate?: boolean;
+    secondScopedValidate?: boolean;
+    endpoints?: Array<{ name: string; role: string; provider: string }>;
+  } = {}) {
+    return {
+      resources: [
+        {
+          name: "primary-db",
+          provider: "validate-capable",
+          isolationStrategy: "name-scoped" as const,
+          scopedValidate: overrides.firstScopedValidate ?? false,
+          scopedReset: false,
+          scopedCleanup: false
+        },
+        {
+          name: "cache",
+          provider: "validate-capable",
+          isolationStrategy: "name-scoped" as const,
+          scopedValidate: overrides.secondScopedValidate ?? false,
+          scopedReset: false,
+          scopedCleanup: false
+        }
+      ],
+      endpoints: overrides.endpoints ?? []
+    };
+  }
+
+  function makeProviders() {
+    return {
+      resources: { "validate-capable": validateCapableProvider },
+      endpoints: {}
+    };
+  }
+
+  describe("multi-resource derive", () => {
+    it("derives all resources when both declare scopedValidate", () => {
+      const result = deriveAndValidateOne({
+        repository: makeTwoResourceRepository({
+          firstScopedValidate: true,
+          secondScopedValidate: true
+        }),
+        worktree: { id: "feature-login" },
+        providers: makeProviders()
+      });
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      expect(result.resourcePlans).toHaveLength(2);
+      expect(result.resourcePlans[0].resourceName).toBe("primary-db");
+      expect(result.resourcePlans[1].resourceName).toBe("cache");
+    });
+
+    it("derives all resources even when none declare scopedValidate", () => {
+      const result = deriveAndValidateOne({
+        repository: makeTwoResourceRepository({
+          firstScopedValidate: false,
+          secondScopedValidate: false
+        }),
+        worktree: { id: "feature-login" },
+        providers: makeProviders()
+      });
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      expect(result.resourcePlans).toHaveLength(2);
+    });
+  });
+
+  describe("multi-resource validate", () => {
+    it("validates all resources that declare scopedValidate", () => {
+      const result = deriveAndValidateOne({
+        repository: makeTwoResourceRepository({
+          firstScopedValidate: true,
+          secondScopedValidate: true
+        }),
+        worktree: { id: "feature-login" },
+        providers: makeProviders()
+      });
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      expect(result.resourceValidations).toHaveLength(2);
+      expect(result.resourceValidations[0].resourceName).toBe("primary-db");
+      expect(result.resourceValidations[0].capability).toBe("validate");
+      expect(result.resourceValidations[1].resourceName).toBe("cache");
+      expect(result.resourceValidations[1].capability).toBe("validate");
+    });
+
+    it("validates only the resources that declare scopedValidate", () => {
+      const result = deriveAndValidateOne({
+        repository: makeTwoResourceRepository({
+          firstScopedValidate: true,
+          secondScopedValidate: false
+        }),
+        worktree: { id: "feature-login" },
+        providers: makeProviders()
+      });
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      expect(result.resourcePlans).toHaveLength(2);
+      expect(result.resourceValidations).toHaveLength(1);
+      expect(result.resourceValidations[0].resourceName).toBe("primary-db");
+    });
+
+    it("succeeds with empty resourceValidations when no resources declare scopedValidate", () => {
+      const result = deriveAndValidateOne({
+        repository: makeTwoResourceRepository({
+          firstScopedValidate: false,
+          secondScopedValidate: false
+        }),
+        worktree: { id: "feature-login" },
+        providers: makeProviders()
+      });
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      expect(result.resourcePlans).toHaveLength(2);
+      expect(result.resourceValidations).toHaveLength(0);
+    });
+
+    it("returns refusal fail-fast when the second resource validation refuses", () => {
+      const refusingValidateProvider = {
+        capabilities: { validate: true as const },
+        deriveResource(input: { resource: { name: string; provider: string; isolationStrategy: "name-scoped" | "path-scoped" | "process-scoped" }; worktree: { id: string } }) {
+          return {
+            resourceName: input.resource.name,
+            provider: input.resource.provider,
+            isolationStrategy: input.resource.isolationStrategy,
+            worktreeId: input.worktree.id,
+            handle: `${input.resource.name}_${input.worktree.id}`
+          };
+        },
+        validateResource() {
+          return {
+            category: "provider_failure" as const,
+            reason: "Validation provider refused."
+          };
+        }
+      };
+
+      const repository = {
+        resources: [
+          {
+            name: "primary-db",
+            provider: "validate-capable",
+            isolationStrategy: "name-scoped" as const,
+            scopedValidate: true,
+            scopedReset: false,
+            scopedCleanup: false
+          },
+          {
+            name: "cache",
+            provider: "refusing-validate",
+            isolationStrategy: "name-scoped" as const,
+            scopedValidate: true,
+            scopedReset: false,
+            scopedCleanup: false
+          }
+        ],
+        endpoints: []
+      };
+
+      const result = deriveAndValidateOne({
+        repository,
+        worktree: { id: "feature-login" },
+        providers: {
+          resources: {
+            "validate-capable": validateCapableProvider,
+            "refusing-validate": refusingValidateProvider
+          },
+          endpoints: {}
+        }
+      });
+
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+
+      expect(result.refusal.category).toBe("provider_failure");
+    });
+  });
+
+  describe("multi-endpoint derive", () => {
+    it("derives all endpoints and includes them in result", () => {
+      const endpointProvider = {
+        deriveEndpoint(input: { endpoint: { name: string; role: string; provider: string }; worktree: { id: string } }) {
+          return {
+            endpointName: input.endpoint.name,
+            provider: input.endpoint.provider,
+            role: input.endpoint.role,
+            worktreeId: input.worktree.id,
+            address: `http://${input.worktree.id}.local/${input.endpoint.name}`
+          };
+        }
+      };
+
+      const result = deriveAndValidateOne({
+        repository: {
+          resources: [
+            {
+              name: "primary-db",
+              provider: "validate-capable",
+              isolationStrategy: "name-scoped" as const,
+              scopedValidate: false,
+              scopedReset: false,
+              scopedCleanup: false
+            },
+            {
+              name: "cache",
+              provider: "validate-capable",
+              isolationStrategy: "name-scoped" as const,
+              scopedValidate: false,
+              scopedReset: false,
+              scopedCleanup: false
+            }
+          ],
+          endpoints: [
+            { name: "app-base-url", role: "application-base-url", provider: "test-endpoint" },
+            { name: "admin-url", role: "admin", provider: "test-endpoint" }
+          ]
+        },
+        worktree: { id: "feature-login" },
+        providers: {
+          resources: { "validate-capable": validateCapableProvider },
+          endpoints: { "test-endpoint": endpointProvider }
+        }
+      });
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      expect(result.resourcePlans).toHaveLength(2);
+      expect(result.endpointMappings).toHaveLength(2);
+      expect(result.endpointMappings[0].endpointName).toBe("app-base-url");
+      expect(result.endpointMappings[1].endpointName).toBe("admin-url");
+    });
+
+    it("succeeds with 0 endpoints (endpoint count not enforced)", () => {
+      const result = deriveAndValidateOne({
+        repository: makeTwoResourceRepository({ endpoints: [] }),
+        worktree: { id: "feature-login" },
+        providers: makeProviders()
+      });
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      expect(result.resourcePlans).toHaveLength(2);
+      expect(result.endpointMappings).toHaveLength(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add `resolveAndDeriveAllWithValidation` to `orchestration.ts`: derives all resources in order (fail-fast), validates those with `scopedValidate: true` immediately after their derive (fail-fast), then derives all endpoints
- Zero resources declaring `scopedValidate` is not a refusal — `resourceValidations` is simply empty (unlike reset/cleanup)
- Update `deriveAndValidateOne` to delegate to the new function
- Remove dead single-resource orchestration: `resolveSlicePreflight`, `resolveSliceExecution`, `resolveSliceDeclarations`, `resolveSliceProviders`, their associated interfaces, and the `validateResourcePlan` helper in `index.ts`
- `index.ts` is now a thin dispatch layer over four orchestration functions

## Scope

- `packages/core/src/orchestration.ts`
- `packages/core/src/index.ts`
- `tests/acceptance/dev-slice-20.acceptance.test.ts` (8 new acceptance tests)
- `docs/development/dev-slice-20.md`, `docs/development/tasks/dev-slice-20-task-01.md`

## Validation

- `pnpm test`: 145 passing, 0 failing
- `tsc --skipLibCheck --noEmit`: clean

## Deferred

- Sample project README / integration guide (backlog item 3)