### PR TITLE
Implement multiverse run and conventional defaults

### DIFF
--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -23,6 +23,17 @@ export interface CliResult {
   stderr: string[];
 }
 
+export type ChildProcessRunner = (input: {
+  cmd: string;
+  args: string[];
+  env: Record<string, string>;
+}) => Promise<{ exitCode: number }>;
+
+export interface RunCliOptions {
+  cwd?: string;
+  runner?: ChildProcessRunner;
+}
+
 function isCliResult(value: unknown): value is CliResult {
   return (
     typeof value === "object" &&
@@ -47,6 +58,14 @@ function failure(value: unknown): CliResult {
   };
 }
 
+function runFailure(value: unknown): CliResult {
+  return {
+    exitCode: 1,
+    stdout: [],
+    stderr: [JSON.stringify(value)]
+  };
+}
+
 function toEnvKey(prefix: string, name: string): string {
   return `${prefix}_${name.toUpperCase().replace(/-/g, "_")}`;
 }
@@ -60,6 +79,21 @@ function formatEnv(result: Extract<DeriveOneResult, { ok: true }>): CliResult {
     lines.push(`${toEnvKey("MULTIVERSE_ENDPOINT", mapping.endpointName)}=${mapping.address}`);
   }
   return { exitCode: 0, stdout: lines, stderr: [] };
+}
+
+function buildRunEnv(
+  worktreeId: string,
+  result: Extract<DeriveOneResult, { ok: true }>
+): Record<string, string> {
+  const env: Record<string, string> = {};
+  env["MULTIVERSE_WORKTREE_ID"] = worktreeId;
+  for (const plan of result.resourcePlans) {
+    env[toEnvKey("MULTIVERSE_RESOURCE", plan.resourceName)] = plan.handle;
+  }
+  for (const mapping of result.endpointMappings) {
+    env[toEnvKey("MULTIVERSE_ENDPOINT", mapping.endpointName)] = mapping.address;
+  }
+  return env;
 }
 
 function usage(message: string): CliResult {
@@ -92,18 +126,38 @@ function readRequiredOption(
   return value;
 }
 
+interface CommonOptions {
+  configPath: string;
+  worktreeId: string;
+  providersModulePath: string;
+}
+
+function readCommonOptions(args: string[], cwd: string): CommonOptions | CliResult {
+  const worktreeId = readRequiredOption(args, "--worktree-id");
+  if (isCliResult(worktreeId)) return worktreeId;
+  return {
+    configPath: readOption(args, "--config") ?? path.resolve(cwd, "multiverse.json"),
+    worktreeId,
+    providersModulePath: readOption(args, "--providers") ?? path.resolve(cwd, "providers.ts")
+  };
+}
+
 async function validateRepositoryFromFile(configPath: string): Promise<CliResult> {
   const parsed = await readRepositoryConfiguration(configPath);
+  if (isCliResult(parsed)) return parsed;
   const result = validateRepositoryConfiguration(parsed);
-
   return result.ok ? success(result) : failure(result);
 }
 
 async function readRepositoryConfiguration(
   configPath: string
-): Promise<RepositoryConfiguration> {
-  const raw = await readFile(configPath, "utf8");
-  return JSON.parse(raw) as RepositoryConfiguration;
+): Promise<RepositoryConfiguration | CliResult> {
+  try {
+    const raw = await readFile(configPath, "utf8");
+    return JSON.parse(raw) as RepositoryConfiguration;
+  } catch {
+    return usage(`Cannot read config file: ${configPath}`);
+  }
 }
 
 function isProviderRegistry(value: unknown): value is ProviderRegistry {
@@ -122,11 +176,14 @@ function isProviderRegistry(value: unknown): value is ProviderRegistry {
 async function loadProviderRegistry(
   providersModulePath: string
 ): Promise<ProviderRegistry | CliResult> {
-  const moduleUrl = pathToFileURL(path.resolve(providersModulePath)).href;
-  const moduleExports = (await import(moduleUrl)) as {
-    default?: unknown;
-    providers?: unknown;
-  };
+  let moduleExports: { default?: unknown; providers?: unknown };
+  try {
+    const moduleUrl = pathToFileURL(path.resolve(providersModulePath)).href;
+    moduleExports = (await import(moduleUrl)) as { default?: unknown; providers?: unknown };
+  } catch {
+    return usage(`Cannot load providers module: ${providersModulePath}`);
+  }
+
   const candidate = moduleExports.providers ?? moduleExports.default;
 
   if (!isProviderRegistry(candidate)) {
@@ -144,6 +201,7 @@ async function executeDeriveOperation(input: {
   providersModulePath: string;
 }): Promise<DeriveOneResult | CliResult> {
   const parsed = await readRepositoryConfiguration(input.configPath);
+  if (isCliResult(parsed)) return parsed;
   const providers = await loadProviderRegistry(input.providersModulePath);
   if (isCliResult(providers)) return providers;
   return deriveOne({ repository: parsed, worktree: { id: input.worktreeId }, providers });
@@ -195,6 +253,7 @@ async function executeOperationFromFiles(input: {
   }) => { ok: boolean } | Promise<{ ok: boolean }>;
 }): Promise<CliResult> {
   const parsed = await readRepositoryConfiguration(input.configPath);
+  if (isCliResult(parsed)) return parsed;
   const providers = await loadProviderRegistry(input.providersModulePath);
 
   if ("exitCode" in providers) {
@@ -212,6 +271,21 @@ async function executeOperationFromFiles(input: {
   );
 
   return result.ok ? success(result) : failure(result);
+}
+
+async function defaultChildProcessRunner(input: {
+  cmd: string;
+  args: string[];
+  env: Record<string, string>;
+}): Promise<{ exitCode: number }> {
+  const { spawn } = await import("node:child_process");
+  return new Promise((resolve) => {
+    const child = spawn(input.cmd, input.args, {
+      env: { ...process.env, ...input.env },
+      stdio: "inherit"
+    });
+    child.on("close", (code) => resolve({ exitCode: code ?? 1 }));
+  });
 }
 
 async function handleValidateWorktree(args: string[]): Promise<CliResult> {
@@ -236,28 +310,16 @@ async function handleValidateRepository(args: string[]): Promise<CliResult> {
   return validateRepositoryFromFile(configPath);
 }
 
-async function handleDerive(args: string[]): Promise<CliResult> {
-  const configPath = readRequiredOption(args, "--config");
-  if (isCliResult(configPath)) {
-    return configPath;
-  }
-
-  const worktreeId = readRequiredOption(args, "--worktree-id");
-  if (isCliResult(worktreeId)) {
-    return worktreeId;
-  }
-
-  const providersModulePath = readRequiredOption(args, "--providers");
-  if (isCliResult(providersModulePath)) {
-    return providersModulePath;
-  }
+async function handleDerive(args: string[], cwd: string): Promise<CliResult> {
+  const opts = readCommonOptions(args, cwd);
+  if (isCliResult(opts)) return opts;
 
   const format = readOption(args, "--format") ?? "json";
   if (format !== "json" && format !== "env") {
     return usage(`Unknown --format value "${format}". Supported values: json, env`);
   }
 
-  const result = await executeDeriveOperation({ configPath, worktreeId, providersModulePath });
+  const result = await executeDeriveOperation(opts);
   if (isCliResult(result)) return result;
 
   if (!result.ok) return failure(result);
@@ -265,76 +327,64 @@ async function handleDerive(args: string[]): Promise<CliResult> {
   return success(result);
 }
 
-async function handleValidate(args: string[]): Promise<CliResult> {
-  const configPath = readRequiredOption(args, "--config");
-  if (isCliResult(configPath)) {
-    return configPath;
-  }
-
-  const worktreeId = readRequiredOption(args, "--worktree-id");
-  if (isCliResult(worktreeId)) {
-    return worktreeId;
-  }
-
-  const providersModulePath = readRequiredOption(args, "--providers");
-  if (isCliResult(providersModulePath)) {
-    return providersModulePath;
-  }
-
-  return validateFromFiles({
-    configPath,
-    worktreeId,
-    providersModulePath
-  });
+async function handleValidate(args: string[], cwd: string): Promise<CliResult> {
+  const opts = readCommonOptions(args, cwd);
+  if (isCliResult(opts)) return opts;
+  return validateFromFiles(opts);
 }
 
-async function handleReset(args: string[]): Promise<CliResult> {
-  const configPath = readRequiredOption(args, "--config");
-  if (isCliResult(configPath)) {
-    return configPath;
-  }
-
-  const worktreeId = readRequiredOption(args, "--worktree-id");
-  if (isCliResult(worktreeId)) {
-    return worktreeId;
-  }
-
-  const providersModulePath = readRequiredOption(args, "--providers");
-  if (isCliResult(providersModulePath)) {
-    return providersModulePath;
-  }
-
-  return resetFromFiles({
-    configPath,
-    worktreeId,
-    providersModulePath
-  });
+async function handleReset(args: string[], cwd: string): Promise<CliResult> {
+  const opts = readCommonOptions(args, cwd);
+  if (isCliResult(opts)) return opts;
+  return resetFromFiles(opts);
 }
 
-async function handleCleanup(args: string[]): Promise<CliResult> {
-  const configPath = readRequiredOption(args, "--config");
-  if (isCliResult(configPath)) {
-    return configPath;
-  }
-
-  const worktreeId = readRequiredOption(args, "--worktree-id");
-  if (isCliResult(worktreeId)) {
-    return worktreeId;
-  }
-
-  const providersModulePath = readRequiredOption(args, "--providers");
-  if (isCliResult(providersModulePath)) {
-    return providersModulePath;
-  }
-
-  return cleanupFromFiles({
-    configPath,
-    worktreeId,
-    providersModulePath
-  });
+async function handleCleanup(args: string[], cwd: string): Promise<CliResult> {
+  const opts = readCommonOptions(args, cwd);
+  if (isCliResult(opts)) return opts;
+  return cleanupFromFiles(opts);
 }
 
-export async function runCli(args: string[]): Promise<CliResult> {
+async function handleRun(
+  args: string[],
+  cwd: string,
+  runner: ChildProcessRunner
+): Promise<CliResult> {
+  const opts = readCommonOptions(args, cwd);
+  if (isCliResult(opts)) return opts;
+
+  const { configPath, worktreeId, providersModulePath } = opts;
+  const separatorIndex = args.indexOf("--");
+  if (separatorIndex === -1) {
+    return usage('Missing -- separator. Usage: multiverse run [options] -- <cmd> [args...]');
+  }
+
+  const childArgs = args.slice(separatorIndex + 1);
+  if (childArgs.length === 0) {
+    return usage('No command provided after --. Usage: multiverse run [options] -- <cmd> [args...]');
+  }
+
+  const [cmd, ...restArgs] = childArgs as [string, ...string[]];
+
+  const deriveResult = await executeDeriveOperation({ configPath, worktreeId, providersModulePath });
+  if (isCliResult(deriveResult)) return deriveResult;
+
+  if (!deriveResult.ok) return runFailure(deriveResult);
+
+  const multiverseEnv = buildRunEnv(worktreeId, deriveResult);
+  const mergedEnv: Record<string, string> = {};
+  for (const [k, v] of Object.entries(process.env)) {
+    if (v !== undefined) mergedEnv[k] = v;
+  }
+  Object.assign(mergedEnv, multiverseEnv);
+
+  const { exitCode } = await runner({ cmd, args: restArgs, env: mergedEnv });
+  return { exitCode, stdout: [], stderr: [] };
+}
+
+export async function runCli(args: string[], options: RunCliOptions = {}): Promise<CliResult> {
+  const cwd = options.cwd ?? process.cwd();
+  const runner = options.runner ?? defaultChildProcessRunner;
   const [command] = args;
 
   if (command === "validate-worktree") {
@@ -346,23 +396,27 @@ export async function runCli(args: string[]): Promise<CliResult> {
   }
 
   if (command === "derive") {
-    return handleDerive(args);
+    return handleDerive(args, cwd);
   }
 
   if (command === "validate") {
-    return handleValidate(args);
+    return handleValidate(args, cwd);
   }
 
   if (command === "reset") {
-    return handleReset(args);
+    return handleReset(args, cwd);
   }
 
   if (command === "cleanup") {
-    return handleCleanup(args);
+    return handleCleanup(args, cwd);
+  }
+
+  if (command === "run") {
+    return handleRun(args, cwd, runner);
   }
 
   return usage(
-    "Usage: multiverse <validate-worktree --worktree-id VALUE | validate-repository --config PATH | derive --config PATH --worktree-id VALUE --providers MODULE | validate --config PATH --worktree-id VALUE --providers MODULE | reset --config PATH --worktree-id VALUE --providers MODULE | cleanup --config PATH --worktree-id VALUE --providers MODULE>"
+    "Usage: multiverse <validate-worktree --worktree-id VALUE | validate-repository --config PATH | derive [--config PATH] [--providers MODULE] --worktree-id VALUE | validate [--config PATH] [--providers MODULE] --worktree-id VALUE | reset [--config PATH] [--providers MODULE] --worktree-id VALUE | cleanup [--config PATH] [--providers MODULE] --worktree-id VALUE | run [--config PATH] [--providers MODULE] --worktree-id VALUE -- <cmd> [args...]>"
   );
 }
 

--- a/tests/acceptance/cli-conventional-defaults.acceptance.test.ts
+++ b/tests/acceptance/cli-conventional-defaults.acceptance.test.ts
@@ -1,0 +1,170 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { runCli } from "../../apps/cli/src/index";
+
+describe("CLI conventional defaults", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(
+      tempDirs.map((dir) => rm(dir, { recursive: true, force: true }))
+    );
+    tempDirs.length = 0;
+  });
+
+  const providersModulePath = fileURLToPath(
+    new URL("./fixtures/explicit-test-providers.ts", import.meta.url)
+  );
+
+  const deriveConfig = {
+    resources: [
+      {
+        name: "primary-db",
+        provider: "test-resource-provider",
+        isolationStrategy: "name-scoped",
+        scopedValidate: false,
+        scopedReset: false,
+        scopedCleanup: false
+      }
+    ],
+    endpoints: [
+      {
+        name: "app-base-url",
+        role: "application-base-url",
+        provider: "test-endpoint-provider"
+      }
+    ]
+  };
+
+  const resetConfig = {
+    resources: [
+      {
+        name: "primary-db",
+        provider: "test-resource-provider-with-reset",
+        isolationStrategy: "name-scoped",
+        scopedValidate: false,
+        scopedReset: true,
+        scopedCleanup: false
+      }
+    ],
+    endpoints: []
+  };
+
+  const cleanupConfig = {
+    resources: [
+      {
+        name: "primary-db",
+        provider: "test-resource-provider-with-cleanup",
+        isolationStrategy: "name-scoped",
+        scopedValidate: false,
+        scopedReset: false,
+        scopedCleanup: true
+      }
+    ],
+    endpoints: []
+  };
+
+  async function makeCwdWithConfig(config: unknown = deriveConfig): Promise<string> {
+    const tempDir = await mkdtemp(path.join(tmpdir(), "multiverse-defaults-"));
+    tempDirs.push(tempDir);
+    await writeFile(path.join(tempDir, "multiverse.json"), JSON.stringify(config));
+    return tempDir;
+  }
+
+  // --- --config default ---
+
+  it("uses ./multiverse.json when --config is omitted from derive", async () => {
+    const cwd = await makeCwdWithConfig();
+
+    const outcome = await runCli(
+      ["derive", "--providers", providersModulePath, "--worktree-id", "wt-cfg-default"],
+      { cwd }
+    );
+
+    expect(outcome.exitCode).toBe(0);
+    const parsed = JSON.parse(outcome.stdout[0]!);
+    expect(parsed.ok).toBe(true);
+    expect(parsed.resourcePlans).toHaveLength(1);
+  });
+
+  it("uses ./multiverse.json when --config is omitted from validate", async () => {
+    const cwd = await makeCwdWithConfig();
+
+    const outcome = await runCli(
+      ["validate", "--providers", providersModulePath, "--worktree-id", "wt-validate-default"],
+      { cwd }
+    );
+
+    expect(outcome.exitCode).toBe(0);
+  });
+
+  it("uses ./multiverse.json when --config is omitted from reset", async () => {
+    const cwd = await makeCwdWithConfig(resetConfig);
+
+    const outcome = await runCli(
+      ["reset", "--providers", providersModulePath, "--worktree-id", "wt-reset-default"],
+      { cwd }
+    );
+
+    expect(outcome.exitCode).toBe(0);
+  });
+
+  it("uses ./multiverse.json when --config is omitted from cleanup", async () => {
+    const cwd = await makeCwdWithConfig(cleanupConfig);
+
+    const outcome = await runCli(
+      ["cleanup", "--providers", providersModulePath, "--worktree-id", "wt-cleanup-default"],
+      { cwd }
+    );
+
+    expect(outcome.exitCode).toBe(0);
+  });
+
+  // --- --providers default: verify it no longer triggers "Missing required option" ---
+
+  it("does not return 'Missing required option --providers' when --providers is omitted", async () => {
+    const cwd = await makeCwdWithConfig();
+
+    const outcome = await runCli(
+      ["derive", "--worktree-id", "wt-providers-default"],
+      { cwd }
+    );
+
+    // The error should be about loading the module, not about a missing required option
+    expect(outcome.stderr).not.toContain("Missing required option --providers");
+    // It should still fail since ./providers.ts doesn't exist in tempDir
+    expect(outcome.exitCode).toBe(1);
+  });
+
+  // --- --worktree-id stays required ---
+
+  it("returns error for missing --worktree-id even when config and providers have defaults", async () => {
+    const cwd = await makeCwdWithConfig();
+
+    const outcome = await runCli(
+      ["derive", "--providers", providersModulePath],
+      { cwd }
+    );
+
+    expect(outcome.exitCode).toBe(1);
+    expect(outcome.stderr[0]).toMatch(/--worktree-id/);
+  });
+
+  // --- run command also uses defaults ---
+
+  it("uses ./multiverse.json when --config is omitted from run", async () => {
+    const cwd = await makeCwdWithConfig();
+
+    const outcome = await runCli(
+      ["run", "--providers", providersModulePath, "--worktree-id", "wt-run-default", "--", "node", "-e", "process.exit(0)"],
+      { cwd, runner: async () => ({ exitCode: 0 }) }
+    );
+
+    expect(outcome.exitCode).toBe(0);
+  });
+});

--- a/tests/acceptance/cli-run-command.acceptance.test.ts
+++ b/tests/acceptance/cli-run-command.acceptance.test.ts
@@ -1,0 +1,156 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { runCli, type ChildProcessRunner } from "../../apps/cli/src/index";
+
+describe("CLI run command", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(
+      tempDirs.map((dir) => rm(dir, { recursive: true, force: true }))
+    );
+    tempDirs.length = 0;
+  });
+
+  const providersModulePath = fileURLToPath(
+    new URL("./fixtures/explicit-test-providers.ts", import.meta.url)
+  );
+
+  async function writeRepositoryConfig(config: unknown): Promise<string> {
+    const tempDir = await mkdtemp(path.join(tmpdir(), "multiverse-cli-run-"));
+    tempDirs.push(tempDir);
+    const configPath = path.join(tempDir, "repository.json");
+    await writeFile(configPath, JSON.stringify(config));
+    return configPath;
+  }
+
+  const baseConfig = {
+    resources: [
+      {
+        name: "primary-db",
+        provider: "test-resource-provider",
+        isolationStrategy: "name-scoped",
+        scopedValidate: false,
+        scopedReset: false,
+        scopedCleanup: false
+      }
+    ],
+    endpoints: [
+      {
+        name: "app-base-url",
+        role: "application-base-url",
+        provider: "test-endpoint-provider"
+      }
+    ]
+  };
+
+  it("injects MULTIVERSE_RESOURCE_* and MULTIVERSE_ENDPOINT_* env vars into the child process", async () => {
+    const configPath = await writeRepositoryConfig(baseConfig);
+    const capturedEnv: Record<string, string> = {};
+
+    const runner: ChildProcessRunner = async ({ env }) => {
+      Object.assign(capturedEnv, env);
+      return { exitCode: 0 };
+    };
+
+    const outcome = await runCli(
+      ["run", "--config", configPath, "--providers", providersModulePath, "--worktree-id", "wt-run-test", "--", "node", "-e", "process.exit(0)"],
+      { runner }
+    );
+
+    expect(outcome.exitCode).toBe(0);
+    expect(capturedEnv["MULTIVERSE_WORKTREE_ID"]).toBe("wt-run-test");
+    expect(capturedEnv["MULTIVERSE_RESOURCE_PRIMARY_DB"]).toBe("primary-db--wt-run-test");
+    expect(capturedEnv["MULTIVERSE_ENDPOINT_APP_BASE_URL"]).toBe("http://wt-run-test.local/app-base-url");
+  });
+
+  it("propagates the child process exit code", async () => {
+    const configPath = await writeRepositoryConfig(baseConfig);
+
+    const runner: ChildProcessRunner = async () => ({ exitCode: 42 });
+
+    const outcome = await runCli(
+      ["run", "--config", configPath, "--providers", providersModulePath, "--worktree-id", "wt-exit-code", "--", "node", "-e", "process.exit(42)"],
+      { runner }
+    );
+
+    expect(outcome.exitCode).toBe(42);
+    expect(outcome.stdout).toEqual([]);
+    expect(outcome.stderr).toEqual([]);
+  });
+
+  it("emits refusal JSON to stderr and exits non-zero when derive fails, child is never started", async () => {
+    const configPath = await writeRepositoryConfig(baseConfig);
+    let runnerCalled = false;
+
+    const runner: ChildProcessRunner = async () => {
+      runnerCalled = true;
+      return { exitCode: 0 };
+    };
+
+    const outcome = await runCli(
+      ["run", "--config", configPath, "--providers", providersModulePath, "--worktree-id", "", "--", "node", "-e", "process.exit(0)"],
+      { runner }
+    );
+
+    expect(outcome.exitCode).toBe(1);
+    expect(outcome.stdout).toEqual([]);
+    expect(outcome.stderr).toHaveLength(1);
+    const parsed = JSON.parse(outcome.stderr[0]!);
+    expect(parsed.ok).toBe(false);
+    expect(parsed.refusal).toBeDefined();
+    expect(runnerCalled).toBe(false);
+  });
+
+  it("returns usage error when no command is provided after --", async () => {
+    const configPath = await writeRepositoryConfig(baseConfig);
+
+    const outcome = await runCli(
+      ["run", "--config", configPath, "--providers", providersModulePath, "--worktree-id", "wt-no-cmd", "--"],
+      { runner: async () => ({ exitCode: 0 }) }
+    );
+
+    expect(outcome.exitCode).toBe(1);
+    expect(outcome.stdout).toEqual([]);
+    expect(outcome.stderr[0]).toMatch(/command/i);
+  });
+
+  it("returns usage error when -- separator is absent", async () => {
+    const configPath = await writeRepositoryConfig(baseConfig);
+
+    const outcome = await runCli(
+      ["run", "--config", configPath, "--providers", providersModulePath, "--worktree-id", "wt-no-sep"],
+      { runner: async () => ({ exitCode: 0 }) }
+    );
+
+    expect(outcome.exitCode).toBe(1);
+    expect(outcome.stdout).toEqual([]);
+    expect(outcome.stderr[0]).toMatch(/--/);
+  });
+
+  it("merges derived env vars into the parent environment for the child", async () => {
+    const configPath = await writeRepositoryConfig(baseConfig);
+    let childEnv: Record<string, string> = {};
+
+    const runner: ChildProcessRunner = async ({ env }) => {
+      childEnv = { ...env };
+      return { exitCode: 0 };
+    };
+
+    const outcome = await runCli(
+      ["run", "--config", configPath, "--providers", providersModulePath, "--worktree-id", "wt-env-merge", "--", "node"],
+      { runner }
+    );
+
+    expect(outcome.exitCode).toBe(0);
+    // MULTIVERSE vars are present
+    expect(childEnv["MULTIVERSE_WORKTREE_ID"]).toBe("wt-env-merge");
+    // PATH from parent env should also be present (merge, not replace)
+    expect(childEnv["PATH"]).toBeDefined();
+  });
+});

--- a/tests/acceptance/cli-validate-command.acceptance.test.ts
+++ b/tests/acceptance/cli-validate-command.acceptance.test.ts
@@ -250,13 +250,17 @@ describe("CLI validate command", () => {
     });
   });
 
-  it("returns usage error when required options are missing", async () => {
-    const outcome = await runCli(["validate", "--worktree-id", "wt-cli-validate"]);
+  it("returns usage error when --worktree-id is missing", async () => {
+    const outcome = await runCli(["validate", "--config", "/nonexistent/path.json", "--providers", providersModulePath]);
 
-    expect(outcome).toEqual({
-      exitCode: 1,
-      stdout: [],
-      stderr: ["Missing required option --config"]
-    });
+    expect(outcome.exitCode).toBe(1);
+    expect(outcome.stderr[0]).toMatch(/--worktree-id/);
+  });
+
+  it("fails with config file error when --config is omitted and ./multiverse.json does not exist", async () => {
+    const outcome = await runCli(["validate", "--worktree-id", "wt-cli-validate", "--providers", providersModulePath]);
+
+    expect(outcome.exitCode).toBe(1);
+    expect(outcome.stderr[0]).toMatch(/multiverse\.json/);
   });
 });

--- a/tests/acceptance/dev-slice-10.acceptance.test.ts
+++ b/tests/acceptance/dev-slice-10.acceptance.test.ts
@@ -287,10 +287,8 @@ describe("Development Slice 10 acceptance", () => {
       "wt-cli-derive"
     ]);
 
-    expect(outcome).toEqual({
-      exitCode: 1,
-      stdout: [],
-      stderr: ["Missing required option --providers"]
-    });
+    expect(outcome.exitCode).toBe(1);
+    expect(outcome.stdout).toEqual([]);
+    expect(outcome.stderr[0]).toMatch(/providers/i);
   });
 });

--- a/tests/acceptance/dev-slice-11.acceptance.test.ts
+++ b/tests/acceptance/dev-slice-11.acceptance.test.ts
@@ -119,11 +119,9 @@ describe("Development Slice 11 acceptance", () => {
       "wt-cli-reset"
     ]);
 
-    expect(outcome).toEqual({
-      exitCode: 1,
-      stdout: [],
-      stderr: ["Missing required option --providers"]
-    });
+    expect(outcome.exitCode).toBe(1);
+    expect(outcome.stdout).toEqual([]);
+    expect(outcome.stderr[0]).toMatch(/providers/i);
   });
 
   it("returns unsupported reset capability unchanged through the CLI", async () => {

--- a/tests/acceptance/dev-slice-12.acceptance.test.ts
+++ b/tests/acceptance/dev-slice-12.acceptance.test.ts
@@ -119,11 +119,9 @@ describe("Development Slice 12 acceptance", () => {
       "wt-cli-cleanup"
     ]);
 
-    expect(outcome).toEqual({
-      exitCode: 1,
-      stdout: [],
-      stderr: ["Missing required option --providers"]
-    });
+    expect(outcome.exitCode).toBe(1);
+    expect(outcome.stdout).toEqual([]);
+    expect(outcome.stderr[0]).toMatch(/providers/i);
   });
 
   it("returns unsupported cleanup capability unchanged through the CLI", async () => {


### PR DESCRIPTION
## Summary

- Adds `multiverse run [--config PATH] [--providers MODULE] --worktree-id VALUE -- <cmd> [args...]` (ADR-0012): derives isolated values, injects `MULTIVERSE_WORKTREE_ID`, `MULTIVERSE_RESOURCE_*`, `MULTIVERSE_ENDPOINT_*` as env vars, spawns child with inherited stdio, propagates exit code
- Adds conventional defaults (ADR-0014): `--config` → `./multiverse.json`, `--providers` → `./providers.ts` for all commands; `--worktree-id` stays required
- File/module I/O errors are now returned as `CliResult` usage errors instead of unhandled throws
- `runCli` accepts `{ cwd?, runner? }` for testability

## Scope

- `apps/cli/src/index.ts` — `run` command, conventional defaults, `readCommonOptions` helper, I/O error handling
- `tests/acceptance/cli-run-command.acceptance.test.ts` — 6 new tests
- `tests/acceptance/cli-conventional-defaults.acceptance.test.ts` — 7 new tests
- `tests/acceptance/{cli-validate-command,dev-slice-10,dev-slice-11,dev-slice-12}.acceptance.test.ts` — updated to reflect new conventional-default behavior

## Validation

- `pnpm tsc --noEmit` — clean
- `pnpm vitest run` — 170/170 passing

## Notes

This completes the three highest Phase 1 priorities: `multiverse run`, env naming contract (already in `--format=env`), and conventional defaults. The consumer can now start their app with `multiverse run --worktree-id <id> -- node server.js` from the repo root without specifying config/providers paths.

Closes #56 (already merged — env naming was part of that). Implements ADR-0012 and ADR-0014.

🤖 Generated with [Claude Code](https://claude.com/claude-code)