### PR TITLE
Add CLI validate command

### DIFF
--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -5,6 +5,7 @@ import { pathToFileURL } from "node:url";
 
 import {
   cleanupOneResource,
+  deriveAndValidateOne,
   resetOneResource,
   deriveOne,
   validateRepositoryConfiguration,
@@ -132,6 +133,17 @@ async function deriveFromFiles(input: {
   });
 }
 
+async function validateFromFiles(input: {
+  configPath: string;
+  worktreeId: string;
+  providersModulePath: string;
+}): Promise<CliResult> {
+  return executeOperationFromFiles({
+    ...input,
+    operation: deriveAndValidateOne
+  });
+}
+
 async function resetFromFiles(input: {
   configPath: string;
   worktreeId: string;
@@ -231,6 +243,29 @@ async function handleDerive(args: string[]): Promise<CliResult> {
   });
 }
 
+async function handleValidate(args: string[]): Promise<CliResult> {
+  const configPath = readRequiredOption(args, "--config");
+  if (isCliResult(configPath)) {
+    return configPath;
+  }
+
+  const worktreeId = readRequiredOption(args, "--worktree-id");
+  if (isCliResult(worktreeId)) {
+    return worktreeId;
+  }
+
+  const providersModulePath = readRequiredOption(args, "--providers");
+  if (isCliResult(providersModulePath)) {
+    return providersModulePath;
+  }
+
+  return validateFromFiles({
+    configPath,
+    worktreeId,
+    providersModulePath
+  });
+}
+
 async function handleReset(args: string[]): Promise<CliResult> {
   const configPath = readRequiredOption(args, "--config");
   if (isCliResult(configPath)) {
@@ -292,6 +327,10 @@ export async function runCli(args: string[]): Promise<CliResult> {
     return handleDerive(args);
   }
 
+  if (command === "validate") {
+    return handleValidate(args);
+  }
+
   if (command === "reset") {
     return handleReset(args);
   }
@@ -301,7 +340,7 @@ export async function runCli(args: string[]): Promise<CliResult> {
   }
 
   return usage(
-    "Usage: multiverse <validate-worktree --worktree-id VALUE | validate-repository --config PATH | derive --config PATH --worktree-id VALUE --providers MODULE | reset --config PATH --worktree-id VALUE --providers MODULE | cleanup --config PATH --worktree-id VALUE --providers MODULE>"
+    "Usage: multiverse <validate-worktree --worktree-id VALUE | validate-repository --config PATH | derive --config PATH --worktree-id VALUE --providers MODULE | validate --config PATH --worktree-id VALUE --providers MODULE | reset --config PATH --worktree-id VALUE --providers MODULE | cleanup --config PATH --worktree-id VALUE --providers MODULE>"
   );
 }
 

--- a/tests/acceptance/cli-validate-command.acceptance.test.ts
+++ b/tests/acceptance/cli-validate-command.acceptance.test.ts
@@ -1,0 +1,262 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { runCli } from "../../apps/cli/src/index";
+
+describe("CLI validate command", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(
+      tempDirs.map((dir) => rm(dir, { recursive: true, force: true }))
+    );
+    tempDirs.length = 0;
+  });
+
+  const providersModulePath = fileURLToPath(
+    new URL("./fixtures/explicit-test-providers.ts", import.meta.url)
+  );
+
+  async function writeRepositoryConfig(config: unknown): Promise<string> {
+    const tempDir = await mkdtemp(path.join(tmpdir(), "multiverse-cli-validate-"));
+    tempDirs.push(tempDir);
+    const configPath = path.join(tempDir, "repository.json");
+    await writeFile(configPath, JSON.stringify(config));
+    return configPath;
+  }
+
+  it("derives and validates a resource that declares scopedValidate through the CLI", async () => {
+    const configPath = await writeRepositoryConfig({
+      resources: [
+        {
+          name: "primary-db",
+          provider: "test-resource-provider",
+          isolationStrategy: "name-scoped",
+          scopedValidate: true,
+          scopedReset: false,
+          scopedCleanup: false
+        }
+      ],
+      endpoints: [
+        {
+          name: "app-base-url",
+          role: "application-base-url",
+          provider: "test-endpoint-provider"
+        }
+      ]
+    });
+
+    const outcome = await runCli([
+      "validate",
+      "--config",
+      configPath,
+      "--worktree-id",
+      "wt-cli-validate",
+      "--providers",
+      providersModulePath
+    ]);
+
+    expect(outcome).toEqual({
+      exitCode: 0,
+      stdout: [
+        JSON.stringify({
+          ok: true,
+          resourcePlans: [
+            {
+              resourceName: "primary-db",
+              provider: "test-resource-provider",
+              isolationStrategy: "name-scoped",
+              worktreeId: "wt-cli-validate",
+              handle: "primary-db--wt-cli-validate"
+            }
+          ],
+          endpointMappings: [
+            {
+              endpointName: "app-base-url",
+              provider: "test-endpoint-provider",
+              role: "application-base-url",
+              worktreeId: "wt-cli-validate",
+              address: "http://wt-cli-validate.local/app-base-url"
+            }
+          ],
+          resourceValidations: [
+            {
+              resourceName: "primary-db",
+              provider: "test-resource-provider",
+              worktreeId: "wt-cli-validate",
+              capability: "validate"
+            }
+          ]
+        })
+      ],
+      stderr: []
+    });
+  });
+
+  it("succeeds with empty resourceValidations when no resources declare scopedValidate", async () => {
+    const configPath = await writeRepositoryConfig({
+      resources: [
+        {
+          name: "primary-db",
+          provider: "test-resource-provider",
+          isolationStrategy: "name-scoped",
+          scopedValidate: false,
+          scopedReset: false,
+          scopedCleanup: false
+        }
+      ],
+      endpoints: [
+        {
+          name: "app-base-url",
+          role: "application-base-url",
+          provider: "test-endpoint-provider"
+        }
+      ]
+    });
+
+    const outcome = await runCli([
+      "validate",
+      "--config",
+      configPath,
+      "--worktree-id",
+      "wt-cli-validate-none",
+      "--providers",
+      providersModulePath
+    ]);
+
+    expect(outcome).toEqual({
+      exitCode: 0,
+      stdout: [
+        JSON.stringify({
+          ok: true,
+          resourcePlans: [
+            {
+              resourceName: "primary-db",
+              provider: "test-resource-provider",
+              isolationStrategy: "name-scoped",
+              worktreeId: "wt-cli-validate-none",
+              handle: "primary-db--wt-cli-validate-none"
+            }
+          ],
+          endpointMappings: [
+            {
+              endpointName: "app-base-url",
+              provider: "test-endpoint-provider",
+              role: "application-base-url",
+              worktreeId: "wt-cli-validate-none",
+              address: "http://wt-cli-validate-none.local/app-base-url"
+            }
+          ],
+          resourceValidations: []
+        })
+      ],
+      stderr: []
+    });
+  });
+
+  it("returns unsupported_capability refusal when provider does not support validate", async () => {
+    const configPath = await writeRepositoryConfig({
+      resources: [
+        {
+          name: "primary-db",
+          provider: "test-resource-provider-no-validate",
+          isolationStrategy: "name-scoped",
+          scopedValidate: true,
+          scopedReset: false,
+          scopedCleanup: false
+        }
+      ],
+      endpoints: [
+        {
+          name: "app-base-url",
+          role: "application-base-url",
+          provider: "test-endpoint-provider"
+        }
+      ]
+    });
+
+    const outcome = await runCli([
+      "validate",
+      "--config",
+      configPath,
+      "--worktree-id",
+      "wt-cli-validate-unsupported",
+      "--providers",
+      providersModulePath
+    ]);
+
+    expect(outcome).toEqual({
+      exitCode: 1,
+      stdout: [
+        JSON.stringify({
+          ok: false,
+          refusal: {
+            category: "unsupported_capability",
+            reason: 'Resource provider "test-resource-provider-no-validate" does not support validate.'
+          }
+        })
+      ],
+      stderr: []
+    });
+  });
+
+  it("returns unsafe_scope refusal when worktree identity cannot be established", async () => {
+    const configPath = await writeRepositoryConfig({
+      resources: [
+        {
+          name: "primary-db",
+          provider: "test-resource-provider",
+          isolationStrategy: "name-scoped",
+          scopedValidate: true,
+          scopedReset: false,
+          scopedCleanup: false
+        }
+      ],
+      endpoints: [
+        {
+          name: "app-base-url",
+          role: "application-base-url",
+          provider: "test-endpoint-provider"
+        }
+      ]
+    });
+
+    const outcome = await runCli([
+      "validate",
+      "--config",
+      configPath,
+      "--worktree-id",
+      "",
+      "--providers",
+      providersModulePath
+    ]);
+
+    expect(outcome).toEqual({
+      exitCode: 1,
+      stdout: [
+        JSON.stringify({
+          ok: false,
+          refusal: {
+            category: "unsafe_scope",
+            reason: "Safe worktree scope cannot be determined."
+          }
+        })
+      ],
+      stderr: []
+    });
+  });
+
+  it("returns usage error when required options are missing", async () => {
+    const outcome = await runCli(["validate", "--worktree-id", "wt-cli-validate"]);
+
+    expect(outcome).toEqual({
+      exitCode: 1,
+      stdout: [],
+      stderr: ["Missing required option --config"]
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Add `validate` as a CLI command, wiring `deriveAndValidateOne` with the same `--config / --worktree-id / --providers` interface as `derive`, `reset`, and `cleanup`.

## Scope

- `apps/cli/src/index.ts` — add `validateFromFiles`, `handleValidate`, wire into `runCli`, update usage string
- `tests/acceptance/cli-validate-command.acceptance.test.ts` — 5 acceptance tests covering success, empty validations, unsupported capability, unsafe scope, and missing options

## Validation

- `pnpm test`: 150 passing, 0 failing
- `tsc --skipLibCheck --noEmit`: clean

## Notes

This fills the last gap in the CLI lifecycle surface: derive → validate → reset → cleanup are all now reachable via CLI.