### PR TITLE
Pre-sample-app cleanup: dead code, type coupling, repo-map

### DIFF
--- a/docs/development/repo-map.md
+++ b/docs/development/repo-map.md
@@ -10,14 +10,20 @@ This map is meant to support the current implementation phase. It is not a commi
 
 ## Current Repository State
 
-The repository currently contains behavior-first design artifacts, including:
+The repository contains behavior-first design artifacts and a working implementation:
 
 - specifications under `docs/spec/`
 - scenarios under `docs/scenarios/`
 - ADRs under `docs/adr/`
 - development guidance under `docs/development/`
+- core business logic in `packages/core/`
+- provider contracts in `packages/provider-contracts/`
+- three concrete resource providers: `provider-name-scoped`, `provider-path-scoped`, `provider-local-port`
+- a test provider registry in `packages/providers-testkit/`
+- a thin CLI in `apps/cli/`
+- 150+ tests across acceptance, contract, and unit layers
 
-Implementation is beginning through narrow vertical slices.
+Implementation has progressed through 20 development slices. The full lifecycle (derive, validate, reset, cleanup) is implemented for all declared resources and endpoints, with multi-resource support throughout.
 
 ## Implementation Model
 
@@ -62,13 +68,16 @@ Applications may parse input, invoke core behavior, and present results, but mus
 
 Reusable implementation packages with explicit responsibility boundaries.
 
-Initial intended packages:
+Current packages:
 
-- `packages/core/`
-- `packages/provider-contracts/`
-- `packages/providers-testkit/`
+- `packages/core/` — business logic, orchestration, validation, refusal enforcement
+- `packages/provider-contracts/` — shared TypeScript interfaces between core and providers
+- `packages/providers-testkit/` — fake providers and test fixtures
+- `packages/provider-name-scoped/` — name-scoped resource isolation (derive, reset, cleanup)
+- `packages/provider-path-scoped/` — path-scoped resource isolation (derive, reset, cleanup)
+- `packages/provider-local-port/` — local-port endpoint isolation (derive)
 
-Additional packages may be introduced later when justified by real implementation boundaries.
+Additional packages may be introduced when justified by real implementation boundaries.
 
 ### `tests/`
 
@@ -149,9 +158,9 @@ Must not:
 
 ## Future Package Candidates
 
-These should be added only when justified by real slices:
+These should be added only when justified by real implementation needs:
 
-- concrete provider packages under `packages/provider-*`
+- additional provider packages under `packages/provider-*` as new isolation strategies are required
 - a configuration-model package if configuration concerns become large enough to justify isolation
 - shared test utilities if test support grows beyond the provider testkit role
 
@@ -226,11 +235,9 @@ Primary code targets as implementation begins:
 
 Current implementation work should follow the active development slice document under `docs/development/`.
 
-At the time of writing, the first active slice is:
+Slices 01–20 are complete. The backlog for upcoming work is tracked in `.claude/data/backlog.md`.
 
-- `docs/development/dev-slice-01.md`
-
-Contributors and coding agents should use that slice document to determine what behavior is currently in scope.
+Contributors and coding agents should use the active slice document and backlog to determine what behavior is currently in scope.
 
 ## Practical Rules
 

--- a/packages/core/src/declarations.ts
+++ b/packages/core/src/declarations.ts
@@ -4,7 +4,6 @@ import type {
   ResourceDeclaration
 } from "@multiverse/provider-contracts";
 
-import { invalidConfiguration, type FailureResult } from "./refusals";
 
 export interface DeclarationValidationError {
   path: string;
@@ -190,38 +189,3 @@ export function validateIndexedEndpointDeclaration(input: {
   };
 }
 
-export function toValidatedResource(
-  resource: ResourceDeclaration
-): ValidatedResourceDeclaration | FailureResult {
-  const validation = validateResourceDeclaration({
-    resource,
-    index: 0
-  });
-
-  if (!validation.ok) {
-    return invalidConfiguration("Resource declaration is invalid.");
-  }
-
-  return validation.value;
-}
-
-export function toValidatedEndpoint(
-  endpoint: EndpointDeclaration
-): ValidatedEndpointDeclaration | FailureResult {
-  const validation = validateEndpointDeclaration(endpoint);
-
-  if (!validation.ok) {
-    return invalidConfiguration("Endpoint declaration is invalid.");
-  }
-
-  return validation.value;
-}
-
-export function isFailureResult(
-  value:
-    | ValidatedResourceDeclaration
-    | ValidatedEndpointDeclaration
-    | FailureResult
-): value is FailureResult {
-  return "ok" in value && value.ok === false;
-}

--- a/packages/core/src/orchestration.ts
+++ b/packages/core/src/orchestration.ts
@@ -24,7 +24,7 @@ import {
 } from "./refusals";
 import { validateWorktreeIdentity } from "./worktree-identity";
 
-export interface ResolvedWorktree {
+interface ResolvedWorktree {
   id: string;
   label?: string;
   branch?: string;

--- a/packages/core/src/refusals.ts
+++ b/packages/core/src/refusals.ts
@@ -1,10 +1,9 @@
-import type {
-  Refusal,
-  DeriveOneResult,
-  DeriveAndValidateOneResult
-} from "@multiverse/provider-contracts";
+import type { Refusal } from "@multiverse/provider-contracts";
 
-export type FailureResult = Extract<DeriveOneResult, { ok: false }>;
+export interface FailureResult {
+  ok: false;
+  refusal: Refusal;
+}
 
 export function invalidConfiguration(reason: string): FailureResult {
   return {
@@ -26,9 +25,7 @@ export function unsafeScope(reason: string): FailureResult {
   };
 }
 
-export function unsupportedCapability(
-  reason: string
-): Extract<DeriveAndValidateOneResult, { ok: false }> {
+export function unsupportedCapability(reason: string): FailureResult {
   return {
     ok: false,
     refusal: {


### PR DESCRIPTION
## Summary

Four targeted cleanup items before the sample application work begins.

**Dead code removal (`declarations.ts`)**
`toValidatedResource`, `toValidatedEndpoint`, and `isFailureResult` had zero callers — they were left over from the single-resource orchestration paths removed in slices 18–20. Removed along with their now-unused `invalidConfiguration`/`FailureResult` import.

**`refusals.ts` type decoupling**
`FailureResult` was defined as `Extract<DeriveOneResult, { ok: false }>` and `unsupportedCapability` returned `Extract<DeriveAndValidateOneResult, { ok: false }>`. Both are structurally `{ ok: false; refusal: Refusal }`. Replaced with a direct interface definition to remove the fragile dependency on specific public result types.

**`ResolvedWorktree` unexported**
This interface was exported from `orchestration.ts` but had no external callers — it was a leftover from the removed `ResolvedSlicePreflight` family. Made internal.

**`repo-map.md` refreshed**
Updated to reflect 20 completed slices, the current package catalog (including the three concrete providers), and a pointer to the backlog.

## Scope

- `packages/core/src/declarations.ts`
- `packages/core/src/refusals.ts`
- `packages/core/src/orchestration.ts`
- `docs/development/repo-map.md`

## Validation

- `pnpm test`: 145 passing, 0 failing
- `tsc --skipLibCheck --noEmit`: clean

## Notes

`scopedValidate` asymmetry (not required in declaration validation, unlike `scopedReset`/`scopedCleanup`) is intentional per `docs/spec/repository-configuration.md` — validate is supplemental. No change made there.