### PR TITLE
feat(sample-compose): prove runtime config boundary

### DIFF
--- a/apps/sample-compose/src/index.ts
+++ b/apps/sample-compose/src/index.ts
@@ -1,40 +1,10 @@
 import process from "node:process";
 
-import { startApp, type AppConfig } from "./app.js";
-
-export function readConfigFromEnv(env: NodeJS.ProcessEnv = process.env): AppConfig {
-  const dbPath = env["DATABASE_PATH"];
-  if (!dbPath) {
-    throw new Error("DATABASE_PATH is required");
-  }
-
-  const cacheAddr = env["CACHE_ADDR"];
-  if (!cacheAddr) {
-    throw new Error("CACHE_ADDR is required");
-  }
-
-  const appHttpUrl = env["APP_HTTP_URL"];
-  if (!appHttpUrl) {
-    throw new Error("APP_HTTP_URL is required");
-  }
-
-  return {
-    dbPath,
-    cacheAddr,
-    port: parsePortFromUrl(appHttpUrl)
-  };
-}
-
-function parsePortFromUrl(address: string): number {
-  const port = Number.parseInt(new URL(address).port, 10);
-  if (Number.isNaN(port)) {
-    throw new Error(`APP_HTTP_URL must include a numeric port: ${address}`);
-  }
-  return port;
-}
+import { startApp } from "./app.js";
+import { readRuntimeConfigFromEnv } from "./runtime-config.js";
 
 async function main(): Promise<void> {
-  const config = readConfigFromEnv();
+  const config = readRuntimeConfigFromEnv();
   await startApp(config);
 }
 

--- a/apps/sample-compose/src/runtime-config.ts
+++ b/apps/sample-compose/src/runtime-config.ts
@@ -1,0 +1,34 @@
+import process from "node:process";
+
+import type { AppConfig } from "./app.js";
+
+export function readRuntimeConfigFromEnv(env: NodeJS.ProcessEnv = process.env): AppConfig {
+  const dbPath = env["DATABASE_PATH"];
+  if (!dbPath) {
+    throw new Error("DATABASE_PATH is required");
+  }
+
+  const cacheAddr = env["CACHE_ADDR"];
+  if (!cacheAddr) {
+    throw new Error("CACHE_ADDR is required");
+  }
+
+  const appHttpUrl = env["APP_HTTP_URL"];
+  if (!appHttpUrl) {
+    throw new Error("APP_HTTP_URL is required");
+  }
+
+  return {
+    dbPath,
+    cacheAddr,
+    port: parsePortFromUrl(appHttpUrl)
+  };
+}
+
+function parsePortFromUrl(address: string): number {
+  const port = Number.parseInt(new URL(address).port, 10);
+  if (Number.isNaN(port)) {
+    throw new Error(`APP_HTTP_URL must include a numeric port: ${address}`);
+  }
+  return port;
+}

--- a/docs/development/current-state.md
+++ b/docs/development/current-state.md
@@ -15,7 +15,7 @@ This is a short state-of-the-project document, not a full history.
 
 ## Current version posture
 
-Current version posture: **0.3.0-alpha.1**
+Current version posture: **0.3.0-alpha.2**
 
 Interpretation:
 

--- a/docs/development/dev-slice-28.md
+++ b/docs/development/dev-slice-28.md
@@ -1,0 +1,70 @@
+# Dev Slice 28 — Sample-Compose Runtime Config Boundary Proof
+
+## Status
+
+In progress
+
+## Intent
+
+Strengthen the `0.3.0-alpha.2` composed-application proof by making the
+application-owned runtime-config boundary in `apps/sample-compose` explicit and
+independently testable.
+
+This slice does not add new Multiverse product behavior. It proves and tightens
+the consumer-side pattern preferred by the roadmap: application code reads
+app-owned config at one boundary instead of scattering direct environment access
+through the application.
+
+## Why this slice now
+
+Dev Slice 27 proved explicit app-native env mapping through `multiverse run`.
+
+The roadmap's next `0.3.x` direction also calls out:
+
+- application-owned runtime config boundaries
+- cleaner common-case Node application consumption
+- continued confidence-building around the composed app workflow
+
+`apps/sample-compose/src/index.ts` already acts as a boundary in practice, but
+the boundary is still implicit. This slice makes it explicit without expanding
+the CLI or declaration model.
+
+## In scope
+
+- extract a dedicated runtime-config module for `apps/sample-compose`
+- keep environment reads isolated to that module
+- keep the accepted app-native names:
+  - `DATABASE_PATH`
+  - `CACHE_ADDR`
+  - `APP_HTTP_URL`
+- add focused unit tests for the boundary behavior
+- prove that raw `MULTIVERSE_*` names are not consumed as fallback inputs by the
+  sample application boundary
+
+## Out of scope
+
+- new CLI behavior
+- new repository configuration fields
+- fallback inference from `MULTIVERSE_*` names
+- typed endpoint extraction beyond existing alias-only URL-to-port parsing in
+  the sample app boundary
+- sample-express changes
+- broader docs/guides churn
+
+## Acceptance criteria
+
+- `apps/sample-compose/src/runtime-config.ts` is the only place the sample app
+  reads process environment variables for startup configuration
+- `apps/sample-compose/src/index.ts` delegates startup config loading to that
+  boundary module
+- unit tests prove:
+  - valid app-native env input maps to `AppConfig`
+  - missing required app-native vars fail explicitly
+  - malformed `APP_HTTP_URL` fails explicitly
+  - raw `MULTIVERSE_*` env vars do not act as fallback inputs
+
+## Definition of done
+
+- relevant unit tests pass
+- integration tests remain green
+- no new product behavior is introduced beyond the sample-app consumer proof

--- a/docs/development/roadmap.md
+++ b/docs/development/roadmap.md
@@ -26,7 +26,7 @@ Multiverse development continues under the same core assumptions:
 
 ## Current version posture
 
-Current version posture: **0.3.0-alpha.1**
+Current version posture: **0.3.0-alpha.2**
 
 What that means:
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "multiverse",
-  "version": "0.3.0-alpha.1",
+  "version": "0.3.0-alpha.2",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.33.0",

--- a/tests/unit/sample-compose-runtime-config.test.ts
+++ b/tests/unit/sample-compose-runtime-config.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+
+import { readRuntimeConfigFromEnv } from "../../apps/sample-compose/src/runtime-config.js";
+
+describe("sample-compose runtime config boundary", () => {
+  it("maps app-native env vars to AppConfig", () => {
+    const config = readRuntimeConfigFromEnv({
+      DATABASE_PATH: "/tmp/app-db",
+      CACHE_ADDR: "localhost:6401",
+      APP_HTTP_URL: "http://127.0.0.1:5401"
+    });
+
+    expect(config).toEqual({
+      dbPath: "/tmp/app-db",
+      cacheAddr: "localhost:6401",
+      port: 5401
+    });
+  });
+
+  it("refuses when DATABASE_PATH is missing", () => {
+    expect(() =>
+      readRuntimeConfigFromEnv({
+        CACHE_ADDR: "localhost:6401",
+        APP_HTTP_URL: "http://127.0.0.1:5401"
+      })
+    ).toThrow("DATABASE_PATH is required");
+  });
+
+  it("refuses when CACHE_ADDR is missing", () => {
+    expect(() =>
+      readRuntimeConfigFromEnv({
+        DATABASE_PATH: "/tmp/app-db",
+        APP_HTTP_URL: "http://127.0.0.1:5401"
+      })
+    ).toThrow("CACHE_ADDR is required");
+  });
+
+  it("refuses when APP_HTTP_URL is missing", () => {
+    expect(() =>
+      readRuntimeConfigFromEnv({
+        DATABASE_PATH: "/tmp/app-db",
+        CACHE_ADDR: "localhost:6401"
+      })
+    ).toThrow("APP_HTTP_URL is required");
+  });
+
+  it("refuses malformed APP_HTTP_URL input", () => {
+    expect(() =>
+      readRuntimeConfigFromEnv({
+        DATABASE_PATH: "/tmp/app-db",
+        CACHE_ADDR: "localhost:6401",
+        APP_HTTP_URL: "http://127.0.0.1"
+      })
+    ).toThrow("APP_HTTP_URL must include a numeric port");
+  });
+
+  it("does not fall back to raw MULTIVERSE_* env vars", () => {
+    expect(() =>
+      readRuntimeConfigFromEnv({
+        MULTIVERSE_RESOURCE_APP_DB: "/tmp/app-db",
+        MULTIVERSE_RESOURCE_CACHE_SIDECAR: "localhost:6401",
+        MULTIVERSE_ENDPOINT_HTTP: "http://127.0.0.1:5401"
+      })
+    ).toThrow("DATABASE_PATH is required");
+  });
+});


### PR DESCRIPTION
## Summary

- bumps the repo posture to `0.3.0-alpha.2`
- extracts an explicit runtime-config boundary for `apps/sample-compose`
- proves the boundary only consumes app-native env names and does not fall back to raw `MULTIVERSE_*` vars

## Scope

- `apps/sample-compose/src/runtime-config.ts` — dedicated startup config boundary
- `apps/sample-compose/src/index.ts` — delegates env loading to the boundary module
- `tests/unit/sample-compose-runtime-config.test.ts` — focused boundary tests
- `docs/development/dev-slice-28.md` — narrow slice doc
- `package.json`, `docs/development/roadmap.md`, `docs/development/current-state.md` — version posture updated to `0.3.0-alpha.2`

## Validation

- `pnpm test:unit -- tests/unit/sample-compose-runtime-config.test.ts`
- `pnpm test:integration`
- `pnpm typecheck`

## Deferred

- no new CLI behavior
- no fallback inference from canonical `MULTIVERSE_*` names
- no broader consumer config redesign
