### PR TITLE
test(slice-23): add CLI acceptance coverage for process-scoped lifecycle

### DIFF
--- a/docs/development/dev-slice-23.md
+++ b/docs/development/dev-slice-23.md
@@ -1,0 +1,48 @@
+# Dev Slice 23 — CLI-Level Acceptance Coverage for Process-Scoped Lifecycle
+
+## Status
+
+Implemented on `main`
+
+## Intent
+
+Add CLI-level acceptance tests for `multiverse reset` and `multiverse cleanup` when a process-scoped resource is declared and registered.
+
+Slices 21–22 proved the process-scoped provider works at the core API level. This slice closes the remaining coverage gap by exercising the full path from CLI arguments → providers module loading → process launch and termination, through the `runCli` function.
+
+## Why this slice
+
+Every other provider lifecycle path (name-scoped reset/cleanup, path-scoped reset/cleanup) has CLI-level acceptance coverage. Process-scoped is the only lifecycle capability that has been proven at the acceptance layer but not at the CLI invocation layer.
+
+## Slice objective
+
+1. Add a `process-scoped-test-providers.ts` fixture that exports a real `ProviderRegistry` using `createProcessScopedProvider`
+2. Add `cli-process-scoped.acceptance.test.ts` proving that:
+   - `multiverse reset` launches the declared process and returns success JSON
+   - `multiverse cleanup` terminates the process and returns success JSON
+   - `multiverse reset` with no worktree ID returns a non-zero exit with a refusal
+   - each worktree instance gets its own isolated state directory
+
+## Scope
+
+- `tests/acceptance/fixtures/process-scoped-test-providers.ts`
+- `tests/acceptance/cli-process-scoped.acceptance.test.ts`
+- `docs/development/dev-slice-23.md`
+
+## Out of scope
+
+- Changes to the CLI, core, or providers
+- Integration test tier (`tests/integration/`)
+- Sample app changes
+
+## Acceptance criteria
+
+- `runCli(["reset", ...])` with a process-scoped resource returns exit code 0 and a JSON result with `resourceResets`
+- `runCli(["cleanup", ...])` terminates the launched process and returns exit code 0
+- `runCli(["reset", ...])` with an empty worktree ID returns exit code 1 and a refusal
+- two distinct worktree IDs derive two distinct state directories at the CLI level
+- all existing 189 tests remain green
+
+## Definition of done
+
+CLI acceptance tests prove that `reset` and `cleanup` commands work end-to-end with a real process-scoped provider, including process launch, state directory creation, and process termination.

--- a/tests/acceptance/cli-process-scoped.acceptance.test.ts
+++ b/tests/acceptance/cli-process-scoped.acceptance.test.ts
@@ -1,0 +1,174 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+import { runCli } from "../../apps/cli/src/index";
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(tempDirs.map((d) => rm(d, { recursive: true, force: true })));
+  tempDirs.length = 0;
+});
+
+const providersModulePath = fileURLToPath(
+  new URL("./fixtures/process-scoped-test-providers.ts", import.meta.url)
+);
+
+const processScopedRepository = {
+  resources: [
+    {
+      name: "background-worker",
+      provider: "process-scoped",
+      isolationStrategy: "process-scoped",
+      scopedValidate: false,
+      scopedReset: true,
+      scopedCleanup: true
+    }
+  ],
+  endpoints: []
+};
+
+async function writeConfig(config: unknown): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "mv-cli-ps-test-"));
+  tempDirs.push(dir);
+  const configPath = join(dir, "multiverse.json");
+  await writeFile(configPath, JSON.stringify(config));
+  return configPath;
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function readPid(stateDir: string): Promise<number | null> {
+  const pidPath = join(stateDir, "pid");
+  if (!existsSync(pidPath)) return null;
+  try {
+    const raw = await readFile(pidPath, "utf8");
+    const pid = parseInt(raw.trim(), 10);
+    return isNaN(pid) ? null : pid;
+  } catch {
+    return null;
+  }
+}
+
+describe("CLI process-scoped lifecycle", () => {
+  it("reset exits 0 and returns resourceResets for a process-scoped resource", async () => {
+    const configPath = await writeConfig(processScopedRepository);
+
+    const result = await runCli([
+      "reset",
+      "--config", configPath,
+      "--providers", providersModulePath,
+      "--worktree-id", "wt-ps-reset-test"
+    ]);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toHaveLength(1);
+
+    const parsed = JSON.parse(result.stdout[0]!) as {
+      ok: boolean;
+      resourceResets: Array<{ resourceName: string; capability: string }>;
+    };
+    expect(parsed.ok).toBe(true);
+    expect(parsed.resourceResets).toHaveLength(1);
+    expect(parsed.resourceResets[0].resourceName).toBe("background-worker");
+    expect(parsed.resourceResets[0].capability).toBe("reset");
+
+    // cleanup spawned process
+    await runCli([
+      "cleanup",
+      "--config", configPath,
+      "--providers", providersModulePath,
+      "--worktree-id", "wt-ps-reset-test"
+    ]);
+  });
+
+  it("cleanup exits 0 and terminates the running process", async () => {
+    const configPath = await writeConfig(processScopedRepository);
+    const worktreeId = "wt-ps-cleanup-test";
+
+    // Reset to start the process
+    const resetResult = await runCli([
+      "reset",
+      "--config", configPath,
+      "--providers", providersModulePath,
+      "--worktree-id", worktreeId
+    ]);
+    expect(resetResult.exitCode).toBe(0);
+
+    const resetParsed = JSON.parse(resetResult.stdout[0]!) as {
+      ok: boolean;
+      resourcePlans: Array<{ handle: string }>;
+    };
+    const stateDir = resetParsed.resourcePlans[0].handle;
+    const pid = await readPid(stateDir);
+    expect(pid).not.toBeNull();
+    expect(isProcessAlive(pid!)).toBe(true);
+
+    // Cleanup to stop the process
+    const cleanupResult = await runCli([
+      "cleanup",
+      "--config", configPath,
+      "--providers", providersModulePath,
+      "--worktree-id", worktreeId
+    ]);
+    expect(cleanupResult.exitCode).toBe(0);
+
+    expect(isProcessAlive(pid!)).toBe(false);
+    expect(existsSync(stateDir)).toBe(false);
+  });
+
+  it("reset exits 1 with a refusal when worktree ID is empty", async () => {
+    const configPath = await writeConfig(processScopedRepository);
+
+    const result = await runCli([
+      "reset",
+      "--config", configPath,
+      "--providers", providersModulePath,
+      "--worktree-id", ""
+    ]);
+
+    expect(result.exitCode).toBe(1);
+    const parsed = JSON.parse(result.stdout[0]!) as { ok: boolean; refusal: { category: string } };
+    expect(parsed.ok).toBe(false);
+    expect(parsed.refusal.category).toBe("unsafe_scope");
+  });
+
+  it("two worktree IDs produce distinct process-scoped state directories", async () => {
+    const configPath = await writeConfig(processScopedRepository);
+
+    const resultA = await runCli([
+      "reset",
+      "--config", configPath,
+      "--providers", providersModulePath,
+      "--worktree-id", "wt-ps-iso-a"
+    ]);
+    const resultB = await runCli([
+      "reset",
+      "--config", configPath,
+      "--providers", providersModulePath,
+      "--worktree-id", "wt-ps-iso-b"
+    ]);
+
+    expect(resultA.exitCode).toBe(0);
+    expect(resultB.exitCode).toBe(0);
+
+    const parsedA = JSON.parse(resultA.stdout[0]!) as { ok: boolean; resourcePlans: Array<{ handle: string }> };
+    const parsedB = JSON.parse(resultB.stdout[0]!) as { ok: boolean; resourcePlans: Array<{ handle: string }> };
+
+    expect(parsedA.resourcePlans[0].handle).not.toBe(parsedB.resourcePlans[0].handle);
+
+    // cleanup both
+    await runCli(["cleanup", "--config", configPath, "--providers", providersModulePath, "--worktree-id", "wt-ps-iso-a"]);
+    await runCli(["cleanup", "--config", configPath, "--providers", providersModulePath, "--worktree-id", "wt-ps-iso-b"]);
+  });
+});

--- a/tests/acceptance/fixtures/process-scoped-test-providers.ts
+++ b/tests/acceptance/fixtures/process-scoped-test-providers.ts
@@ -1,0 +1,13 @@
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { createProcessScopedProvider } from "@multiverse/provider-process-scoped";
+
+export const providers = {
+  resources: {
+    "process-scoped": createProcessScopedProvider({
+      baseDir: join(tmpdir(), "multiverse-cli-process-scoped-test"),
+      command: ["node", "-e", "setTimeout(() => {}, 60000)"]
+    })
+  },
+  endpoints: {}
+};


### PR DESCRIPTION
## Summary

Closes the CLI-level test coverage gap for the process-scoped provider. Slices 21–22 proved the provider works at the core API level; this slice proves the `reset` and `cleanup` CLI commands work end-to-end with a real process-scoped provider.

## Scope

- `tests/acceptance/fixtures/process-scoped-test-providers.ts` — new providers fixture using `createProcessScopedProvider` with a long-running `node` process
- `tests/acceptance/cli-process-scoped.acceptance.test.ts` — 4 acceptance tests via `runCli`
- `docs/development/dev-slice-23.md`

No production code changes.

## Validation

193 tests passing (37 test files, 4 new).

## Tests cover

- `reset` exits 0, returns `resourceResets` JSON with correct shape
- `cleanup` exits 0, terminates the launched process, removes the state directory
- empty worktree ID refused as `unsafe_scope` (exit 1)
- two worktree IDs produce distinct state directories