### PR TITLE
Add test-integration job to CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,3 +105,27 @@ jobs:
 
       - name: Run unit tests
         run: pnpm test:unit
+
+  test-integration:
+    name: test-integration
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.33.0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run integration tests
+        run: pnpm test:integration


### PR DESCRIPTION
Adds a `test-integration` CI job that runs `pnpm test:integration` on every PR and push to main. Follows the same structure as the existing `test-acceptance`, `test-contracts`, and `test-unit` jobs.

The integration suite (added in #53) starts live Express servers and proves runtime isolation guarantees. Without this job it could regress silently.