### PR TITLE
Add --format=env flag to derive CLI command

### DIFF
--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -12,6 +12,7 @@ import {
   validateWorktreeIdentity
 } from "@multiverse/core";
 import type {
+  DeriveOneResult,
   ProviderRegistry,
   RepositoryConfiguration
 } from "@multiverse/provider-contracts";
@@ -44,6 +45,21 @@ function failure(value: unknown): CliResult {
     stdout: [JSON.stringify(value)],
     stderr: []
   };
+}
+
+function toEnvKey(prefix: string, name: string): string {
+  return `${prefix}_${name.toUpperCase().replace(/-/g, "_")}`;
+}
+
+function formatEnv(result: Extract<DeriveOneResult, { ok: true }>): CliResult {
+  const lines: string[] = [];
+  for (const plan of result.resourcePlans) {
+    lines.push(`${toEnvKey("MULTIVERSE_RESOURCE", plan.resourceName)}=${plan.handle}`);
+  }
+  for (const mapping of result.endpointMappings) {
+    lines.push(`${toEnvKey("MULTIVERSE_ENDPOINT", mapping.endpointName)}=${mapping.address}`);
+  }
+  return { exitCode: 0, stdout: lines, stderr: [] };
 }
 
 function usage(message: string): CliResult {
@@ -122,15 +138,15 @@ async function loadProviderRegistry(
   return candidate;
 }
 
-async function deriveFromFiles(input: {
+async function executeDeriveOperation(input: {
   configPath: string;
   worktreeId: string;
   providersModulePath: string;
-}): Promise<CliResult> {
-  return executeOperationFromFiles({
-    ...input,
-    operation: deriveOne
-  });
+}): Promise<DeriveOneResult | CliResult> {
+  const parsed = await readRepositoryConfiguration(input.configPath);
+  const providers = await loadProviderRegistry(input.providersModulePath);
+  if (isCliResult(providers)) return providers;
+  return deriveOne({ repository: parsed, worktree: { id: input.worktreeId }, providers });
 }
 
 async function validateFromFiles(input: {
@@ -236,11 +252,17 @@ async function handleDerive(args: string[]): Promise<CliResult> {
     return providersModulePath;
   }
 
-  return deriveFromFiles({
-    configPath,
-    worktreeId,
-    providersModulePath
-  });
+  const format = readOption(args, "--format") ?? "json";
+  if (format !== "json" && format !== "env") {
+    return usage(`Unknown --format value "${format}". Supported values: json, env`);
+  }
+
+  const result = await executeDeriveOperation({ configPath, worktreeId, providersModulePath });
+  if (isCliResult(result)) return result;
+
+  if (!result.ok) return failure(result);
+  if (format === "env") return formatEnv(result);
+  return success(result);
 }
 
 async function handleValidate(args: string[]): Promise<CliResult> {

--- a/tests/acceptance/cli-derive-env-format.acceptance.test.ts
+++ b/tests/acceptance/cli-derive-env-format.acceptance.test.ts
@@ -1,0 +1,214 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { runCli } from "../../apps/cli/src/index";
+
+describe("CLI derive --format=env", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(
+      tempDirs.map((dir) => rm(dir, { recursive: true, force: true }))
+    );
+    tempDirs.length = 0;
+  });
+
+  const providersModulePath = fileURLToPath(
+    new URL("./fixtures/explicit-test-providers.ts", import.meta.url)
+  );
+
+  async function writeRepositoryConfig(config: unknown): Promise<string> {
+    const tempDir = await mkdtemp(path.join(tmpdir(), "multiverse-cli-env-"));
+    tempDirs.push(tempDir);
+    const configPath = path.join(tempDir, "repository.json");
+    await writeFile(configPath, JSON.stringify(config));
+    return configPath;
+  }
+
+  const baseConfig = {
+    resources: [
+      {
+        name: "primary-db",
+        provider: "test-resource-provider",
+        isolationStrategy: "name-scoped",
+        scopedValidate: false,
+        scopedReset: false,
+        scopedCleanup: false
+      }
+    ],
+    endpoints: [
+      {
+        name: "app-base-url",
+        role: "application-base-url",
+        provider: "test-endpoint-provider"
+      }
+    ]
+  };
+
+  it("emits KEY=VALUE pairs when --format=env is specified", async () => {
+    const configPath = await writeRepositoryConfig(baseConfig);
+
+    const outcome = await runCli([
+      "derive",
+      "--config",
+      configPath,
+      "--worktree-id",
+      "wt-env-test",
+      "--providers",
+      providersModulePath,
+      "--format",
+      "env"
+    ]);
+
+    expect(outcome.exitCode).toBe(0);
+    expect(outcome.stderr).toEqual([]);
+    expect(outcome.stdout).toContain("MULTIVERSE_RESOURCE_PRIMARY_DB=primary-db--wt-env-test");
+    expect(outcome.stdout).toContain("MULTIVERSE_ENDPOINT_APP_BASE_URL=http://wt-env-test.local/app-base-url");
+  });
+
+  it("emits JSON when --format=json is specified (no regression)", async () => {
+    const configPath = await writeRepositoryConfig(baseConfig);
+
+    const outcome = await runCli([
+      "derive",
+      "--config",
+      configPath,
+      "--worktree-id",
+      "wt-json-test",
+      "--providers",
+      providersModulePath,
+      "--format",
+      "json"
+    ]);
+
+    expect(outcome.exitCode).toBe(0);
+    expect(outcome.stderr).toEqual([]);
+    expect(outcome.stdout).toHaveLength(1);
+    const parsed = JSON.parse(outcome.stdout[0]!);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.resourcePlans).toBeDefined();
+    expect(parsed.endpointMappings).toBeDefined();
+  });
+
+  it("emits JSON when no --format is specified (default behavior unchanged)", async () => {
+    const configPath = await writeRepositoryConfig(baseConfig);
+
+    const outcome = await runCli([
+      "derive",
+      "--config",
+      configPath,
+      "--worktree-id",
+      "wt-default-test",
+      "--providers",
+      providersModulePath
+    ]);
+
+    expect(outcome.exitCode).toBe(0);
+    expect(outcome.stderr).toEqual([]);
+    expect(outcome.stdout).toHaveLength(1);
+    const parsed = JSON.parse(outcome.stdout[0]!);
+    expect(parsed.ok).toBe(true);
+  });
+
+  it("exits non-zero with usage error when --format is an unknown value", async () => {
+    const configPath = await writeRepositoryConfig(baseConfig);
+
+    const outcome = await runCli([
+      "derive",
+      "--config",
+      configPath,
+      "--worktree-id",
+      "wt-bad-format",
+      "--providers",
+      providersModulePath,
+      "--format",
+      "xml"
+    ]);
+
+    expect(outcome.exitCode).toBe(1);
+    expect(outcome.stdout).toEqual([]);
+    expect(outcome.stderr[0]).toMatch(/unknown.*format/i);
+  });
+
+  it("emits refusal as JSON to stdout and exits non-zero when derive fails with --format=env", async () => {
+    const configPath = await writeRepositoryConfig({
+      resources: [
+        {
+          name: "primary-db",
+          provider: "test-resource-provider",
+          isolationStrategy: "name-scoped",
+          scopedValidate: false,
+          scopedReset: false,
+          scopedCleanup: false
+        }
+      ],
+      endpoints: [
+        {
+          name: "app-base-url",
+          role: "application-base-url",
+          provider: "test-endpoint-provider"
+        }
+      ]
+    });
+
+    const outcome = await runCli([
+      "derive",
+      "--config",
+      configPath,
+      "--worktree-id",
+      "",
+      "--providers",
+      providersModulePath,
+      "--format",
+      "env"
+    ]);
+
+    expect(outcome.exitCode).toBe(1);
+    expect(outcome.stderr).toEqual([]);
+    const parsed = JSON.parse(outcome.stdout[0]!);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.refusal).toBeDefined();
+  });
+
+  it("uses deterministic uppercase key names with underscores for hyphenated resource names", async () => {
+    const configPath = await writeRepositoryConfig({
+      resources: [
+        {
+          name: "my-primary-db",
+          provider: "test-resource-provider",
+          isolationStrategy: "name-scoped",
+          scopedValidate: false,
+          scopedReset: false,
+          scopedCleanup: false
+        }
+      ],
+      endpoints: [
+        {
+          name: "admin-api-url",
+          role: "admin-base-url",
+          provider: "test-endpoint-provider"
+        }
+      ]
+    });
+
+    const outcome = await runCli([
+      "derive",
+      "--config",
+      configPath,
+      "--worktree-id",
+      "wt-naming",
+      "--providers",
+      providersModulePath,
+      "--format",
+      "env"
+    ]);
+
+    expect(outcome.exitCode).toBe(0);
+    expect(outcome.stdout).toContain("MULTIVERSE_RESOURCE_MY_PRIMARY_DB=my-primary-db--wt-naming");
+    expect(outcome.stdout).toContain("MULTIVERSE_ENDPOINT_ADMIN_API_URL=http://wt-naming.local/admin-api-url");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `--format=env` to the `derive` CLI command, emitting `KEY=VALUE` pairs suitable for `eval` or `env -S` shell injection
- Key convention: `MULTIVERSE_RESOURCE_<NAME>=<handle>` and `MULTIVERSE_ENDPOINT_<NAME>=<address>` (uppercased, hyphens → underscores)
- `--format=json` (or no flag) continues to emit JSON — no regression
- Unknown format values exit non-zero with a usage error
- Refusal results still emit JSON to stdout and exit non-zero regardless of format

## Scope

- `apps/cli/src/index.ts` — `--format` option parsing, `toEnvKey` helper, `formatEnv` formatter
- `tests/acceptance/cli-derive-env-format.acceptance.test.ts` — 6 new acceptance tests

## Validation

- `pnpm tsc --noEmit` — clean
- `pnpm vitest run` — 156/156 tests passing

## Deferred

- `--format=env` not added to `validate`, `reset`, `cleanup` (out of scope per issue)

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)