### PR TITLE
Implement destructive path-scoped lifecycle operations

### DIFF
--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -176,9 +176,7 @@ async function executeOperationFromFiles(input: {
       id: string;
     };
     providers: ProviderRegistry;
-  }) => {
-    ok: boolean;
-  };
+  }) => { ok: boolean } | Promise<{ ok: boolean }>;
 }): Promise<CliResult> {
   const parsed = await readRepositoryConfiguration(input.configPath);
   const providers = await loadProviderRegistry(input.providersModulePath);
@@ -187,13 +185,15 @@ async function executeOperationFromFiles(input: {
     return providers;
   }
 
-  const result = input.operation({
-    repository: parsed,
-    worktree: {
-      id: input.worktreeId
-    },
-    providers
-  });
+  const result = await Promise.resolve(
+    input.operation({
+      repository: parsed,
+      worktree: {
+        id: input.worktreeId
+      },
+      providers
+    })
+  );
 
   return result.ok ? success(result) : failure(result);
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -47,7 +47,7 @@ export function resetOneResource(input: {
   repository: RepositoryConfiguration;
   worktree: WorktreeInstanceInput;
   providers: ProviderRegistry;
-}): ResetOneResourceResult {
+}): Promise<ResetOneResourceResult> {
   return resolveAndResetAll(input);
 }
 
@@ -55,6 +55,6 @@ export function cleanupOneResource(input: {
   repository: RepositoryConfiguration;
   worktree: WorktreeInstanceInput;
   providers: ProviderRegistry;
-}): CleanupOneResourceResult {
+}): Promise<CleanupOneResourceResult> {
   return resolveAndCleanupAll(input);
 }

--- a/packages/core/src/orchestration.ts
+++ b/packages/core/src/orchestration.ts
@@ -239,11 +239,11 @@ export function resolveAndDeriveAllWithValidation(input: {
   return { ok: true, resourcePlans, endpointMappings, resourceValidations };
 }
 
-export function resolveAndResetAll(input: {
+export async function resolveAndResetAll(input: {
   repository: RepositoryConfiguration;
   worktree: WorktreeInstanceInput;
   providers: ProviderRegistry;
-}): ResetOneResourceResult {
+}): Promise<ResetOneResourceResult> {
   const resolvedWorktree = requireResolvedWorktree(input.worktree);
   if (isFailureOutcome(resolvedWorktree)) {
     return resolvedWorktree;
@@ -289,7 +289,7 @@ export function resolveAndResetAll(input: {
       return { ok: false, refusal: plan };
     }
 
-    const reset = resourceProvider.resetResource({
+    const reset = await resourceProvider.resetResource({
       resource: resourceDecl,
       derived: plan,
       worktree: resolvedWorktree
@@ -305,11 +305,11 @@ export function resolveAndResetAll(input: {
   return { ok: true, resourcePlans, resourceResets };
 }
 
-export function resolveAndCleanupAll(input: {
+export async function resolveAndCleanupAll(input: {
   repository: RepositoryConfiguration;
   worktree: WorktreeInstanceInput;
   providers: ProviderRegistry;
-}): CleanupOneResourceResult {
+}): Promise<CleanupOneResourceResult> {
   const resolvedWorktree = requireResolvedWorktree(input.worktree);
   if (isFailureOutcome(resolvedWorktree)) {
     return resolvedWorktree;
@@ -355,7 +355,7 @@ export function resolveAndCleanupAll(input: {
       return { ok: false, refusal: plan };
     }
 
-    const cleanup = resourceProvider.cleanupResource({
+    const cleanup = await resourceProvider.cleanupResource({
       resource: resourceDecl,
       derived: plan,
       worktree: resolvedWorktree

--- a/packages/provider-contracts/src/index.ts
+++ b/packages/provider-contracts/src/index.ts
@@ -131,7 +131,7 @@ export interface ResourceProvider {
       label?: string;
       branch?: string;
     };
-  }): ResourceReset | Refusal;
+  }): Promise<ResourceReset | Refusal>;
   cleanupResource?(input: {
     resource: {
       name: string;
@@ -147,7 +147,7 @@ export interface ResourceProvider {
       label?: string;
       branch?: string;
     };
-  }): ResourceCleanup | Refusal;
+  }): Promise<ResourceCleanup | Refusal>;
 }
 
 export interface EndpointProvider {

--- a/packages/provider-name-scoped/src/index.ts
+++ b/packages/provider-name-scoped/src/index.ts
@@ -34,7 +34,7 @@ export function createNameScopedProvider(): ResourceProvider {
       };
     },
 
-    resetResource({ resource, derived, worktree }): ResourceReset | Refusal {
+    async resetResource({ resource, derived, worktree }): Promise<ResourceReset | Refusal> {
       if (!worktree.id) {
         return unsafeScope();
       }
@@ -47,7 +47,7 @@ export function createNameScopedProvider(): ResourceProvider {
       };
     },
 
-    cleanupResource({ resource, derived, worktree }): ResourceCleanup | Refusal {
+    async cleanupResource({ resource, derived, worktree }): Promise<ResourceCleanup | Refusal> {
       if (!worktree.id) {
         return unsafeScope();
       }

--- a/packages/provider-path-scoped/src/index.ts
+++ b/packages/provider-path-scoped/src/index.ts
@@ -1,4 +1,5 @@
 import { join } from "node:path";
+import { rm } from "node:fs/promises";
 import type {
   ResourceProvider,
   DerivedResourcePlan,
@@ -39,10 +40,12 @@ export function createPathScopedProvider(config: PathScopedProviderConfig): Reso
       };
     },
 
-    resetResource({ resource, derived, worktree }): ResourceReset | Refusal {
+    async resetResource({ resource, derived, worktree }): Promise<ResourceReset | Refusal> {
       if (!worktree.id) {
         return unsafeScope();
       }
+
+      await rm(derived.handle, { recursive: true, force: true });
 
       return {
         resourceName: resource.name,
@@ -52,10 +55,12 @@ export function createPathScopedProvider(config: PathScopedProviderConfig): Reso
       };
     },
 
-    cleanupResource({ resource, derived, worktree }): ResourceCleanup | Refusal {
+    async cleanupResource({ resource, derived, worktree }): Promise<ResourceCleanup | Refusal> {
       if (!worktree.id) {
         return unsafeScope();
       }
+
+      await rm(derived.handle, { recursive: true, force: true });
 
       return {
         resourceName: resource.name,

--- a/packages/providers-testkit/src/index.ts
+++ b/packages/providers-testkit/src/index.ts
@@ -57,14 +57,14 @@ function deriveScopedResource(input: {
   };
 }
 
-function resetScopedResource(input: {
+async function resetScopedResource(input: {
   resource: {
     name: string;
     provider: string;
   };
   derived: DerivedResourcePlan;
   worktree: WorktreeInstanceInput;
-}): ResourceReset | Refusal {
+}): Promise<ResourceReset | Refusal> {
   if (!input.worktree.id) {
     return unsafeScope("Safe worktree scope cannot be determined.");
   }
@@ -77,14 +77,14 @@ function resetScopedResource(input: {
   };
 }
 
-function cleanupScopedResource(input: {
+async function cleanupScopedResource(input: {
   resource: {
     name: string;
     provider: string;
   };
   derived: DerivedResourcePlan;
   worktree: WorktreeInstanceInput;
-}): ResourceCleanup | Refusal {
+}): Promise<ResourceCleanup | Refusal> {
   if (!input.worktree.id) {
     return unsafeScope("Safe worktree scope cannot be determined.");
   }
@@ -234,7 +234,7 @@ export function createProvidersWithResourceResetRefusal(
 
   providers.resources["test-resource-provider-with-reset"] = {
     ...providers.resources["test-resource-provider-with-reset"],
-    resetResource() {
+    async resetResource() {
       return refusal;
     }
   };
@@ -249,7 +249,7 @@ export function createProvidersWithResourceCleanupRefusal(
 
   providers.resources["test-resource-provider-with-cleanup"] = {
     ...providers.resources["test-resource-provider-with-cleanup"],
-    cleanupResource() {
+    async cleanupResource() {
       return refusal;
     }
   };

--- a/tests/acceptance/dev-slice-08.acceptance.test.ts
+++ b/tests/acceptance/dev-slice-08.acceptance.test.ts
@@ -9,8 +9,8 @@ import {
 } from "@multiverse/providers-testkit";
 
 describe("Development Slice 08 acceptance", () => {
-  it("executes one explicit scoped reset when reset is supported", () => {
-    const outcome = resetOneResource({
+  it("executes one explicit scoped reset when reset is supported", async () => {
+    const outcome = await resetOneResource({
       repository: createValidRepositoryConfiguration({
         resources: [
           {
@@ -51,14 +51,14 @@ describe("Development Slice 08 acceptance", () => {
     });
   });
 
-  it("refuses unsupported reset intent explicitly", () => {
+  it("refuses unsupported reset intent explicitly", async () => {
     const providers = createExplicitTestProviders();
     const deriveResource = vi.spyOn(
       providers.resources["test-resource-provider"],
       "deriveResource"
     );
 
-    const outcome = resetOneResource({
+    const outcome = await resetOneResource({
       repository: createValidRepositoryConfiguration({
         resources: [
           {
@@ -86,14 +86,14 @@ describe("Development Slice 08 acceptance", () => {
     expect(deriveResource).not.toHaveBeenCalled();
   });
 
-  it("refuses reset when repository intent does not enable scoped reset", () => {
+  it("refuses reset when repository intent does not enable scoped reset", async () => {
     const providers = createExplicitTestProviders();
     const deriveResource = vi.spyOn(
       providers.resources["test-resource-provider-with-reset"],
       "deriveResource"
     );
 
-    const outcome = resetOneResource({
+    const outcome = await resetOneResource({
       repository: createValidRepositoryConfiguration({
         resources: [
           {
@@ -121,8 +121,8 @@ describe("Development Slice 08 acceptance", () => {
     expect(deriveResource).not.toHaveBeenCalled();
   });
 
-  it("refuses reset when safe scope cannot be established", () => {
-    const outcome = resetOneResource({
+  it("refuses reset when safe scope cannot be established", async () => {
+    const outcome = await resetOneResource({
       repository: createValidRepositoryConfiguration({
         resources: [
           {
@@ -179,8 +179,8 @@ describe("Development Slice 08 acceptance", () => {
     expect(resetResource).not.toHaveBeenCalled();
   });
 
-  it("returns provider-originated unsafe scope during reset unchanged", () => {
-    const outcome = resetOneResource({
+  it("returns provider-originated unsafe scope during reset unchanged", async () => {
+    const outcome = await resetOneResource({
       repository: createValidRepositoryConfiguration({
         resources: [
           {
@@ -211,8 +211,8 @@ describe("Development Slice 08 acceptance", () => {
     });
   });
 
-  it("returns provider-originated provider failure during reset unchanged", () => {
-    const outcome = resetOneResource({
+  it("returns provider-originated provider failure during reset unchanged", async () => {
+    const outcome = await resetOneResource({
       repository: createValidRepositoryConfiguration({
         resources: [
           {

--- a/tests/acceptance/dev-slice-09.acceptance.test.ts
+++ b/tests/acceptance/dev-slice-09.acceptance.test.ts
@@ -9,8 +9,8 @@ import {
 } from "@multiverse/providers-testkit";
 
 describe("Development Slice 09 acceptance", () => {
-  it("executes one explicit scoped cleanup when cleanup is supported", () => {
-    const outcome = cleanupOneResource({
+  it("executes one explicit scoped cleanup when cleanup is supported", async () => {
+    const outcome = await cleanupOneResource({
       repository: createValidRepositoryConfiguration({
         resources: [
           {
@@ -51,14 +51,14 @@ describe("Development Slice 09 acceptance", () => {
     });
   });
 
-  it("refuses unsupported cleanup intent explicitly", () => {
+  it("refuses unsupported cleanup intent explicitly", async () => {
     const providers = createExplicitTestProviders();
     const deriveResource = vi.spyOn(
       providers.resources["test-resource-provider"],
       "deriveResource"
     );
 
-    const outcome = cleanupOneResource({
+    const outcome = await cleanupOneResource({
       repository: createValidRepositoryConfiguration({
         resources: [
           {
@@ -86,14 +86,14 @@ describe("Development Slice 09 acceptance", () => {
     expect(deriveResource).not.toHaveBeenCalled();
   });
 
-  it("refuses cleanup when repository intent does not enable scoped cleanup", () => {
+  it("refuses cleanup when repository intent does not enable scoped cleanup", async () => {
     const providers = createExplicitTestProviders();
     const deriveResource = vi.spyOn(
       providers.resources["test-resource-provider-with-cleanup"],
       "deriveResource"
     );
 
-    const outcome = cleanupOneResource({
+    const outcome = await cleanupOneResource({
       repository: createValidRepositoryConfiguration({
         resources: [
           {
@@ -121,8 +121,8 @@ describe("Development Slice 09 acceptance", () => {
     expect(deriveResource).not.toHaveBeenCalled();
   });
 
-  it("refuses cleanup when safe scope cannot be established", () => {
-    const outcome = cleanupOneResource({
+  it("refuses cleanup when safe scope cannot be established", async () => {
+    const outcome = await cleanupOneResource({
       repository: createValidRepositoryConfiguration({
         resources: [
           {
@@ -179,8 +179,8 @@ describe("Development Slice 09 acceptance", () => {
     expect(cleanupResource).not.toHaveBeenCalled();
   });
 
-  it("returns provider-originated unsafe scope during cleanup unchanged", () => {
-    const outcome = cleanupOneResource({
+  it("returns provider-originated unsafe scope during cleanup unchanged", async () => {
+    const outcome = await cleanupOneResource({
       repository: createValidRepositoryConfiguration({
         resources: [
           {
@@ -211,8 +211,8 @@ describe("Development Slice 09 acceptance", () => {
     });
   });
 
-  it("returns provider-originated provider failure during cleanup unchanged", () => {
-    const outcome = cleanupOneResource({
+  it("returns provider-originated provider failure during cleanup unchanged", async () => {
+    const outcome = await cleanupOneResource({
       repository: createValidRepositoryConfiguration({
         resources: [
           {

--- a/tests/acceptance/dev-slice-16.acceptance.test.ts
+++ b/tests/acceptance/dev-slice-16.acceptance.test.ts
@@ -37,8 +37,8 @@ describe("dev-slice-16: name-scoped provider lifecycle", () => {
   }
 
   describe("reset", () => {
-    it("succeeds for a name-scoped resource with scopedReset declared", () => {
-      const result = resetOneResource({
+    it("succeeds for a name-scoped resource with scopedReset declared", async () => {
+      const result = await resetOneResource({
         repository: makeRepository({ scopedReset: true }),
         worktree: { id: "feature-login" },
         providers: makeProviders()
@@ -52,8 +52,8 @@ describe("dev-slice-16: name-scoped provider lifecycle", () => {
       expect(result.resourceResets[0].worktreeId).toBe("feature-login");
     });
 
-    it("returns invalid_configuration when scopedReset is not declared", () => {
-      const result = resetOneResource({
+    it("returns invalid_configuration when scopedReset is not declared", async () => {
+      const result = await resetOneResource({
         repository: makeRepository({ scopedReset: false }),
         worktree: { id: "feature-login" },
         providers: makeProviders()
@@ -65,8 +65,8 @@ describe("dev-slice-16: name-scoped provider lifecycle", () => {
       expect(result.refusal.category).toBe("invalid_configuration");
     });
 
-    it("returns unsafe_scope when worktree ID is absent", () => {
-      const result = resetOneResource({
+    it("returns unsafe_scope when worktree ID is absent", async () => {
+      const result = await resetOneResource({
         repository: makeRepository({ scopedReset: true }),
         worktree: {},
         providers: makeProviders()
@@ -80,8 +80,8 @@ describe("dev-slice-16: name-scoped provider lifecycle", () => {
   });
 
   describe("cleanup", () => {
-    it("succeeds for a name-scoped resource with scopedCleanup declared", () => {
-      const result = cleanupOneResource({
+    it("succeeds for a name-scoped resource with scopedCleanup declared", async () => {
+      const result = await cleanupOneResource({
         repository: makeRepository({ scopedCleanup: true }),
         worktree: { id: "feature-login" },
         providers: makeProviders()
@@ -95,8 +95,8 @@ describe("dev-slice-16: name-scoped provider lifecycle", () => {
       expect(result.resourceCleanups[0].worktreeId).toBe("feature-login");
     });
 
-    it("returns invalid_configuration when scopedCleanup is not declared", () => {
-      const result = cleanupOneResource({
+    it("returns invalid_configuration when scopedCleanup is not declared", async () => {
+      const result = await cleanupOneResource({
         repository: makeRepository({ scopedCleanup: false }),
         worktree: { id: "feature-login" },
         providers: makeProviders()
@@ -108,8 +108,8 @@ describe("dev-slice-16: name-scoped provider lifecycle", () => {
       expect(result.refusal.category).toBe("invalid_configuration");
     });
 
-    it("returns unsafe_scope when worktree ID is absent", () => {
-      const result = cleanupOneResource({
+    it("returns unsafe_scope when worktree ID is absent", async () => {
+      const result = await cleanupOneResource({
         repository: makeRepository({ scopedCleanup: true }),
         worktree: {},
         providers: makeProviders()

--- a/tests/acceptance/dev-slice-17.acceptance.test.ts
+++ b/tests/acceptance/dev-slice-17.acceptance.test.ts
@@ -38,8 +38,8 @@ describe("dev-slice-17: path-scoped provider lifecycle", () => {
   }
 
   describe("reset", () => {
-    it("succeeds for a path-scoped resource with scopedReset declared", () => {
-      const result = resetOneResource({
+    it("succeeds for a path-scoped resource with scopedReset declared", async () => {
+      const result = await resetOneResource({
         repository: makeRepository({ scopedReset: true }),
         worktree: { id: "feature-login" },
         providers: makeProviders()
@@ -53,8 +53,8 @@ describe("dev-slice-17: path-scoped provider lifecycle", () => {
       expect(result.resourceResets[0].worktreeId).toBe("feature-login");
     });
 
-    it("returns invalid_configuration when scopedReset is not declared", () => {
-      const result = resetOneResource({
+    it("returns invalid_configuration when scopedReset is not declared", async () => {
+      const result = await resetOneResource({
         repository: makeRepository({ scopedReset: false }),
         worktree: { id: "feature-login" },
         providers: makeProviders()
@@ -66,8 +66,8 @@ describe("dev-slice-17: path-scoped provider lifecycle", () => {
       expect(result.refusal.category).toBe("invalid_configuration");
     });
 
-    it("returns unsafe_scope when worktree ID is absent", () => {
-      const result = resetOneResource({
+    it("returns unsafe_scope when worktree ID is absent", async () => {
+      const result = await resetOneResource({
         repository: makeRepository({ scopedReset: true }),
         worktree: {},
         providers: makeProviders()
@@ -81,8 +81,8 @@ describe("dev-slice-17: path-scoped provider lifecycle", () => {
   });
 
   describe("cleanup", () => {
-    it("succeeds for a path-scoped resource with scopedCleanup declared", () => {
-      const result = cleanupOneResource({
+    it("succeeds for a path-scoped resource with scopedCleanup declared", async () => {
+      const result = await cleanupOneResource({
         repository: makeRepository({ scopedCleanup: true }),
         worktree: { id: "feature-login" },
         providers: makeProviders()
@@ -96,8 +96,8 @@ describe("dev-slice-17: path-scoped provider lifecycle", () => {
       expect(result.resourceCleanups[0].worktreeId).toBe("feature-login");
     });
 
-    it("returns invalid_configuration when scopedCleanup is not declared", () => {
-      const result = cleanupOneResource({
+    it("returns invalid_configuration when scopedCleanup is not declared", async () => {
+      const result = await cleanupOneResource({
         repository: makeRepository({ scopedCleanup: false }),
         worktree: { id: "feature-login" },
         providers: makeProviders()
@@ -109,8 +109,8 @@ describe("dev-slice-17: path-scoped provider lifecycle", () => {
       expect(result.refusal.category).toBe("invalid_configuration");
     });
 
-    it("returns unsafe_scope when worktree ID is absent", () => {
-      const result = cleanupOneResource({
+    it("returns unsafe_scope when worktree ID is absent", async () => {
+      const result = await cleanupOneResource({
         repository: makeRepository({ scopedCleanup: true }),
         worktree: {},
         providers: makeProviders()

--- a/tests/acceptance/dev-slice-19.acceptance.test.ts
+++ b/tests/acceptance/dev-slice-19.acceptance.test.ts
@@ -42,8 +42,8 @@ describe("dev-slice-19: multi-resource reset and cleanup", () => {
   }
 
   describe("reset", () => {
-    it("resets all resources that declare scopedReset", () => {
-      const result = resetOneResource({
+    it("resets all resources that declare scopedReset", async () => {
+      const result = await resetOneResource({
         repository: makeTwoResourceRepository({
           firstScopedReset: true,
           secondScopedReset: true
@@ -63,8 +63,8 @@ describe("dev-slice-19: multi-resource reset and cleanup", () => {
       expect(result.resourceResets[1].capability).toBe("reset");
     });
 
-    it("resets only the resources that declare scopedReset", () => {
-      const result = resetOneResource({
+    it("resets only the resources that declare scopedReset", async () => {
+      const result = await resetOneResource({
         repository: makeTwoResourceRepository({
           firstScopedReset: true,
           secondScopedReset: false
@@ -81,8 +81,8 @@ describe("dev-slice-19: multi-resource reset and cleanup", () => {
       expect(result.resourceResets[0].resourceName).toBe("primary-db");
     });
 
-    it("returns invalid_configuration when no resources declare scopedReset", () => {
-      const result = resetOneResource({
+    it("returns invalid_configuration when no resources declare scopedReset", async () => {
+      const result = await resetOneResource({
         repository: makeTwoResourceRepository({
           firstScopedReset: false,
           secondScopedReset: false
@@ -97,7 +97,7 @@ describe("dev-slice-19: multi-resource reset and cleanup", () => {
       expect(result.refusal.category).toBe("invalid_configuration");
     });
 
-    it("returns refusal fail-fast when the second resource reset refuses", () => {
+    it("returns refusal fail-fast when the second resource reset refuses", async () => {
       const failingProvider = {
         capabilities: { reset: true as const },
         deriveResource() {
@@ -109,7 +109,7 @@ describe("dev-slice-19: multi-resource reset and cleanup", () => {
             handle: "cache_feature-login"
           };
         },
-        resetResource() {
+        async resetResource() {
           return {
             category: "provider_failure" as const,
             reason: "Reset provider encountered an error."
@@ -117,7 +117,7 @@ describe("dev-slice-19: multi-resource reset and cleanup", () => {
         }
       };
 
-      const result = resetOneResource({
+      const result = await resetOneResource({
         repository: makeTwoResourceRepository({
           firstScopedReset: true,
           secondScopedReset: true
@@ -137,7 +137,7 @@ describe("dev-slice-19: multi-resource reset and cleanup", () => {
       expect(result.ok).toBe(true); // both name-scoped resources succeed
     });
 
-    it("returns refusal fail-fast when a reset provider refuses", () => {
+    it("returns refusal fail-fast when a reset provider refuses", async () => {
       const refusingResetProvider = {
         capabilities: { reset: true as const },
         deriveResource() {
@@ -149,7 +149,7 @@ describe("dev-slice-19: multi-resource reset and cleanup", () => {
             handle: "cache_feature-login"
           };
         },
-        resetResource() {
+        async resetResource() {
           return {
             category: "provider_failure" as const,
             reason: "Reset provider refused."
@@ -179,7 +179,7 @@ describe("dev-slice-19: multi-resource reset and cleanup", () => {
         endpoints: []
       };
 
-      const result = resetOneResource({
+      const result = await resetOneResource({
         repository,
         worktree: { id: "feature-login" },
         providers: {
@@ -197,8 +197,8 @@ describe("dev-slice-19: multi-resource reset and cleanup", () => {
       expect(result.refusal.category).toBe("provider_failure");
     });
 
-    it("succeeds with no endpoints declared (endpoints are irrelevant to reset)", () => {
-      const result = resetOneResource({
+    it("succeeds with no endpoints declared (endpoints are irrelevant to reset)", async () => {
+      const result = await resetOneResource({
         repository: {
           resources: [
             {
@@ -225,8 +225,8 @@ describe("dev-slice-19: multi-resource reset and cleanup", () => {
   });
 
   describe("cleanup", () => {
-    it("cleans up all resources that declare scopedCleanup", () => {
-      const result = cleanupOneResource({
+    it("cleans up all resources that declare scopedCleanup", async () => {
+      const result = await cleanupOneResource({
         repository: makeTwoResourceRepository({
           firstScopedCleanup: true,
           secondScopedCleanup: true
@@ -246,8 +246,8 @@ describe("dev-slice-19: multi-resource reset and cleanup", () => {
       expect(result.resourceCleanups[1].capability).toBe("cleanup");
     });
 
-    it("cleans up only the resources that declare scopedCleanup", () => {
-      const result = cleanupOneResource({
+    it("cleans up only the resources that declare scopedCleanup", async () => {
+      const result = await cleanupOneResource({
         repository: makeTwoResourceRepository({
           firstScopedCleanup: true,
           secondScopedCleanup: false
@@ -264,8 +264,8 @@ describe("dev-slice-19: multi-resource reset and cleanup", () => {
       expect(result.resourceCleanups[0].resourceName).toBe("primary-db");
     });
 
-    it("returns invalid_configuration when no resources declare scopedCleanup", () => {
-      const result = cleanupOneResource({
+    it("returns invalid_configuration when no resources declare scopedCleanup", async () => {
+      const result = await cleanupOneResource({
         repository: makeTwoResourceRepository({
           firstScopedCleanup: false,
           secondScopedCleanup: false
@@ -280,7 +280,7 @@ describe("dev-slice-19: multi-resource reset and cleanup", () => {
       expect(result.refusal.category).toBe("invalid_configuration");
     });
 
-    it("returns refusal fail-fast when a cleanup provider refuses", () => {
+    it("returns refusal fail-fast when a cleanup provider refuses", async () => {
       const refusingCleanupProvider = {
         capabilities: { cleanup: true as const },
         deriveResource() {
@@ -292,7 +292,7 @@ describe("dev-slice-19: multi-resource reset and cleanup", () => {
             handle: "cache_feature-login"
           };
         },
-        cleanupResource() {
+        async cleanupResource() {
           return {
             category: "provider_failure" as const,
             reason: "Cleanup provider refused."
@@ -322,7 +322,7 @@ describe("dev-slice-19: multi-resource reset and cleanup", () => {
         endpoints: []
       };
 
-      const result = cleanupOneResource({
+      const result = await cleanupOneResource({
         repository,
         worktree: { id: "feature-login" },
         providers: {
@@ -340,8 +340,8 @@ describe("dev-slice-19: multi-resource reset and cleanup", () => {
       expect(result.refusal.category).toBe("provider_failure");
     });
 
-    it("succeeds with no endpoints declared (endpoints are irrelevant to cleanup)", () => {
-      const result = cleanupOneResource({
+    it("succeeds with no endpoints declared (endpoints are irrelevant to cleanup)", async () => {
+      const result = await cleanupOneResource({
         repository: {
           resources: [
             {

--- a/tests/contracts/resource-provider.cleanup.contract.test.ts
+++ b/tests/contracts/resource-provider.cleanup.contract.test.ts
@@ -6,7 +6,7 @@ import {
 } from "@multiverse/providers-testkit";
 
 describe("resource provider cleanup contract", () => {
-  it("declares cleanup support explicitly and cleans up one worktree instance", () => {
+  it("declares cleanup support explicitly and cleans up one worktree instance", async () => {
     const providers = createExplicitTestProviders();
     const resourceProvider = providers.resources["test-resource-provider-with-cleanup"];
 
@@ -18,7 +18,7 @@ describe("resource provider cleanup contract", () => {
       throw new Error("Expected cleanupResource to be defined.");
     }
 
-    const cleanup = resourceProvider.cleanupResource({
+    const cleanup = await resourceProvider.cleanupResource({
       resource: {
         name: "primary-db",
         provider: "test-resource-provider-with-cleanup",
@@ -47,7 +47,7 @@ describe("resource provider cleanup contract", () => {
     });
   });
 
-  it("refuses cleanup when provider-level scope safety cannot be established", () => {
+  it("refuses cleanup when provider-level scope safety cannot be established", async () => {
     const providers = createExplicitTestProviders();
     const resourceProvider = providers.resources["test-resource-provider-with-cleanup"];
 
@@ -55,7 +55,7 @@ describe("resource provider cleanup contract", () => {
       throw new Error("Expected cleanupResource to be defined.");
     }
 
-    const cleanup = resourceProvider.cleanupResource({
+    const cleanup = await resourceProvider.cleanupResource({
       resource: {
         name: "primary-db",
         provider: "test-resource-provider-with-cleanup",
@@ -81,7 +81,7 @@ describe("resource provider cleanup contract", () => {
     });
   });
 
-  it("may refuse cleanup with provider failure distinctly from unsafe scope", () => {
+  it("may refuse cleanup with provider failure distinctly from unsafe scope", async () => {
     const providers = createProvidersWithResourceCleanupRefusal({
       category: "provider_failure",
       reason: "Provider cleanup failed after safe scope was established."
@@ -92,7 +92,7 @@ describe("resource provider cleanup contract", () => {
       throw new Error("Expected cleanupResource to be defined.");
     }
 
-    const cleanup = resourceProvider.cleanupResource({
+    const cleanup = await resourceProvider.cleanupResource({
       resource: {
         name: "primary-db",
         provider: "test-resource-provider-with-cleanup",

--- a/tests/contracts/resource-provider.name-scoped.contract.test.ts
+++ b/tests/contracts/resource-provider.name-scoped.contract.test.ts
@@ -80,11 +80,11 @@ describe("resource provider contract: name-scoped reset", () => {
     expect(provider.capabilities?.reset).toBe(true);
   });
 
-  it("returns a ResourceReset for valid input", () => {
+  it("returns a ResourceReset for valid input", async () => {
     expect(provider.resetResource).toBeDefined();
     if (!provider.resetResource) return;
 
-    const result = provider.resetResource({
+    const result = await provider.resetResource({
       resource: resourceInput,
       derived,
       worktree: { id: "feature-login" }
@@ -121,11 +121,11 @@ describe("resource provider contract: name-scoped cleanup", () => {
     expect(provider.capabilities?.cleanup).toBe(true);
   });
 
-  it("returns a ResourceCleanup for valid input", () => {
+  it("returns a ResourceCleanup for valid input", async () => {
     expect(provider.cleanupResource).toBeDefined();
     if (!provider.cleanupResource) return;
 
-    const result = provider.cleanupResource({
+    const result = await provider.cleanupResource({
       resource: resourceInput,
       derived,
       worktree: { id: "feature-login" }

--- a/tests/contracts/resource-provider.path-scoped.contract.test.ts
+++ b/tests/contracts/resource-provider.path-scoped.contract.test.ts
@@ -81,11 +81,11 @@ describe("resource provider contract: path-scoped reset", () => {
     expect(provider.capabilities?.reset).toBe(true);
   });
 
-  it("returns a ResourceReset for valid input", () => {
+  it("returns a ResourceReset for valid input", async () => {
     expect(provider.resetResource).toBeDefined();
     if (!provider.resetResource) return;
 
-    const result = provider.resetResource({
+    const result = await provider.resetResource({
       resource: resourceInput,
       derived,
       worktree: { id: "feature-login" }
@@ -122,11 +122,11 @@ describe("resource provider contract: path-scoped cleanup", () => {
     expect(provider.capabilities?.cleanup).toBe(true);
   });
 
-  it("returns a ResourceCleanup for valid input", () => {
+  it("returns a ResourceCleanup for valid input", async () => {
     expect(provider.cleanupResource).toBeDefined();
     if (!provider.cleanupResource) return;
 
-    const result = provider.cleanupResource({
+    const result = await provider.cleanupResource({
       resource: resourceInput,
       derived,
       worktree: { id: "feature-login" }

--- a/tests/contracts/resource-provider.refusal.contract.test.ts
+++ b/tests/contracts/resource-provider.refusal.contract.test.ts
@@ -44,7 +44,7 @@ describe("resource provider refusal contract", () => {
     });
   });
 
-  it("may refuse reset with provider failure distinctly from unsafe scope", () => {
+  it("may refuse reset with provider failure distinctly from unsafe scope", async () => {
     const providers = createProvidersWithResourceResetRefusal({
       category: "provider_failure",
       reason: "Provider reset failed after safe scope was established."
@@ -55,7 +55,7 @@ describe("resource provider refusal contract", () => {
       throw new Error("Expected resetResource to be defined.");
     }
 
-    const reset = resourceProvider.resetResource({
+    const reset = await resourceProvider.resetResource({
       resource: {
         name: "primary-db",
         provider: "test-resource-provider-with-reset",

--- a/tests/contracts/resource-provider.reset.contract.test.ts
+++ b/tests/contracts/resource-provider.reset.contract.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import { createExplicitTestProviders } from "@multiverse/providers-testkit";
 
 describe("resource provider reset contract", () => {
-  it("declares reset support explicitly and resets one worktree instance", () => {
+  it("declares reset support explicitly and resets one worktree instance", async () => {
     const providers = createExplicitTestProviders();
     const resourceProvider = providers.resources["test-resource-provider-with-reset"];
 
@@ -15,7 +15,7 @@ describe("resource provider reset contract", () => {
       throw new Error("Expected resetResource to be defined.");
     }
 
-    const reset = resourceProvider.resetResource({
+    const reset = await resourceProvider.resetResource({
       resource: {
         name: "primary-db",
         provider: "test-resource-provider-with-reset",
@@ -44,7 +44,7 @@ describe("resource provider reset contract", () => {
     });
   });
 
-  it("refuses reset when provider-level scope safety cannot be established", () => {
+  it("refuses reset when provider-level scope safety cannot be established", async () => {
     const providers = createExplicitTestProviders();
     const resourceProvider = providers.resources["test-resource-provider-with-reset"];
 
@@ -52,7 +52,7 @@ describe("resource provider reset contract", () => {
       throw new Error("Expected resetResource to be defined.");
     }
 
-    const reset = resourceProvider.resetResource({
+    const reset = await resourceProvider.resetResource({
       resource: {
         name: "primary-db",
         provider: "test-resource-provider-with-reset",

--- a/tests/integration/sample-express.integration.test.ts
+++ b/tests/integration/sample-express.integration.test.ts
@@ -9,18 +9,17 @@
  *   2. State written through one worktree's server does not appear in the
  *      other worktree's server (runtime isolation).
  *   3. Both instances can run simultaneously without interference.
- *   4. Reset returns the correct resource handle for the target worktree
- *      only, and applying it clears that worktree's state without touching
- *      the other.
- *   5. Cleanup returns the correct resource handle for the target worktree
- *      only, and applying it removes that worktree's data file without
- *      touching the other.
+ *   4. Reset actually deletes the worktree's data file so the app starts
+ *      fresh, without touching the other worktree.
+ *   5. Cleanup actually deletes the worktree's data file, without touching
+ *      the other worktree's file.
  */
 
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
-import { rm, access } from "node:fs/promises";
+import { access } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { rm } from "node:fs/promises";
 
 import { deriveOne, resetOneResource, cleanupOneResource } from "@multiverse/core";
 import { createPathScopedProvider } from "@multiverse/provider-path-scoped";
@@ -214,8 +213,8 @@ describe("sample-express integration", () => {
 
   // -------------------------------------------------------------------------
   describe("lifecycle: reset", () => {
-    it("reset returns a successful result for a worktree with scopedReset declared", () => {
-      const result = resetOneResource({
+    it("reset returns a successful result for a worktree with scopedReset declared", async () => {
+      const result = await resetOneResource({
         repository,
         worktree: { id: "wt-int-a" },
         providers
@@ -229,8 +228,8 @@ describe("sample-express integration", () => {
       expect(result.resourceResets[0].worktreeId).toBe("wt-int-a");
     });
 
-    it("reset returns the same handle that was derived for that worktree", () => {
-      const result = resetOneResource({
+    it("reset returns the same handle that was derived for that worktree", async () => {
+      const result = await resetOneResource({
         repository,
         worktree: { id: "wt-int-a" },
         providers
@@ -242,9 +241,9 @@ describe("sample-express integration", () => {
       expect(result.resourcePlans[0].handle).toBe(dbPathA);
     });
 
-    it("reset handle for A and reset handle for B are different", () => {
-      const resultA = resetOneResource({ repository, worktree: { id: "wt-int-a" }, providers });
-      const resultB = resetOneResource({ repository, worktree: { id: "wt-int-b" }, providers });
+    it("reset handle for A and reset handle for B are different", async () => {
+      const resultA = await resetOneResource({ repository, worktree: { id: "wt-int-a" }, providers });
+      const resultB = await resetOneResource({ repository, worktree: { id: "wt-int-b" }, providers });
 
       expect(resultA.ok && resultB.ok).toBe(true);
       if (!resultA.ok || !resultB.ok) return;
@@ -252,21 +251,15 @@ describe("sample-express integration", () => {
       expect(resultA.resourcePlans[0].handle).not.toBe(resultB.resourcePlans[0].handle);
     });
 
-    it("resetting A's resource clears A's state and leaves B's state intact", async () => {
+    it("resetting A's resource deletes A's data file and leaves B's state intact", async () => {
       await postItem(addrA, "before-reset-a");
       await postItem(addrB, "stays-in-b");
 
-      // Get the confirmed handle from multiverse reset
-      const result = resetOneResource({ repository, worktree: { id: "wt-int-a" }, providers });
+      // resetOneResource now actually deletes A's file on disk
+      const result = await resetOneResource({ repository, worktree: { id: "wt-int-a" }, providers });
       expect(result.ok).toBe(true);
-      if (!result.ok) return;
 
-      // The app manager uses the confirmed handle to clear A's resource.
-      // Here the test acts as the app manager: it clears A's state via the
-      // server's management endpoint (which writes an empty store to the
-      // confirmed file path — the same path multiverse just confirmed).
-      await clearItems(addrA);
-
+      // A's file is gone — server returns empty store on next read
       const itemsA = await getItems(addrA);
       const itemsB = await getItems(addrB);
 
@@ -278,8 +271,8 @@ describe("sample-express integration", () => {
 
   // -------------------------------------------------------------------------
   describe("lifecycle: cleanup", () => {
-    it("cleanup returns a successful result for a worktree with scopedCleanup declared", () => {
-      const result = cleanupOneResource({
+    it("cleanup returns a successful result for a worktree with scopedCleanup declared", async () => {
+      const result = await cleanupOneResource({
         repository,
         worktree: { id: "wt-int-a" },
         providers
@@ -293,8 +286,8 @@ describe("sample-express integration", () => {
       expect(result.resourceCleanups[0].worktreeId).toBe("wt-int-a");
     });
 
-    it("cleanup returns the same handle that was derived for that worktree", () => {
-      const result = cleanupOneResource({
+    it("cleanup returns the same handle that was derived for that worktree", async () => {
+      const result = await cleanupOneResource({
         repository,
         worktree: { id: "wt-int-a" },
         providers
@@ -306,9 +299,9 @@ describe("sample-express integration", () => {
       expect(result.resourcePlans[0].handle).toBe(dbPathA);
     });
 
-    it("cleanup handle for A and cleanup handle for B are different", () => {
-      const resultA = cleanupOneResource({ repository, worktree: { id: "wt-int-a" }, providers });
-      const resultB = cleanupOneResource({ repository, worktree: { id: "wt-int-b" }, providers });
+    it("cleanup handle for A and cleanup handle for B are different", async () => {
+      const resultA = await cleanupOneResource({ repository, worktree: { id: "wt-int-a" }, providers });
+      const resultB = await cleanupOneResource({ repository, worktree: { id: "wt-int-b" }, providers });
 
       expect(resultA.ok && resultB.ok).toBe(true);
       if (!resultA.ok || !resultB.ok) return;
@@ -316,7 +309,7 @@ describe("sample-express integration", () => {
       expect(resultA.resourcePlans[0].handle).not.toBe(resultB.resourcePlans[0].handle);
     });
 
-    it("removing A's data file via the confirmed handle does not affect B's data file", async () => {
+    it("cleaning up A's resource deletes A's data file without affecting B's data file", async () => {
       // Write data to both — ensures both files exist on disk
       await postItem(addrA, "will-be-cleaned");
       await postItem(addrB, "survives-cleanup");
@@ -324,16 +317,9 @@ describe("sample-express integration", () => {
       expect(await fileExists(dbPathA)).toBe(true);
       expect(await fileExists(dbPathB)).toBe(true);
 
-      // Get cleanup confirmation from multiverse — it tells us A's path
-      const result = cleanupOneResource({ repository, worktree: { id: "wt-int-a" }, providers });
+      // cleanupOneResource now actually deletes A's file on disk
+      const result = await cleanupOneResource({ repository, worktree: { id: "wt-int-a" }, providers });
       expect(result.ok).toBe(true);
-      if (!result.ok) return;
-
-      const confirmedPath = result.resourcePlans[0].handle;
-      expect(confirmedPath).toBe(dbPathA);
-
-      // App manager deletes the confirmed file (simulating real cleanup)
-      await rm(confirmedPath, { force: true });
 
       // A's file is gone; B's file is untouched
       expect(await fileExists(dbPathA)).toBe(false);


### PR DESCRIPTION
## Summary
Implement actual destructive reset and cleanup behavior for the path-scoped provider and propagate async lifecycle support through the core and CLI seams.

## Scope
- make resource provider reset/cleanup operations async across contracts, core, CLI, and testkit
- perform real filesystem deletion in the path-scoped provider for reset and cleanup
- update acceptance, contract, and integration tests to await lifecycle operations and verify destructive behavior

## Validation
- scripts/codex-env.sh pnpm typecheck
- scripts/codex-env.sh pnpm test
- scripts/codex-env.sh pnpm test:integration -- --run tests/integration/sample-express.integration.test.ts

## Deferred
- issue #56 (--format=env) not started; no repo markdown task/spec grounding found yet