### PR TITLE
feat(run): support typed endpoint appenv mapping

### DIFF
--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -13,6 +13,7 @@ import {
 } from "@multiverse/core";
 import type {
   DeriveOneResult,
+  EndpointAppEnvValueKind,
   ProviderRegistry,
   RepositoryConfiguration
 } from "@multiverse/provider-contracts";
@@ -103,10 +104,26 @@ function buildRunEnv(
  * Correlates each declaration's appEnv name with the derived value from the derive result.
  * Returns a map of appEnv name → derived value.
  */
+function extractEndpointAppEnvValue(
+  address: string,
+  kind: EndpointAppEnvValueKind
+): string | undefined {
+  if (kind === "url") {
+    return address;
+  }
+
+  const parsed = new URL(address);
+  if (parsed.port) {
+    return parsed.port;
+  }
+
+  return undefined;
+}
+
 function collectAppEnvAliases(
   repository: RepositoryConfiguration,
   result: Extract<DeriveOneResult, { ok: true }>
-): Record<string, string> {
+): Record<string, string> | { refusal: { category: "invalid_configuration"; reason: string } } {
   const aliases: Record<string, string> = {};
 
   for (const resource of repository.resources) {
@@ -118,7 +135,25 @@ function collectAppEnvAliases(
   for (const endpoint of repository.endpoints) {
     if (!endpoint.appEnv || !endpoint.name) continue;
     const mapping = result.endpointMappings.find((m) => m.endpointName === endpoint.name);
-    if (mapping) aliases[endpoint.appEnv] = mapping.address;
+    if (!mapping) continue;
+
+    if (typeof endpoint.appEnv === "string") {
+      aliases[endpoint.appEnv] = mapping.address;
+      continue;
+    }
+
+    for (const [envName, kind] of Object.entries(endpoint.appEnv)) {
+      const extracted = extractEndpointAppEnvValue(mapping.address, kind);
+      if (extracted === undefined) {
+        return {
+          refusal: {
+            category: "invalid_configuration",
+            reason: `Cannot inject app-native env var "${envName}": endpoint value kind "${kind}" could not be extracted from derived endpoint "${mapping.address}".`
+          }
+        };
+      }
+      aliases[envName] = extracted;
+    }
   }
 
   return aliases;
@@ -429,6 +464,12 @@ async function handleRun(
 
   // Collect appEnv aliases declared in the repository configuration.
   const appEnvAliases = collectAppEnvAliases(parsedConfig, deriveResult);
+  if ("refusal" in appEnvAliases) {
+    return runFailure({
+      ok: false,
+      refusal: appEnvAliases.refusal
+    });
+  }
 
   // Refuse if any appEnv name already exists in the parent environment.
   const conflict = findAppEnvConflict(appEnvAliases, parentEnv);

--- a/apps/sample-compose/multiverse.json
+++ b/apps/sample-compose/multiverse.json
@@ -24,7 +24,10 @@
       "name": "http",
       "role": "application-http",
       "provider": "local-port",
-      "appEnv": "APP_HTTP_URL"
+      "appEnv": {
+        "PORT": "port",
+        "APP_HTTP_URL": "url"
+      }
     }
   ]
 }

--- a/apps/sample-compose/src/runtime-config.ts
+++ b/apps/sample-compose/src/runtime-config.ts
@@ -13,22 +13,22 @@ export function readRuntimeConfigFromEnv(env: NodeJS.ProcessEnv = process.env): 
     throw new Error("CACHE_ADDR is required");
   }
 
-  const appHttpUrl = env["APP_HTTP_URL"];
-  if (!appHttpUrl) {
-    throw new Error("APP_HTTP_URL is required");
+  const port = env["PORT"];
+  if (!port) {
+    throw new Error("PORT is required");
   }
 
   return {
     dbPath,
     cacheAddr,
-    port: parsePortFromUrl(appHttpUrl)
+    port: parsePort(port)
   };
 }
 
-function parsePortFromUrl(address: string): number {
-  const port = Number.parseInt(new URL(address).port, 10);
+function parsePort(value: string): number {
+  const port = Number.parseInt(value, 10);
   if (Number.isNaN(port)) {
-    throw new Error(`APP_HTTP_URL must include a numeric port: ${address}`);
+    throw new Error(`PORT must be a numeric string: ${value}`);
   }
   return port;
 }

--- a/docs/development/current-state.md
+++ b/docs/development/current-state.md
@@ -15,7 +15,7 @@ This is a short state-of-the-project document, not a full history.
 
 ## Current version posture
 
-Current version posture: **0.3.0-alpha.2**
+Current version posture: **0.3.0-alpha.3**
 
 Interpretation:
 

--- a/docs/development/dev-slice-30.md
+++ b/docs/development/dev-slice-30.md
@@ -1,0 +1,60 @@
+# Dev Slice 30 — Typed Endpoint App-Env Mapping
+
+## Status
+
+In progress
+
+## ADR
+
+ADR-0019: Explicit typed endpoint mapping for app-native environment variables
+
+## Intent
+
+Extend endpoint `appEnv` mapping so `multiverse run` can inject explicit typed
+app-native values for endpoints, with support for `url` and `port`.
+
+This slice advances the `0.3.x` common-case workflow by supporting direct
+application needs like `PORT` while preserving explicit declaration, refusal-first
+behavior, and unchanged provider responsibilities.
+
+## In scope
+
+- endpoint `appEnv` may be:
+  - a single string alias, preserving ADR-0018 behavior
+  - a mapping object from app-native env names to endpoint value kinds
+- supported endpoint value kinds:
+  - `url`
+  - `port`
+- declaration validation for typed endpoint mappings
+- collision refusal for all mapped app-native endpoint env names
+- refusal when `port` cannot be extracted from the derived endpoint value
+- update `sample-compose` to consume `PORT` through its runtime-config boundary
+
+## Out of scope
+
+- resource typed mapping
+- changes to `derive --format=env`
+- provider contract or implementation changes
+- additional endpoint value kinds
+- config-file overlays
+- framework-specific behavior
+
+## Acceptance criteria
+
+- typed endpoint mapping injects both `url` and `port` values during `run`
+- alias-only endpoint mapping continues to work unchanged
+- declaration validation rejects:
+  - empty mapping objects
+  - invalid env names in typed mappings
+  - reserved `MULTIVERSE_*` names
+  - unsupported endpoint value kinds
+  - duplicate app-env names across declarations
+- `run` refuses when a mapped endpoint app-env name already exists in the parent env
+- `run` refuses when a requested `port` value cannot be extracted
+- `sample-compose` can consume `PORT` through its runtime-config boundary
+
+## Definition of done
+
+- targeted acceptance, unit, integration, and type checks pass
+- no new provider behavior is introduced
+- canonical `MULTIVERSE_*` endpoint injection remains unchanged

--- a/docs/development/roadmap.md
+++ b/docs/development/roadmap.md
@@ -26,7 +26,7 @@ Multiverse development continues under the same core assumptions:
 
 ## Current version posture
 
-Current version posture: **0.3.0-alpha.2**
+Current version posture: **0.3.0-alpha.3**
 
 What that means:
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "multiverse",
-  "version": "0.3.0-alpha.2",
+  "version": "0.3.0-alpha.3",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.33.0",

--- a/packages/core/src/declarations.ts
+++ b/packages/core/src/declarations.ts
@@ -1,5 +1,7 @@
 import type {
   EndpointDeclaration,
+  EndpointAppEnvMapping,
+  EndpointAppEnvValueKind,
   IsolationStrategy,
   ResourceDeclaration
 } from "@multiverse/provider-contracts";
@@ -7,7 +9,7 @@ import type {
 
 export interface DeclarationValidationError {
   path: string;
-  code: "required" | "invalid_env_var_name" | "reserved_name" | "duplicate_appenv";
+  code: "required" | "invalid_env_var_name" | "reserved_name" | "duplicate_appenv" | "invalid_appenv_mapping_kind";
 }
 
 export interface ValidatedResourceDeclaration {
@@ -24,12 +26,12 @@ export interface ValidatedEndpointDeclaration {
   name: string;
   role: string;
   provider: string;
-  appEnv?: string;
+  appEnv?: string | EndpointAppEnvMapping;
 }
 
 export interface EndpointDeclarationValidationError {
   path: "name" | "role" | "provider" | "appEnv";
-  code: "required" | "invalid_env_var_name" | "reserved_name";
+  code: "required" | "invalid_env_var_name" | "reserved_name" | "invalid_appenv_mapping_kind";
 }
 
 export type EndpointDeclarationValidationResult<T> =
@@ -78,14 +80,41 @@ function appEnvErrors(
 }
 
 function endpointAppEnvErrors(
-  value: string
+  value: string | EndpointAppEnvMapping
 ): EndpointDeclarationValidationError[] {
-  const errors: EndpointDeclarationValidationError[] = [];
-  if (!isValidEnvVarName(value)) {
-    errors.push({ path: "appEnv", code: "invalid_env_var_name" });
-  } else if (isReservedEnvVarName(value)) {
-    errors.push({ path: "appEnv", code: "reserved_name" });
+  if (typeof value === "string") {
+    const errors: EndpointDeclarationValidationError[] = [];
+    if (!isValidEnvVarName(value)) {
+      errors.push({ path: "appEnv", code: "invalid_env_var_name" });
+    } else if (isReservedEnvVarName(value)) {
+      errors.push({ path: "appEnv", code: "reserved_name" });
+    }
+    return errors;
   }
+
+  const errors: EndpointDeclarationValidationError[] = [];
+  const entries = Object.entries(value);
+  if (entries.length === 0) {
+    errors.push({ path: "appEnv", code: "invalid_env_var_name" });
+    return errors;
+  }
+
+  for (const [envName, kind] of entries) {
+    if (!isValidEnvVarName(envName)) {
+      errors.push({ path: "appEnv", code: "invalid_env_var_name" });
+      continue;
+    }
+
+    if (isReservedEnvVarName(envName)) {
+      errors.push({ path: "appEnv", code: "reserved_name" });
+      continue;
+    }
+
+    if (kind !== "url" && kind !== "port") {
+      errors.push({ path: "appEnv", code: "invalid_appenv_mapping_kind" });
+    }
+  }
+
   return errors;
 }
 

--- a/packages/core/src/repository-configuration.ts
+++ b/packages/core/src/repository-configuration.ts
@@ -81,14 +81,21 @@ export function validateRepositoryConfiguration(
 
     for (const [index, endpoint] of endpoints.entries()) {
       if (endpoint.appEnv === undefined) continue;
-      const existing = seen.get(endpoint.appEnv);
-      if (existing !== undefined) {
-        errors.push({
-          path: `endpoints[${index}].appEnv`,
-          code: "duplicate_appenv"
-        });
-      } else {
-        seen.set(endpoint.appEnv, `endpoints[${index}].appEnv`);
+
+      const names = typeof endpoint.appEnv === "string"
+        ? [endpoint.appEnv]
+        : Object.keys(endpoint.appEnv);
+
+      for (const envName of names) {
+        const existing = seen.get(envName);
+        if (existing !== undefined) {
+          errors.push({
+            path: `endpoints[${index}].appEnv`,
+            code: "duplicate_appenv"
+          });
+        } else {
+          seen.set(envName, `endpoints[${index}].appEnv`);
+        }
       }
     }
   }

--- a/packages/provider-contracts/src/index.ts
+++ b/packages/provider-contracts/src/index.ts
@@ -37,11 +37,14 @@ export interface ResourceDeclaration {
   appEnv?: string;
 }
 
+export type EndpointAppEnvValueKind = "url" | "port";
+export type EndpointAppEnvMapping = Record<string, EndpointAppEnvValueKind>;
+
 export interface EndpointDeclaration {
   name?: string;
   role?: string;
   provider?: string;
-  appEnv?: string;
+  appEnv?: string | EndpointAppEnvMapping;
 }
 
 export interface RepositoryConfiguration {

--- a/packages/providers-testkit/src/index.ts
+++ b/packages/providers-testkit/src/index.ts
@@ -178,6 +178,21 @@ export function createExplicitTestProviders(): ProviderRegistry {
             address: `http://${worktree.id}.local/${endpoint.name}`
           };
         }
+      },
+      "test-port-endpoint-provider": {
+        deriveEndpoint({ endpoint, worktree }) {
+          if (!worktree.id) {
+            return unsafeScope("Safe worktree scope cannot be determined.");
+          }
+
+          return {
+            endpointName: endpoint.name,
+            provider: endpoint.provider,
+            role: endpoint.role,
+            worktreeId: worktree.id,
+            address: "http://127.0.0.1:5500"
+          };
+        }
       }
     }
   };

--- a/tests/acceptance/cli-run-appenv-mapping.acceptance.test.ts
+++ b/tests/acceptance/cli-run-appenv-mapping.acceptance.test.ts
@@ -1,14 +1,15 @@
 /**
- * Acceptance tests for ADR-0018: explicit app-native env mapping for `multiverse run`.
+ * Acceptance tests for ADR-0018 and ADR-0019: explicit app-native env mapping for `multiverse run`.
  *
  * Behavior under test:
  *   - `appEnv` on a resource declaration causes `run` to inject both the canonical
  *     MULTIVERSE_RESOURCE_<NAME> var and an alias under the declared app-native name
- *   - `appEnv` on an endpoint declaration causes the same alias behavior
- *   - The alias value equals the canonical derived string (alias-only, no extraction)
+ *   - `appEnv` on an endpoint declaration supports alias-only or explicit typed mapping behavior
+ *   - Typed endpoint mapping can inject both `url` and `port` values
  *   - Declarations without `appEnv` inject only the canonical var (no regression)
  *   - `run` refuses when a declared `appEnv` name already exists in the parent environment
- *   - Declaration validation refuses invalid, empty, reserved, and duplicate `appEnv` values
+ *   - `run` refuses when a typed endpoint value cannot be extracted
+ *   - Declaration validation refuses invalid, empty, reserved, unsupported, and duplicate `appEnv` values
  *   - `derive --format=env` is unaffected (canonical-only output)
  */
 
@@ -116,6 +117,40 @@ describe("CLI run — appEnv mapping (ADR-0018)", () => {
     expect(capturedEnv["MULTIVERSE_ENDPOINT_APP_BASE_URL"]).toBe("http://wt-appenv-endpoint.local/app-base-url");
     // alias injected with the same string value
     expect(capturedEnv["APP_URL"]).toBe("http://wt-appenv-endpoint.local/app-base-url");
+  });
+
+  it("injects typed endpoint appEnv values for both url and port", async () => {
+    const configPath = await writeConfig({
+      resources: [],
+      endpoints: [
+        {
+          name: "http",
+          role: "application-http",
+          provider: "test-port-endpoint-provider",
+          appEnv: {
+            APP_HTTP_URL: "url",
+            PORT: "port"
+          }
+        }
+      ]
+    });
+
+    let capturedEnv: Record<string, string> = {};
+    const runner: ChildProcessRunner = async ({ env }) => {
+      capturedEnv = { ...env };
+      return { exitCode: 0 };
+    };
+
+    const outcome = await runCli(
+      ["run", "--config", configPath, "--providers", providersModulePath,
+       "--worktree-id", "wt-typed-endpoint", "--", "node", "-e", "0"],
+      { runner, parentEnv: {} }
+    );
+
+    expect(outcome.exitCode).toBe(0);
+    expect(capturedEnv["MULTIVERSE_ENDPOINT_HTTP"]).toBe("http://127.0.0.1:5500");
+    expect(capturedEnv["APP_HTTP_URL"]).toBe("http://127.0.0.1:5500");
+    expect(capturedEnv["PORT"]).toBe("5500");
   });
 
   // ---------------------------------------------------------------------------
@@ -320,6 +355,77 @@ describe("CLI run — appEnv mapping (ADR-0018)", () => {
     expect(parsed.refusal?.category).toBe("invalid_configuration");
   });
 
+  it("refuses when a typed endpoint appEnv name already exists in the parent environment", async () => {
+    const configPath = await writeConfig({
+      resources: [],
+      endpoints: [
+        {
+          name: "http",
+          role: "application-http",
+          provider: "test-port-endpoint-provider",
+          appEnv: {
+            PORT: "port",
+            APP_HTTP_URL: "url"
+          }
+        }
+      ]
+    });
+
+    let runnerCalled = false;
+    const runner: ChildProcessRunner = async () => {
+      runnerCalled = true;
+      return { exitCode: 0 };
+    };
+
+    const outcome = await runCli(
+      ["run", "--config", configPath, "--providers", providersModulePath,
+       "--worktree-id", "wt-typed-endpoint-conflict", "--", "node", "-e", "0"],
+      { runner, parentEnv: { PORT: "3000" } }
+    );
+
+    expect(outcome.exitCode).toBe(1);
+    expect(runnerCalled).toBe(false);
+    const parsed = JSON.parse(outcome.stderr[0]!) as { ok: boolean; refusal?: { category: string; reason: string } };
+    expect(parsed.ok).toBe(false);
+    expect(parsed.refusal?.category).toBe("invalid_configuration");
+    expect(parsed.refusal?.reason).toMatch(/PORT/);
+  });
+
+  it("refuses when typed endpoint port extraction cannot be performed", async () => {
+    const configPath = await writeConfig({
+      resources: [],
+      endpoints: [
+        {
+          name: "app-base-url",
+          role: "application-base-url",
+          provider: "test-endpoint-provider",
+          appEnv: {
+            PORT: "port"
+          }
+        }
+      ]
+    });
+
+    let runnerCalled = false;
+    const runner: ChildProcessRunner = async () => {
+      runnerCalled = true;
+      return { exitCode: 0 };
+    };
+
+    const outcome = await runCli(
+      ["run", "--config", configPath, "--providers", providersModulePath,
+       "--worktree-id", "wt-port-extraction-refusal", "--", "node", "-e", "0"],
+      { runner, parentEnv: {} }
+    );
+
+    expect(outcome.exitCode).toBe(1);
+    expect(runnerCalled).toBe(false);
+    const parsed = JSON.parse(outcome.stderr[0]!) as { ok: boolean; refusal?: { category: string; reason: string } };
+    expect(parsed.ok).toBe(false);
+    expect(parsed.refusal?.category).toBe("invalid_configuration");
+    expect(parsed.refusal?.reason).toMatch(/PORT/);
+  });
+
   // ---------------------------------------------------------------------------
   // Declaration validation — appEnv field
   // ---------------------------------------------------------------------------
@@ -431,6 +537,56 @@ describe("CLI run — appEnv mapping (ADR-0018)", () => {
     const outcome = await runCli(
       ["run", "--config", configPath, "--providers", providersModulePath,
        "--worktree-id", "wt-dup-appenv", "--", "node", "-e", "0"],
+      { runner: async () => ({ exitCode: 0 }) }
+    );
+
+    expect(outcome.exitCode).toBe(1);
+    const parsed = JSON.parse(outcome.stderr[0]!) as { ok: boolean };
+    expect(parsed.ok).toBe(false);
+  });
+
+  it("refuses derive when endpoint typed appEnv uses an unsupported value kind", async () => {
+    const configPath = await writeConfig({
+      resources: [],
+      endpoints: [
+        {
+          name: "http",
+          role: "application-http",
+          provider: "test-endpoint-provider",
+          appEnv: {
+            PORT: "hostname"
+          }
+        }
+      ]
+    });
+
+    const outcome = await runCli(
+      ["run", "--config", configPath, "--providers", providersModulePath,
+       "--worktree-id", "wt-invalid-kind", "--", "node", "-e", "0"],
+      { runner: async () => ({ exitCode: 0 }) }
+    );
+
+    expect(outcome.exitCode).toBe(1);
+    const parsed = JSON.parse(outcome.stderr[0]!) as { ok: boolean };
+    expect(parsed.ok).toBe(false);
+  });
+
+  it("refuses derive when endpoint typed appEnv is an empty object", async () => {
+    const configPath = await writeConfig({
+      resources: [],
+      endpoints: [
+        {
+          name: "http",
+          role: "application-http",
+          provider: "test-endpoint-provider",
+          appEnv: {}
+        }
+      ]
+    });
+
+    const outcome = await runCli(
+      ["run", "--config", configPath, "--providers", providersModulePath,
+       "--worktree-id", "wt-empty-object", "--", "node", "-e", "0"],
       { runner: async () => ({ exitCode: 0 }) }
     );
 

--- a/tests/unit/declarations-appenv.test.ts
+++ b/tests/unit/declarations-appenv.test.ts
@@ -5,6 +5,7 @@
  *   - "invalid_env_var_name" — appEnv is present but fails the valid name pattern
  *   - "reserved_name"        — appEnv begins with MULTIVERSE_
  *   - "duplicate_appenv"     — same appEnv value appears in more than one declaration
+ *   - "invalid_appenv_mapping_kind" — endpoint typed mapping uses an unsupported value kind
  */
 
 import { describe, expect, it } from "vitest";
@@ -240,6 +241,86 @@ describe("endpoint declaration appEnv validation", () => {
       expect.objectContaining({ code: "reserved_name" })
     );
   });
+
+  it("accepts a typed endpoint appEnv mapping with url and port", () => {
+    const result = validateEndpointDeclaration({
+      name: "http",
+      role: "application-http",
+      provider: "local-port",
+      appEnv: {
+        APP_HTTP_URL: "url",
+        PORT: "port"
+      }
+    });
+
+    expect(result.ok).toBe(true);
+  });
+
+  it("rejects an empty typed endpoint appEnv mapping", () => {
+    const result = validateEndpointDeclaration({
+      name: "http",
+      role: "application-http",
+      provider: "local-port",
+      appEnv: {}
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors).toContainEqual(
+      expect.objectContaining({ code: "invalid_env_var_name" })
+    );
+  });
+
+  it("rejects a typed endpoint appEnv mapping with an invalid env name", () => {
+    const result = validateEndpointDeclaration({
+      name: "http",
+      role: "application-http",
+      provider: "local-port",
+      appEnv: {
+        "BAD-NAME": "port"
+      }
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors).toContainEqual(
+      expect.objectContaining({ code: "invalid_env_var_name" })
+    );
+  });
+
+  it("rejects a typed endpoint appEnv mapping with a reserved env name", () => {
+    const result = validateEndpointDeclaration({
+      name: "http",
+      role: "application-http",
+      provider: "local-port",
+      appEnv: {
+        MULTIVERSE_PORT: "port"
+      }
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors).toContainEqual(
+      expect.objectContaining({ code: "reserved_name" })
+    );
+  });
+
+  it("rejects a typed endpoint appEnv mapping with an unsupported value kind", () => {
+    const result = validateEndpointDeclaration({
+      name: "http",
+      role: "application-http",
+      provider: "local-port",
+      appEnv: {
+        PORT: "hostname"
+      } as unknown as NonNullable<Parameters<typeof validateEndpointDeclaration>[0]["appEnv"]>
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors).toContainEqual(
+      expect.objectContaining({ code: "invalid_appenv_mapping_kind" })
+    );
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -333,6 +414,39 @@ describe("cross-declaration duplicate appEnv validation", () => {
     });
 
     expect(result.ok).toBe(true);
+  });
+
+  it("rejects a config where an endpoint typed appEnv name duplicates another declaration", () => {
+    const result = validateRepositoryConfiguration({
+      resources: [
+        {
+          name: "primary-db",
+          provider: "test-resource-provider",
+          isolationStrategy: "name-scoped",
+          scopedValidate: false,
+          scopedReset: false,
+          scopedCleanup: false,
+          appEnv: "PORT"
+        }
+      ],
+      endpoints: [
+        {
+          name: "http",
+          role: "application-http",
+          provider: "test-endpoint-provider",
+          appEnv: {
+            PORT: "port",
+            APP_HTTP_URL: "url"
+          }
+        }
+      ]
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors).toContainEqual(
+      expect.objectContaining({ code: "duplicate_appenv" })
+    );
   });
 
   it("accepts a config where no declarations have appEnv (no duplicate check needed)", () => {

--- a/tests/unit/sample-compose-runtime-config.test.ts
+++ b/tests/unit/sample-compose-runtime-config.test.ts
@@ -7,7 +7,7 @@ describe("sample-compose runtime config boundary", () => {
     const config = readRuntimeConfigFromEnv({
       DATABASE_PATH: "/tmp/app-db",
       CACHE_ADDR: "localhost:6401",
-      APP_HTTP_URL: "http://127.0.0.1:5401"
+      PORT: "5401"
     });
 
     expect(config).toEqual({
@@ -21,7 +21,7 @@ describe("sample-compose runtime config boundary", () => {
     expect(() =>
       readRuntimeConfigFromEnv({
         CACHE_ADDR: "localhost:6401",
-        APP_HTTP_URL: "http://127.0.0.1:5401"
+        PORT: "5401"
       })
     ).toThrow("DATABASE_PATH is required");
   });
@@ -30,28 +30,28 @@ describe("sample-compose runtime config boundary", () => {
     expect(() =>
       readRuntimeConfigFromEnv({
         DATABASE_PATH: "/tmp/app-db",
-        APP_HTTP_URL: "http://127.0.0.1:5401"
+        PORT: "5401"
       })
     ).toThrow("CACHE_ADDR is required");
   });
 
-  it("refuses when APP_HTTP_URL is missing", () => {
+  it("refuses when PORT is missing", () => {
     expect(() =>
       readRuntimeConfigFromEnv({
         DATABASE_PATH: "/tmp/app-db",
         CACHE_ADDR: "localhost:6401"
       })
-    ).toThrow("APP_HTTP_URL is required");
+    ).toThrow("PORT is required");
   });
 
-  it("refuses malformed APP_HTTP_URL input", () => {
+  it("refuses malformed PORT input", () => {
     expect(() =>
       readRuntimeConfigFromEnv({
         DATABASE_PATH: "/tmp/app-db",
         CACHE_ADDR: "localhost:6401",
-        APP_HTTP_URL: "http://127.0.0.1"
+        PORT: "not-a-number"
       })
-    ).toThrow("APP_HTTP_URL must include a numeric port");
+    ).toThrow("PORT must be a numeric string");
   });
 
   it("does not fall back to raw MULTIVERSE_* env vars", () => {


### PR DESCRIPTION
## Summary

- bumps the repo posture to `0.3.0-alpha.3`
- implements ADR 0019 typed endpoint `appEnv` mapping for `run`
- supports explicit endpoint app-native `url` and `port` injection
- updates `sample-compose` to consume `PORT` through its runtime-config boundary

## Scope

- `packages/provider-contracts/src/index.ts` — typed endpoint `appEnv` shape
- `packages/core/src/declarations.ts` — endpoint typed-mapping validation
- `packages/core/src/repository-configuration.ts` — duplicate detection across typed endpoint names
- `apps/cli/src/index.ts` — typed endpoint extraction and refusal handling during `run`
- `packages/providers-testkit/src/index.ts` — port-bearing endpoint fixture for acceptance coverage
- `tests/acceptance/cli-run-appenv-mapping.acceptance.test.ts` — typed endpoint run/refusal coverage
- `tests/unit/declarations-appenv.test.ts` — typed endpoint validation coverage
- `apps/sample-compose/multiverse.json` and `apps/sample-compose/src/runtime-config.ts` — `PORT` proof
- `tests/unit/sample-compose-runtime-config.test.ts` — runtime-config boundary updated for `PORT`
- `docs/development/dev-slice-30.md` — slice doc
- `package.json`, `docs/development/roadmap.md`, `docs/development/current-state.md` — version posture updated to `0.3.0-alpha.3`

## Validation

- `pnpm test:acceptance -- tests/acceptance/cli-run-appenv-mapping.acceptance.test.ts`
- `pnpm test:unit -- tests/unit/declarations-appenv.test.ts tests/unit/sample-compose-runtime-config.test.ts`
- `pnpm test:integration`
- `pnpm typecheck`

## Deferred

- no resource typed mapping
- no `derive --format=env` changes
- no endpoint kinds beyond `url` and `port`
