### PR TITLE
docs: sync common-case workflow story

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Today’s repo includes:
 
 * a thin CLI application in `apps/cli/`
 * a sample Express application in `apps/sample-express/`
+* a composed proving application in `apps/sample-compose/`
 * core business logic in `packages/core/`
 * explicit provider contracts in `packages/provider-contracts/`
 * test support in `packages/providers-testkit/`
@@ -44,11 +45,13 @@ Today’s repo includes:
   * name-scoped resources
   * path-scoped resources
   * local-port endpoints
+  * process-scoped resources
+  * process-port-scoped resources
 * acceptance, contract, unit, and integration tests
 
 ## Current behavior being proven
 
-The current implementation proves the core loop for explicit declarations and deterministic derivation.
+The current implementation proves the core loop for explicit declarations and deterministic derivation, plus the current `0.3.0-alpha.2` consumer-workflow refinement direction.
 
 That includes:
 
@@ -60,13 +63,19 @@ That includes:
   * name-scoped resources
   * path-scoped resources
   * local-port endpoints
+  * process-scoped resources
+  * process-port-scoped resources
 * multi-resource and multi-endpoint support
 * lifecycle support:
 
   * name-scoped reset/cleanup as scope confirmation only
   * path-scoped reset/cleanup as effectful operations for provider-managed filesystem state
+  * process-scoped and process-port-scoped reset/cleanup for declared child-process lifecycle
 * `derive --format=env` for shell-sourceable KEY=VALUE output
 * sample Express application end-to-end integration proof
+* app-native env alias injection during `run`
+* a composed `sample-compose` proof for mixed-provider consumption in one app
+* an application-owned runtime-config boundary for the composed sample app
 
 ## Design principles
 
@@ -87,6 +96,7 @@ This keeps the tool predictable and avoids hidden behavior around consequential 
 
 * `apps/cli/` — thin command-line entrypoint
 * `apps/sample-express/` — sample application used for end-to-end integration proof
+* `apps/sample-compose/` — composed proving app for the current `0.3.x` consumer workflow
 
 ### Packages
 
@@ -96,6 +106,8 @@ This keeps the tool predictable and avoids hidden behavior around consequential 
 * `packages/provider-name-scoped/` — name-scoped resource provider
 * `packages/provider-path-scoped/` — path-scoped resource provider
 * `packages/provider-local-port/` — local-port endpoint provider
+* `packages/provider-process-scoped/` — process-backed resource provider
+* `packages/provider-process-port-scoped/` — process-backed resource-with-address provider
 
 ### Tests
 
@@ -154,6 +166,8 @@ pnpm cli cleanup --worktree-id <id>
 
 `--config` defaults to `./multiverse.json` and `--providers` defaults to `./providers.ts` when not specified. `--worktree-id` is always required.
 
+For the current common-case `0.3.x` proving path, `run` can inject both canonical `MULTIVERSE_*` transport vars and explicit app-native aliases declared with `appEnv`. The preferred application pattern is to read those app-owned names at one runtime-config boundary rather than scatter direct `MULTIVERSE_*` reads through the app.
+
 ## Source-of-truth order
 
 When implementation questions arise, precedence is:
@@ -172,6 +186,8 @@ Start here:
 * `AGENTS.md`
 * `docs/guides/external-demo-guide.md` — practical usage guide: multiverse run, parallel worktrees, reset/cleanup
 * `docs/development/repo-map.md`
+* `docs/development/current-state.md`
+* `docs/development/roadmap.md`
 * `docs/development/implementation-strategy.md`
 * `docs/development/testing-strategy.md`
 

--- a/docs/development/dev-slice-29.md
+++ b/docs/development/dev-slice-29.md
@@ -1,0 +1,59 @@
+# Dev Slice 29 — Common-Case Docs Sync
+
+## Status
+
+In progress
+
+## Intent
+
+Align top-level project docs with the now-merged `0.3.0-alpha.2` proving state.
+
+This slice does not add product behavior. It updates repository-facing guidance so
+the documented common-case story matches the implementation now present on `main`.
+
+## Why this slice now
+
+The roadmap explicitly prioritizes:
+
+- docs and guides that support the richer proving story
+- a clearer common-case Node workflow
+- a cleaner explanation of how applications consume Multiverse-managed values
+
+After the `appEnv` and runtime-config-boundary slices, key docs still describe an
+older repo shape and understate the composed-app workflow.
+
+## In scope
+
+- update `README.md` to reflect:
+  - current provider and sample-app surface
+  - the composed-app / app-native env proving story
+- update `docs/development/repo-map.md` to reflect:
+  - `apps/sample-compose`
+  - process-backed provider packages
+  - current slice progression through 29
+- update `docs/guides/external-demo-guide.md` to mention the explicit common-case
+  consumer direction:
+  - canonical `MULTIVERSE_*` vars remain available
+  - app-native env aliases via `appEnv` are supported for `run`
+  - an application-owned runtime-config boundary is a preferred consumer pattern
+
+## Out of scope
+
+- new CLI behavior
+- new declaration fields
+- new sample applications
+- broad documentation rewrite
+- changes to ADRs/specs/scenarios
+
+## Acceptance criteria
+
+- top-level repo docs no longer describe the old pre-`sample-compose` surface
+- docs explicitly acknowledge the current common-case consumer direction for
+  `0.3.x`
+- docs remain explicit about the repo-local `pnpm cli ...` path versus the
+  formal `multiverse ...` binary path
+
+## Definition of done
+
+- the in-scope docs are internally consistent with the current implementation
+- no new product behavior is introduced

--- a/docs/development/repo-map.md
+++ b/docs/development/repo-map.md
@@ -18,13 +18,14 @@ The repository contains behavior-first design artifacts and a working implementa
 * development guidance under `docs/development/`
 * core business logic in `packages/core/`
 * provider contracts in `packages/provider-contracts/`
-* three concrete provider packages: `provider-name-scoped`, `provider-path-scoped`, and `provider-local-port`
+* five concrete provider packages: `provider-name-scoped`, `provider-path-scoped`, `provider-local-port`, `provider-process-scoped`, and `provider-process-port-scoped`
 * a test provider registry in `packages/providers-testkit/`
 * a thin CLI in `apps/cli/`
 * a sample Express application in `apps/sample-express/`
+* a composed proving application in `apps/sample-compose/`
 * acceptance, contract, unit, and integration tests under `tests/`
 
-Implementation has progressed through 20 development slices. The core lifecycle (derive, validate, reset, cleanup) is implemented across the current declared resource and endpoint model, with multi-resource and multi-endpoint support in place.
+Implementation has progressed through 29 development slices. The core lifecycle (derive, validate, reset, cleanup) is implemented across the current declared resource and endpoint model, with multi-resource and multi-endpoint support in place, and the current `0.3.x` work is refining the composed-application consumer workflow.
 
 ## Implementation Model
 
@@ -63,6 +64,7 @@ Current application areas:
 
 * `apps/cli/` — thin CLI entrypoint for invoking Multiverse behavior
 * `apps/sample-express/` — sample application used for end-to-end integration proof
+* `apps/sample-compose/` — composed proving application for the current consumer-workflow phase
 
 Applications may parse input, invoke core behavior, and present results, but must not become the home of business rules.
 
@@ -78,6 +80,8 @@ Current packages:
 * `packages/provider-name-scoped/` — name-scoped resource isolation (derive, reset, cleanup confirmation only)
 * `packages/provider-path-scoped/` — path-scoped resource isolation (derive, effectful reset, effectful cleanup for provider-managed filesystem state)
 * `packages/provider-local-port/` — local-port endpoint isolation (derive)
+* `packages/provider-process-scoped/` — process-backed resource lifecycle as a declared isolation seam
+* `packages/provider-process-port-scoped/` — process-backed resource seam with deterministic local address handles
 
 Additional packages may be introduced when justified by real implementation boundaries.
 
@@ -238,19 +242,22 @@ Primary code targets in the current implementation phase include:
 
 * `apps/cli/`
 * `apps/sample-express/`
+* `apps/sample-compose/`
 * `packages/core/`
 * `packages/provider-contracts/`
 * `packages/providers-testkit/`
 * `packages/provider-name-scoped/`
 * `packages/provider-path-scoped/`
 * `packages/provider-local-port/`
+* `packages/provider-process-scoped/`
+* `packages/provider-process-port-scoped/`
 * `tests/`
 
 ## Development Slice Alignment
 
 Current implementation work should follow the active development slice and task documents under `docs/development/`.
 
-Slices 01–20 have been implemented. Subsequent work is tracked through current development documents and the repository’s open issues.
+Slices 01–29 have been implemented. Subsequent work is tracked through current development documents and the repository’s open issues.
 
 Contributors and agents should use those sources to determine what behavior is currently in scope.
 

--- a/docs/guides/external-demo-guide.md
+++ b/docs/guides/external-demo-guide.md
@@ -97,6 +97,13 @@ The `baseDir` is where isolated resource directories are created. Each worktree 
 
 When `pnpm cli run` starts your app, it injects isolated values as environment variables. Your application reads these instead of hardcoded configuration.
 
+For the current `0.3.x` common-case direction, there are now two explicit consumer patterns:
+
+- read the canonical `MULTIVERSE_*` transport vars directly
+- declare app-native aliases with `appEnv` and read those at one application-owned runtime-config boundary
+
+The second pattern is the preferred proving direction for composed applications because it avoids scattering Multiverse-specific names throughout application code.
+
 **Environment variables injected by `pnpm cli run`:**
 
 | Variable | Content | Example |
@@ -132,6 +139,35 @@ const port = parseInt(new URL(endpointAddress).port, 10);
 // start your server on `port`, use `dbPath` for your database file
 ```
 
+If you prefer app-owned names, declare `appEnv` in `multiverse.json`. Then `pnpm cli run` injects both the canonical `MULTIVERSE_*` variable and the alias with the same derived string value.
+
+Example:
+
+```json
+{
+  "resources": [
+    {
+      "name": "app-db",
+      "provider": "path-scoped",
+      "isolationStrategy": "path-scoped",
+      "scopedReset": true,
+      "scopedCleanup": true,
+      "appEnv": "DATABASE_PATH"
+    }
+  ],
+  "endpoints": [
+    {
+      "name": "http",
+      "role": "application-http",
+      "provider": "local-port",
+      "appEnv": "APP_HTTP_URL"
+    }
+  ]
+}
+```
+
+An application-owned runtime-config boundary can then read `DATABASE_PATH` and `APP_HTTP_URL` instead of the raw canonical names.
+
 ---
 
 ## Step 4 — Run your application
@@ -156,6 +192,7 @@ Multiverse will:
 1. Load `./multiverse.json` and `./providers.ts`
 2. Derive isolated values for `feature-login`
 3. Inject `MULTIVERSE_RESOURCE_APP_DB`, `MULTIVERSE_ENDPOINT_HTTP`, and `MULTIVERSE_WORKTREE_ID` into the process environment
+   If `appEnv` aliases are declared, inject those aliases too
 4. Start `node server.js` with those values
 5. Pass the process's stdout and stderr through unchanged
 6. Exit with the same exit code as `node server.js`


### PR DESCRIPTION
## Summary

- syncs top-level docs to the current `0.3.0-alpha.2` proving surface
- documents `sample-compose`, process-backed providers, and the current common-case consumer direction
- makes the external demo guide acknowledge app-native env aliases and runtime-config boundaries

## Scope

- `README.md`
- `docs/development/repo-map.md`
- `docs/guides/external-demo-guide.md`
- `docs/development/dev-slice-29.md`

## Validation

- documentation-only slice; no code or behavior changes

## Deferred

- no new CLI behavior
- no new declaration fields
- no broad documentation rewrite beyond the current common-case story
