### PR TITLE
Add Phase 1 ADRs: multiverse run, env naming, conventional defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ That includes:
 
   * name-scoped reset/cleanup as scope confirmation only
   * path-scoped reset/cleanup as effectful operations for provider-managed filesystem state
+* `derive --format=env` for shell-sourceable KEY=VALUE output
+* sample Express application end-to-end integration proof
 
 ## Design principles
 
@@ -121,6 +123,28 @@ pnpm test:unit
 pnpm typecheck
 pnpm cli
 ```
+
+## CLI usage
+
+```bash
+# Derive isolated values as JSON (explicit paths)
+multiverse derive --config multiverse.json --providers providers.ts --worktree-id <id>
+
+# Derive as shell-sourceable KEY=VALUE pairs
+multiverse derive --config multiverse.json --providers providers.ts --worktree-id <id> --format=env
+
+# Run a command with derived values injected as env vars
+multiverse run --worktree-id <id> -- node server.js
+
+# Validate derived values against running resources
+multiverse validate --worktree-id <id> -- ...
+
+# Reset or clean up isolated state
+multiverse reset --worktree-id <id>
+multiverse cleanup --worktree-id <id>
+```
+
+`--config` defaults to `./multiverse.json` and `--providers` defaults to `./providers.ts` when not specified. `--worktree-id` is always required.
 
 ## Source-of-truth order
 

--- a/docs/adr/0012-explicit-process-wrapper-run.md
+++ b/docs/adr/0012-explicit-process-wrapper-run.md
@@ -1,0 +1,68 @@
+# ADR-0012: Explicit process wrapper — `multiverse run`
+
+## Status
+
+Accepted
+
+## Context
+
+After deriving isolated runtime values, a consumer must manually extract those values and inject them into their process environment. This is friction: the consumer reads JSON output, copies values, and re-injects them as environment variables before starting their application.
+
+The natural solution is a direct process wrapper that derives values and launches the consumer's command with those values already injected as environment variables. This eliminates the copy/paste loop entirely.
+
+However, a process wrapper risks scope creep toward general orchestration. The design must preserve explicit boundaries.
+
+## Decision
+
+Introduce a `run` subcommand to the CLI with the following semantics:
+
+```
+multiverse run [--config PATH] [--providers MODULE] --worktree-id VALUE -- <cmd> [args...]
+```
+
+Everything after `--` is the user-supplied command and arguments. Multiverse does not interpret it.
+
+### Behavior
+
+1. Derive isolated values by calling the existing `deriveOne` path with the supplied configuration, providers, and worktree identity.
+2. If derivation fails (any refusal): write the refusal JSON to **stderr**, exit non-zero. The child process is never started.
+3. If derivation succeeds: inject the derived values as environment variables into the child process environment, spawn the child, inherit its stdio streams, and propagate its exit code.
+
+### Environment variable injection
+
+The injected variables follow the runtime env naming convention defined in ADR-0013:
+
+- `MULTIVERSE_WORKTREE_ID` — the worktree identity used for derivation
+- `MULTIVERSE_RESOURCE_<NAME>` — the derived handle for each declared resource
+- `MULTIVERSE_ENDPOINT_<NAME>` — the derived address for each declared endpoint
+
+The child process environment is the parent's current environment extended with the Multiverse-injected variables. Multiverse does not sanitize or restrict the parent environment.
+
+### Explicit boundaries
+
+`multiverse run` must not:
+
+- infer what command to run
+- start or manage long-running background processes as a supervisor
+- restart the child process on failure
+- watch for file changes and re-run
+- inject values not derived through the explicit derivation path
+- mutate the current shell's environment
+- accept a format flag (output goes to the child, not to stdout)
+
+These responsibilities belong to external tools, not to Multiverse.
+
+## Consequences
+
+- Consumers can start their application with isolated values without any manual copy/paste
+- The command is fully explicit: the user supplies the config, providers, worktree identity, and command
+- Refusal semantics remain intact — the child never starts if derivation is refused
+- Stdio pass-through means the child's output appears naturally in the terminal
+- Exit code propagation means the caller can detect child failure normally
+
+## Out of scope
+
+- Process supervision or restart behavior
+- Port extraction from endpoint addresses (reserved for a future ADR if needed)
+- Watching or reacting to application lifecycle events
+- Managed process registries

--- a/docs/adr/0013-runtime-env-variable-naming.md
+++ b/docs/adr/0013-runtime-env-variable-naming.md
@@ -1,0 +1,73 @@
+# ADR-0013: Runtime environment variable naming convention
+
+## Status
+
+Accepted
+
+## Context
+
+When Multiverse injects derived values into a child process (via `multiverse run`) or emits them as shell-sourceable output (via `derive --format=env`), the variable names must be deterministic and consistent across both paths.
+
+An ad-hoc naming scheme creates friction for consumers who need to know what variable names to expect before they can write their application configuration.
+
+A documented convention removes that uncertainty and makes the contract stable enough to depend on.
+
+## Decision
+
+All Multiverse-injected environment variables use the `MULTIVERSE_` prefix followed by a category and a normalized name.
+
+### Name normalization rule
+
+A declared name (resource name or endpoint name) is normalized to an env key segment by:
+
+1. Converting to uppercase
+2. Replacing all hyphens (`-`) with underscores (`_`)
+
+Example: `primary-db` → `PRIMARY_DB`, `app-base-url` → `APP_BASE_URL`.
+
+### Variable categories
+
+#### Worktree identity
+
+```
+MULTIVERSE_WORKTREE_ID=<worktreeId>
+```
+
+The exact worktree identity value used for the current derivation.
+
+#### Resource handles
+
+```
+MULTIVERSE_RESOURCE_<NAME>=<handle>
+```
+
+Where `<NAME>` is the normalized declared resource name and `<handle>` is the provider-derived isolation handle (e.g., a namespaced database name or a scoped filesystem path).
+
+#### Endpoint addresses
+
+```
+MULTIVERSE_ENDPOINT_<NAME>=<address>
+```
+
+Where `<NAME>` is the normalized declared endpoint name and `<address>` is the provider-derived full address string (e.g., `http://localhost:3001`).
+
+### Consistency requirement
+
+The same normalization rule and category prefixes apply in both:
+
+- `multiverse run` env injection (ADR-0012)
+- `multiverse derive --format=env` output
+
+The two paths must emit identical variable names for the same declared objects.
+
+## Consequences
+
+- Consumers can predict variable names from their `multiverse.json` declaration without running the tool first
+- Both `run` and `derive --format=env` produce identical variable name shapes
+- The convention is unambiguous: the normalization rule is deterministic and documented
+- There is no ambiguity for names containing numbers, multiple hyphens, or mixed case — the rule applies uniformly
+
+## Out of scope for 1.0
+
+- Port extraction variables (e.g., `MULTIVERSE_ENDPOINT_<NAME>_PORT`) — reserved for a future ADR when the provider model supports structured address decomposition
+- Variables derived from provider-specific metadata beyond handle and address

--- a/docs/adr/0014-strict-conventional-defaults.md
+++ b/docs/adr/0014-strict-conventional-defaults.md
@@ -1,0 +1,52 @@
+# ADR-0014: Strict conventional defaults for common CLI options
+
+## Status
+
+Accepted
+
+## Context
+
+Every Multiverse CLI command that operates on a repository configuration and a providers module requires `--config` and `--providers` to be specified explicitly. For the common case — working in the root of a repository that already has the conventional files in place — this is repetitive ceremony without information value.
+
+Strict conventional defaults reduce that ceremony while keeping the tool explicit and inspectable. The key constraint is that defaults must be strict and documented, not magical or inferred.
+
+## Decision
+
+The following CLI options adopt documented conventional defaults:
+
+| Option | Conventional default |
+|---|---|
+| `--config` | `./multiverse.json` (resolved relative to the current working directory) |
+| `--providers` | `./providers.ts` (resolved relative to the current working directory) |
+
+These defaults apply to all commands that accept these options: `derive`, `validate`, `reset`, `cleanup`, and `run`.
+
+### Behavior when the default path does not exist
+
+If a default path is used and the file does not exist, the command fails with the same file-read error it would produce if the user had specified that path explicitly. There is no special handling or fallback.
+
+### `--worktree-id` remains required
+
+Worktree identity is not defaulted, inferred, or auto-detected. The caller must always supply `--worktree-id` explicitly.
+
+Defaulting the worktree identity would be inference, which violates the hard constraint that Multiverse must not infer managed-object scope.
+
+### Inspectability
+
+The convention is visible and documented. When a consumer omits `--config` or `--providers`, they can reason about what file was used without reading Multiverse source code.
+
+## Consequences
+
+- Common invocations become materially shorter
+- The convention is the same across all commands — no per-command surprises
+- The tool remains explicit: defaults are visible in documentation, not hidden behind magic discovery
+- `--worktree-id` staying required preserves the safety boundary from ADR-0008
+
+## What this is not
+
+Conventional defaults are not:
+
+- auto-detection (no filesystem scanning beyond the single conventional path)
+- inference of configuration from project structure
+- fallback chains across multiple candidate paths
+- worktree identity resolution from git state

--- a/docs/development/implementation-strategy.md
+++ b/docs/development/implementation-strategy.md
@@ -123,7 +123,21 @@ Current `main` includes implemented slices covering:
 - explicit capability-intent refusal behavior
 - refusal propagation from providers
 - explicit reset and cleanup core paths
-- thin CLI validation plus explicit provider-wired derive, reset, and cleanup commands
+- thin CLI with derive, validate, reset, cleanup, and validate-repository commands
+- multi-resource and multi-endpoint support across all core paths
+- path-scoped provider with effectful reset and cleanup (filesystem state)
+- name-scoped provider with scope-confirmation reset and cleanup
+- local-port endpoint provider
+- sample Express application for end-to-end integration proof
+- CI pipeline with acceptance, contract, unit, and integration test jobs
+- `derive --format=env` for shell-sourceable KEY=VALUE output
+
+Phase 1 work in progress (targeting 0.2.x):
+
+- ADR-0012: explicit process wrapper (`multiverse run`)
+- ADR-0013: runtime env variable naming convention
+- ADR-0014: strict conventional defaults for `--config` and `--providers`
+- Implementation of `multiverse run` and conventional defaults
 
 The purpose of this document is still to preserve implementation posture and first-phase boundaries, not to serve as the complete change log for every later slice.
 


### PR DESCRIPTION
## Summary

- ADR-0012: Explicit process wrapper (`multiverse run`) — defines child-process execution semantics, env injection, and explicit boundaries
- ADR-0013: Runtime env variable naming convention — formalizes `MULTIVERSE_WORKTREE_ID`, `MULTIVERSE_RESOURCE_<NAME>`, `MULTIVERSE_ENDPOINT_<NAME>` as the stable contract
- ADR-0014: Strict conventional defaults — `--config` → `./multiverse.json`, `--providers` → `./providers.ts`; `--worktree-id` stays required

## Scope

- `docs/adr/` — three new ADRs
- `docs/development/implementation-strategy.md` — updated current progress note for Phase 1
- `README.md` — CLI usage section, updated behavior inventory

## Validation

Docs-only change. No production code or tests changed.

## Notes

These ADRs establish the business truth for the next implementation branch, which will implement `multiverse run` and conventional defaults with full TDD coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)