### PR TITLE
Replace JSON file store with SQLite in sample-express

### DIFF
--- a/apps/sample-express/src/app.ts
+++ b/apps/sample-express/src/app.ts
@@ -1,10 +1,11 @@
 import express from "express";
-import { readFile, writeFile, mkdir } from "node:fs/promises";
+import { mkdirSync } from "node:fs";
 import { dirname } from "node:path";
+import { DatabaseSync } from "node:sqlite";
 import type { Server } from "node:http";
 
 export interface AppConfig {
-  /** Absolute path to the JSON data file. Derived by multiverse path-scoped provider. */
+  /** Absolute path to the SQLite database file. Derived by multiverse path-scoped provider. */
   dbPath: string;
   /** Port to listen on. Derived by multiverse local-port provider. */
   port: number;
@@ -15,23 +16,24 @@ interface Item {
   name: string;
 }
 
-interface Store {
-  items: Item[];
-  nextId: number;
-}
-
-async function readStore(dbPath: string): Promise<Store> {
+/**
+ * Open the database at dbPath for the duration of fn, then close it.
+ * Creates the parent directory and schema on first access.
+ * Using per-call open/close so that after a reset/cleanup (file deletion),
+ * the next call recreates a fresh empty database at the same path.
+ */
+function withDb<T>(dbPath: string, fn: (db: DatabaseSync) => T): T {
+  mkdirSync(dirname(dbPath), { recursive: true });
+  const db = new DatabaseSync(dbPath);
   try {
-    const raw = await readFile(dbPath, "utf-8");
-    return JSON.parse(raw) as Store;
-  } catch {
-    return { items: [], nextId: 1 };
+    db.exec("PRAGMA journal_mode = DELETE");
+    db.exec(
+      "CREATE TABLE IF NOT EXISTS items (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL)"
+    );
+    return fn(db);
+  } finally {
+    db.close();
   }
-}
-
-async function writeStore(dbPath: string, store: Store): Promise<void> {
-  await mkdir(dirname(dbPath), { recursive: true });
-  await writeFile(dbPath, JSON.stringify(store, null, 2), "utf-8");
 }
 
 export function createApp(config: AppConfig): express.Application {
@@ -42,26 +44,30 @@ export function createApp(config: AppConfig): express.Application {
     res.json({ ok: true, dbPath: config.dbPath, port: config.port });
   });
 
-  app.get("/items", async (_req, res) => {
-    const store = await readStore(config.dbPath);
-    res.json(store.items);
+  app.get("/items", (_req, res) => {
+    const items = withDb(config.dbPath, (db) =>
+      db.prepare("SELECT id, name FROM items").all() as unknown as Item[]
+    );
+    res.json(items);
   });
 
-  app.post("/items", async (req, res) => {
+  app.post("/items", (req, res) => {
     const { name } = req.body as { name?: string };
     if (!name) {
       res.status(400).json({ error: "name is required" });
       return;
     }
-    const store = await readStore(config.dbPath);
-    const item: Item = { id: store.nextId++, name };
-    store.items.push(item);
-    await writeStore(config.dbPath, store);
+    const item = withDb(config.dbPath, (db) => {
+      const result = db.prepare("INSERT INTO items (name) VALUES (?)").run(name);
+      return { id: result.lastInsertRowid as number, name };
+    });
     res.status(201).json(item);
   });
 
-  app.delete("/items", async (_req, res) => {
-    await writeStore(config.dbPath, { items: [], nextId: 1 });
+  app.delete("/items", (_req, res) => {
+    withDb(config.dbPath, (db) => {
+      db.exec("DELETE FROM items");
+    });
     res.json({ ok: true });
   });
 

--- a/apps/sample-express/src/index.ts
+++ b/apps/sample-express/src/index.ts
@@ -1,25 +1,29 @@
 import process from "node:process";
 import { startApp } from "./app.js";
 
-const dbPath = process.env.MULTIVERSE_DB_PATH;
-const portEnv = process.env.MULTIVERSE_PORT;
+// Env vars injected by `multiverse run` following ADR-0013 naming convention:
+//   MULTIVERSE_RESOURCE_APP_DB  — path-scoped handle for the "app-db" resource
+//   MULTIVERSE_ENDPOINT_HTTP    — full address for the "http" endpoint (e.g. http://localhost:5200)
+const dbPath = process.env["MULTIVERSE_RESOURCE_APP_DB"];
+const endpointAddress = process.env["MULTIVERSE_ENDPOINT_HTTP"];
 
 if (!dbPath) {
-  process.stderr.write("MULTIVERSE_DB_PATH is required\n");
+  process.stderr.write("MULTIVERSE_RESOURCE_APP_DB is required\n");
   process.exit(1);
 }
 
-if (!portEnv) {
-  process.stderr.write("MULTIVERSE_PORT is required\n");
+if (!endpointAddress) {
+  process.stderr.write("MULTIVERSE_ENDPOINT_HTTP is required\n");
   process.exit(1);
 }
 
-const port = parseInt(portEnv, 10);
-if (isNaN(port)) {
-  process.stderr.write(`MULTIVERSE_PORT must be a number, got: ${portEnv}\n`);
+const portStr = new URL(endpointAddress).port;
+const port = parseInt(portStr, 10);
+if (isNaN(port) || port === 0) {
+  process.stderr.write(`Cannot parse port from MULTIVERSE_ENDPOINT_HTTP: ${endpointAddress}\n`);
   process.exit(1);
 }
 
 const handle = await startApp({ dbPath, port });
 process.stdout.write(`Sample Express app running at ${handle.baseUrl}\n`);
-process.stdout.write(`Data file: ${dbPath}\n`);
+process.stdout.write(`Database: ${dbPath}\n`);

--- a/tests/integration/sample-express.integration.test.ts
+++ b/tests/integration/sample-express.integration.test.ts
@@ -16,7 +16,7 @@
  */
 
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
-import { access } from "node:fs/promises";
+import { access, readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { rm } from "node:fs/promises";
@@ -208,6 +208,15 @@ describe("sample-express integration", () => {
 
       expect(await fileExists(dbPathA)).toBe(true);
       expect(await fileExists(dbPathB)).toBe(true);
+    });
+
+    it("database files are SQLite format, not JSON", async () => {
+      await postItem(addrA, "sqlite-proof");
+
+      // SQLite files start with the magic header "SQLite format 3\0"
+      const header = await readFile(dbPathA);
+      const magic = header.subarray(0, 16).toString("utf8");
+      expect(magic).toBe("SQLite format 3\0");
     });
   });
 


### PR DESCRIPTION
## Summary

- Migrates the sample-express proving seam from flat JSON I/O to SQLite using Node.js 22's built-in `node:sqlite` (no new dependencies)
- Uses per-call `withDb` open/close so that after path-scoped `reset`/`cleanup` deletes the database file, the next request sees an empty fresh database — same semantics as the JSON fallback
- Updates `index.ts` to use `MULTIVERSE_RESOURCE_APP_DB` and `MULTIVERSE_ENDPOINT_HTTP` per ADR-0013, replacing the old ad-hoc env var names
- Adds integration assertion that verifies the SQLite magic header (`SQLite format 3\0`), proving the store is no longer JSON

## Scope

- `apps/sample-express/src/app.ts` — SQLite via `node:sqlite`, `withDb` helper, schema creation on first access
- `apps/sample-express/src/index.ts` — ADR-0013 env var names, port extracted from endpoint address URL
- `tests/integration/sample-express.integration.test.ts` — SQLite format assertion added

## Validation

- `pnpm tsc --noEmit` — clean
- `pnpm vitest run` — 170/170 passing
- `pnpm vitest run --config vitest.integration.config.ts` — 18/18 passing (all isolation, lifecycle, and new SQLite format tests)

## Notes

`node:sqlite` emits an ExperimentalWarning to stderr on Node.js 22. This is informational only and does not affect test outcomes or exit codes.

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)