### PR TITLE
docs: recalibrate state after ADR 0019

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Today’s repo includes:
 
 ## Current behavior being proven
 
-The current implementation proves the core loop for explicit declarations and deterministic derivation, plus the current `0.3.0-alpha.2` consumer-workflow refinement direction.
+The current implementation proves the core loop for explicit declarations and deterministic derivation, plus the current `0.3.0-alpha.3` consumer-workflow refinement direction.
 
 That includes:
 
@@ -74,6 +74,7 @@ That includes:
 * `derive --format=env` for shell-sourceable KEY=VALUE output
 * sample Express application end-to-end integration proof
 * app-native env alias injection during `run`
+* typed endpoint app-native env injection for `url` and `port`
 * a composed `sample-compose` proof for mixed-provider consumption in one app
 * an application-owned runtime-config boundary for the composed sample app
 
@@ -166,7 +167,7 @@ pnpm cli cleanup --worktree-id <id>
 
 `--config` defaults to `./multiverse.json` and `--providers` defaults to `./providers.ts` when not specified. `--worktree-id` is always required.
 
-For the current common-case `0.3.x` proving path, `run` can inject both canonical `MULTIVERSE_*` transport vars and explicit app-native aliases declared with `appEnv`. The preferred application pattern is to read those app-owned names at one runtime-config boundary rather than scatter direct `MULTIVERSE_*` reads through the app.
+For the current common-case `0.3.x` proving path, `run` can inject both canonical `MULTIVERSE_*` transport vars and explicit app-native values declared with `appEnv`. For endpoints, that now includes explicit typed mapping for `url` and `port`. The preferred application pattern is to read those app-owned names at one runtime-config boundary rather than scatter direct `MULTIVERSE_*` reads through the app.
 
 ## Source-of-truth order
 

--- a/docs/development/current-state.md
+++ b/docs/development/current-state.md
@@ -22,7 +22,7 @@ Interpretation:
 * the core product thesis is proven in real workflows
 * the usable core of Multiverse has moved beyond isolated seam proofs
 * a richer composed application workflow has now been demonstrated through mixed-provider integration
-* the product is still in active proving, but the next major focus is consumer workflow maturity rather than basic feasibility
+* the product is still in active proving, but the consumer-workflow question is now materially narrower than it was before ADR 0018 and ADR 0019
 
 ## What is already proven
 
@@ -43,6 +43,8 @@ The following are now considered proven enough to serve as the working baseline 
 * `reset` and `cleanup` support declared lifecycle behavior where allowed
 * `pnpm cli ...` remains the repo-local development path
 * formal CLI packaging and binary invocation support for `multiverse ...` now exist alongside the repo-local `pnpm cli ...` development path
+* `run` supports explicit app-native env injection for resources and endpoints
+* endpoint app-native mapping now supports both `url` and extracted `port` values
 
 ### Provider model
 
@@ -72,37 +74,41 @@ A richer composed proving application now demonstrates that one application can 
 
 This proves that mixed-provider composition can work in one running application without collapsing the model.
 
+The current composed proof also now demonstrates:
+
+* app-native env mapping for all three seams
+* typed endpoint mapping for `PORT`
+* an application-owned runtime-config boundary in `sample-compose`
+
 ## Current highest-priority proving question
 
 The current highest-priority question is:
 
-**What is the cleanest explicit consumer integration model for composed applications, so that developers do not have to code directly against raw MULTIVERSE_* environment variables in the common 1.0 workflow?**
+**Has the current explicit consumer integration model been proven enough to treat it as the credible common-case direction for 1.0, rather than still as an open exploration?**
 
-This is the main focus of the current implementation phase.
+ADR 0018 and ADR 0019, together with the current `sample-compose` proof, have narrowed this question substantially.
 
 ## Current priority
 
 The current priority is:
 
-**Refining the composed application developer experience**
+**Confirming and stabilizing the now-proven composed application developer experience**
 
 That means work should preferentially strengthen:
 
-* the common-case workflow for composed applications
+* clarity and stability of the common-case workflow for composed applications
 * explicit and low-friction consumption of derived runtime values
-* app-native configuration mapping where justified
-* realistic multi-seam runtime flows
-* continued integration coverage only where it sharpens confidence in the consumer experience
+* the now-proven app-native mapping and runtime-config boundary story
+* realistic multi-seam runtime flows only where they sharpen confidence
 
 ## What kinds of work are highest-value right now
 
 Examples of work that are strongly aligned with the current phase:
 
-* building a more complex proving application than the initial sample
-* composing path-scoped, process-backed, and endpoint-based seams in one app
-* adding integration tests for mixed-provider workflows
-* refining docs/guides around composed application demos
-* tightening CLI/runtime behavior only where it improves the common proving workflow
+* tightening docs and planning around the proven common-case path
+* bounded stabilization of the chosen consumer model
+* clarifying any remaining refusal or lifecycle edges only where they affect trust in the current consumer story
+* preparing the transition to the next major proving question if no concrete `0.3.x` behavior gap remains
 
 ## What is intentionally deferred
 
@@ -120,10 +126,12 @@ These are not rejected. They are deferred until the richer composed application 
 The 0.3.x line should be understood as:
 
 * composed application behavior is now proven enough to refine
-* the current focus is consumer workflow maturity
+* the current focus is confirming that the chosen consumer workflow is credible and stable enough
 * the repo is not yet in ecosystem or outside-user optimization mode
 
 A move beyond 0.3.x should happen only after the composed application workflow feels clean, the consumer integration model is materially improved, and the common-case workflow is stable enough for broader extension and usability work.
+
+At the current repo state, the source documents do not define one remaining concrete product-behavior gap inside `0.3.x`. If more `0.3.x` work is needed, it is most likely a narrow stabilization or documentation clarification, not a new exploratory consumer-model feature.
 
 ## Practical instruction for contributors and agents
 
@@ -131,9 +139,9 @@ When deciding what to work on next, prefer work that answers the current proving
 
 Use this preference order:
 
-1. richer composed application behavior
-2. integration coverage for mixed-provider workflows
-3. docs/guides that support the richer proving story
+1. bounded stabilization of the proven common-case workflow
+2. docs/guides that support the richer proving story
+3. transition planning toward the next major proving question
 4. only then broader extension/ecosystem work
 
 If a potential task is interesting but does not materially strengthen the current proving direction, it is probably not the highest-value next task.

--- a/docs/development/dev-slice-29.md
+++ b/docs/development/dev-slice-29.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-In progress
+Completed
 
 ## Intent
 

--- a/docs/development/dev-slice-30.md
+++ b/docs/development/dev-slice-30.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-In progress
+Completed
 
 ## ADR
 

--- a/docs/development/repo-map.md
+++ b/docs/development/repo-map.md
@@ -25,7 +25,7 @@ The repository contains behavior-first design artifacts and a working implementa
 * a composed proving application in `apps/sample-compose/`
 * acceptance, contract, unit, and integration tests under `tests/`
 
-Implementation has progressed through 29 development slices. The core lifecycle (derive, validate, reset, cleanup) is implemented across the current declared resource and endpoint model, with multi-resource and multi-endpoint support in place, and the current `0.3.x` work is refining the composed-application consumer workflow.
+Implementation has progressed through 30 development slices. The core lifecycle (derive, validate, reset, cleanup) is implemented across the current declared resource and endpoint model, with multi-resource and multi-endpoint support in place, and the current `0.3.x` work has now proven the main composed-application consumer workflow.
 
 ## Implementation Model
 
@@ -257,7 +257,7 @@ Primary code targets in the current implementation phase include:
 
 Current implementation work should follow the active development slice and task documents under `docs/development/`.
 
-Slices 01–29 have been implemented. Subsequent work is tracked through current development documents and the repository’s open issues.
+Slices 01–30 have been implemented. Subsequent work is tracked through current development documents and the repository’s open issues.
 
 Contributors and agents should use those sources to determine what behavior is currently in scope.
 

--- a/docs/development/roadmap.md
+++ b/docs/development/roadmap.md
@@ -35,7 +35,11 @@ What that means:
 * explicit `run` workflow exists
 * multiple provider shapes have been implemented and tested
 * a richer composed application workflow has now been proven through mixed-provider integration
-* the current focus is refining the composed application developer experience and stabilizing the common-case workflow
+* the current `0.3.x` proving path now includes:
+  * explicit app-native env mapping for resources and endpoints
+  * typed endpoint mapping for `url` and `port`
+  * an application-owned runtime-config boundary proof in `sample-compose`
+* the current focus is confirming that the common-case workflow is now credible enough to transition toward `0.4.x` extensibility proof
 
 ## Version roadmap
 
@@ -128,6 +132,19 @@ The likely preferred 1.0-facing direction is:
 
 The product should evolve away from requiring direct reads of raw `MULTIVERSE_*` names throughout consumer application code.
 
+### What 0.3.x has now proven
+
+The current `0.3.x` implementation has proven a concrete common-case consumer path:
+
+* `multiverse run` still injects canonical `MULTIVERSE_*` transport variables
+* repository configuration can map resources to app-native env names explicitly
+* repository configuration can map endpoints to either:
+  * full `url` values, or
+  * extracted `port` values
+* a composed application can consume those app-owned names at one explicit runtime-config boundary instead of scattering direct `MULTIVERSE_*` reads through the app
+
+This means the `0.3.x` line is no longer primarily exploring whether a cleaner consumer model is possible. It has a credible explicit proving path.
+
 ### Typical work in this phase
 
 Examples:
@@ -158,6 +175,11 @@ The project should not move beyond `0.3.x` until:
 * reset and cleanup behavior remain understandable under mixed-provider composition
 * the richer proving app can be demonstrated and explained without author-only knowledge
 * the common-case workflow is stable enough to support broader extension and usability work
+
+At the current `0.3.0-alpha.3` posture, no additional single concrete product-behavior gap is defined in the source-of-truth documents. Remaining `0.3.x` work, if any, is more likely to be:
+
+* bounded stabilization of the chosen consumer model, or
+* documentation and transition work that makes readiness for `0.4.x` explicit
 
 ## 0.4.x alpha — extensibility proof
 
@@ -457,10 +479,9 @@ It should mean that the product is trustworthy in its intended scope.
 
 The current near-term direction is:
 
-* refine the composed application workflow now proven by `sample-compose`
-* reduce developer friction in how applications consume Multiverse-derived runtime values
-* explore explicit app-native configuration mapping for the common-case workflow
-* continue strengthening realistic multi-seam integration coverage where it improves confidence
+* confirm and document the now-proven common-case consumer workflow
+* stabilize the chosen consumer model where needed without broadening scope
+* transition toward `0.4.x` extensibility proof once no concrete remaining `0.3.x` consumer gap is identified
 
 Provider-ecosystem formalization remains deferred until the consumer workflow for composed applications is more mature.
 
@@ -471,6 +492,8 @@ The current preferred direction for reducing developer friction is:
 1. explicit app-native environment variable overlay at process launch
 2. application-owned runtime config boundaries where needed
 3. generated or overlay config-file workflows only if explicitly declared and truly necessary
+
+The current implementation has already proven items 1 and 2 in the composed sample application. No broader config-overlay workflow is currently justified by the source documents.
 
 The following are explicitly out of bounds for the common path:
 

--- a/docs/guides/external-demo-guide.md
+++ b/docs/guides/external-demo-guide.md
@@ -139,7 +139,7 @@ const port = parseInt(new URL(endpointAddress).port, 10);
 // start your server on `port`, use `dbPath` for your database file
 ```
 
-If you prefer app-owned names, declare `appEnv` in `multiverse.json`. Then `pnpm cli run` injects both the canonical `MULTIVERSE_*` variable and the alias with the same derived string value.
+If you prefer app-owned names, declare `appEnv` in `multiverse.json`. Then `pnpm cli run` injects both the canonical `MULTIVERSE_*` variable and the explicit app-native values for that declaration.
 
 Example:
 
@@ -160,13 +160,16 @@ Example:
       "name": "http",
       "role": "application-http",
       "provider": "local-port",
-      "appEnv": "APP_HTTP_URL"
+      "appEnv": {
+        "PORT": "port",
+        "APP_HTTP_URL": "url"
+      }
     }
   ]
 }
 ```
 
-An application-owned runtime-config boundary can then read `DATABASE_PATH` and `APP_HTTP_URL` instead of the raw canonical names.
+An application-owned runtime-config boundary can then read `DATABASE_PATH`, `APP_HTTP_URL`, and `PORT` instead of the raw canonical names.
 
 ---
 


### PR DESCRIPTION
## Summary

- recalibrates roadmap, current-state, README, repo-map, and the external demo guide after ADR 0019
- makes the `0.3.0-alpha.3` repo truth explicit: app-native env mapping, typed endpoint `url`/`port` mapping, and the `sample-compose` runtime-config boundary are now proven
- clarifies that no single remaining concrete `0.3.x` product-behavior gap is currently defined in the source docs

## Scope

- `README.md`
- `docs/development/current-state.md`
- `docs/development/roadmap.md`
- `docs/development/repo-map.md`
- `docs/guides/external-demo-guide.md`
- `docs/development/dev-slice-29.md`
- `docs/development/dev-slice-30.md`

## Validation

- documentation-only slice; no code or behavior changes

## Deferred

- no new product behavior
- no new slice implementation
- no roadmap expansion beyond the current source-of-truth state
