### PR TITLE
feat(slice-31): add fixed-host-port endpoint provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,13 +45,14 @@ Today’s repo includes:
   * name-scoped resources
   * path-scoped resources
   * local-port endpoints
+  * fixed-host-port endpoints
   * process-scoped resources
   * process-port-scoped resources
 * acceptance, contract, unit, and integration tests
 
 ## Current behavior being proven
 
-The current implementation proves the core loop for explicit declarations and deterministic derivation, plus the current `0.3.0-alpha.3` consumer-workflow refinement direction.
+The current implementation proves the core loop for explicit declarations and deterministic derivation, plus the current `0.3.0-alpha.3` consumer-workflow path and the first `0.4.x` endpoint-provider extensibility proof.
 
 That includes:
 
@@ -63,6 +64,7 @@ That includes:
   * name-scoped resources
   * path-scoped resources
   * local-port endpoints
+  * fixed-host-port endpoints
   * process-scoped resources
   * process-port-scoped resources
 * multi-resource and multi-endpoint support
@@ -107,6 +109,7 @@ This keeps the tool predictable and avoids hidden behavior around consequential 
 * `packages/provider-name-scoped/` — name-scoped resource provider
 * `packages/provider-path-scoped/` — path-scoped resource provider
 * `packages/provider-local-port/` — local-port endpoint provider
+* `packages/provider-fixed-host-port/` — fixed-host plus derived-port endpoint provider
 * `packages/provider-process-scoped/` — process-backed resource provider
 * `packages/provider-process-port-scoped/` — process-backed resource-with-address provider
 

--- a/docs/development/current-state.md
+++ b/docs/development/current-state.md
@@ -23,6 +23,7 @@ Interpretation:
 * the usable core of Multiverse has moved beyond isolated seam proofs
 * a richer composed application workflow has now been demonstrated through mixed-provider integration
 * the product is still in active proving, but the consumer-workflow question is now materially narrower than it was before ADR 0018 and ADR 0019
+* the repository has now started the first `0.4.x` extensibility proof with a second endpoint-provider shape
 
 ## What is already proven
 
@@ -53,6 +54,7 @@ The provider model has been proven across several shapes, including:
 * name-scoped resource behavior
 * path-scoped resource behavior
 * local-port endpoint behavior
+* fixed-host-port endpoint behavior
 * process-scoped resource behavior
 * process-port-scoped resource behavior
 
@@ -84,31 +86,31 @@ The current composed proof also now demonstrates:
 
 The current highest-priority question is:
 
-**Has the current explicit consumer integration model been proven enough to treat it as the credible common-case direction for 1.0, rather than still as an open exploration?**
+**Can a second explicit endpoint-provider shape be added without changing the established consumer workflow or weakening the core/provider boundary?**
 
-ADR 0018 and ADR 0019, together with the current `sample-compose` proof, have narrowed this question substantially.
+ADR 0018 and ADR 0019 established the consumer workflow strongly enough to move to this next question. ADR 0020 defines the first narrow extensibility proof.
 
 ## Current priority
 
 The current priority is:
 
-**Confirming and stabilizing the now-proven composed application developer experience**
+**Executing and stabilizing the first `0.4.x` extensibility proof while preserving the now-proven consumer workflow**
 
 That means work should preferentially strengthen:
 
-* clarity and stability of the common-case workflow for composed applications
-* explicit and low-friction consumption of derived runtime values
-* the now-proven app-native mapping and runtime-config boundary story
-* realistic multi-seam runtime flows only where they sharpen confidence
+* the first additional provider shape under the existing endpoint contract
+* clarity of the line between repository-owned declaration config and provider-owned derivation rules
+* confidence that `run` and app-native endpoint mapping remain unchanged for consumers
+* docs and tests that make the new extensibility seam understandable without widening scope
 
 ## What kinds of work are highest-value right now
 
 Examples of work that are strongly aligned with the current phase:
 
-* tightening docs and planning around the proven common-case path
-* bounded stabilization of the chosen consumer model
-* clarifying any remaining refusal or lifecycle edges only where they affect trust in the current consumer story
-* preparing the transition to the next major proving question if no concrete `0.3.x` behavior gap remains
+* implementing one additional meaningful provider shape cleanly
+* tightening docs around what belongs in core versus provider code
+* bounded stabilization of declaration validation and refusal behavior for the new seam
+* preserving the proven app-native mapping and runtime-config boundary story while extensibility grows
 
 ## What is intentionally deferred
 

--- a/docs/development/roadmap.md
+++ b/docs/development/roadmap.md
@@ -39,7 +39,7 @@ What that means:
   * explicit app-native env mapping for resources and endpoints
   * typed endpoint mapping for `url` and `port`
   * an application-owned runtime-config boundary proof in `sample-compose`
-* the current focus is confirming that the common-case workflow is now credible enough to transition toward `0.4.x` extensibility proof
+* the common-case workflow is now credible enough that the first `0.4.x` extensibility slice can begin
 
 ## Version roadmap
 

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@multiverse/core": "workspace:*",
     "@multiverse/cli": "workspace:*",
     "@multiverse/provider-contracts": "workspace:*",
+    "@multiverse/provider-fixed-host-port": "workspace:*",
     "@multiverse/provider-local-port": "workspace:*",
     "@multiverse/provider-name-scoped": "workspace:*",
     "@multiverse/provider-path-scoped": "workspace:*",

--- a/packages/core/src/declarations.ts
+++ b/packages/core/src/declarations.ts
@@ -1,15 +1,17 @@
 import type {
   EndpointDeclaration,
   EndpointAppEnvMapping,
-  EndpointAppEnvValueKind,
   IsolationStrategy,
   ResourceDeclaration
+} from "@multiverse/provider-contracts";
+import {
+  isValidFixedHostPortBasePort
 } from "@multiverse/provider-contracts";
 
 
 export interface DeclarationValidationError {
   path: string;
-  code: "required" | "invalid_env_var_name" | "reserved_name" | "duplicate_appenv" | "invalid_appenv_mapping_kind";
+  code: "required" | "invalid_value" | "invalid_env_var_name" | "reserved_name" | "duplicate_appenv" | "invalid_appenv_mapping_kind";
 }
 
 export interface ValidatedResourceDeclaration {
@@ -27,11 +29,13 @@ export interface ValidatedEndpointDeclaration {
   role: string;
   provider: string;
   appEnv?: string | EndpointAppEnvMapping;
+  host?: string;
+  basePort?: number;
 }
 
 export interface EndpointDeclarationValidationError {
-  path: "name" | "role" | "provider" | "appEnv";
-  code: "required" | "invalid_env_var_name" | "reserved_name" | "invalid_appenv_mapping_kind";
+  path: "name" | "role" | "provider" | "appEnv" | "host" | "basePort";
+  code: "required" | "invalid_value" | "invalid_env_var_name" | "reserved_name" | "invalid_appenv_mapping_kind";
 }
 
 export type EndpointDeclarationValidationResult<T> =
@@ -47,7 +51,6 @@ export type EndpointDeclarationValidationResult<T> =
 /** Pattern for a valid environment variable name (POSIX-like). */
 const ENV_VAR_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
 const RESERVED_PREFIX = "MULTIVERSE_";
-
 function isValidEnvVarName(name: string): boolean {
   return ENV_VAR_NAME_PATTERN.test(name);
 }
@@ -113,6 +116,32 @@ function endpointAppEnvErrors(
     if (kind !== "url" && kind !== "port") {
       errors.push({ path: "appEnv", code: "invalid_appenv_mapping_kind" });
     }
+  }
+
+  return errors;
+}
+
+function invalidEndpointValueError(
+  path: EndpointDeclarationValidationError["path"]
+): EndpointDeclarationValidationError {
+  return { path, code: "invalid_value" };
+}
+
+function fixedHostPortConfigErrors(
+  input: EndpointDeclaration
+): EndpointDeclarationValidationError[] {
+  const errors: EndpointDeclarationValidationError[] = [];
+
+  if (input.host === undefined) {
+    errors.push(requiredEndpointError("host"));
+  } else if (typeof input.host !== "string" || input.host.trim().length === 0) {
+    errors.push(invalidEndpointValueError("host"));
+  }
+
+  if (input.basePort === undefined) {
+    errors.push(requiredEndpointError("basePort"));
+  } else if (!isValidFixedHostPortBasePort(input.basePort)) {
+    errors.push(invalidEndpointValueError("basePort"));
   }
 
   return errors;
@@ -192,6 +221,10 @@ export function validateEndpointDeclaration(
     errors.push(requiredEndpointError("provider"));
   }
 
+  if (input.provider === "fixed-host-port") {
+    errors.push(...fixedHostPortConfigErrors(input));
+  }
+
   if (input.appEnv !== undefined) {
     errors.push(...endpointAppEnvErrors(input.appEnv));
   }
@@ -206,6 +239,10 @@ export function validateEndpointDeclaration(
       name: input.name!,
       role: input.role!,
       provider: input.provider!,
+      ...(input.provider === "fixed-host-port" && input.host !== undefined ? { host: input.host } : {}),
+      ...(input.provider === "fixed-host-port" && input.basePort !== undefined
+        ? { basePort: input.basePort }
+        : {}),
       ...(input.appEnv !== undefined ? { appEnv: input.appEnv } : {})
     }
   };

--- a/packages/provider-contracts/src/index.ts
+++ b/packages/provider-contracts/src/index.ts
@@ -45,6 +45,19 @@ export interface EndpointDeclaration {
   role?: string;
   provider?: string;
   appEnv?: string | EndpointAppEnvMapping;
+  host?: string;
+  basePort?: number;
+}
+
+export const FIXED_HOST_PORT_PORT_RANGE = 1000;
+export const FIXED_HOST_PORT_MIN_BASE_PORT = 1;
+export const FIXED_HOST_PORT_MAX_BASE_PORT = 65535 - (FIXED_HOST_PORT_PORT_RANGE - 1);
+
+export function isValidFixedHostPortBasePort(value: number | undefined): value is number {
+  return typeof value === "number" &&
+    Number.isInteger(value) &&
+    value >= FIXED_HOST_PORT_MIN_BASE_PORT &&
+    value <= FIXED_HOST_PORT_MAX_BASE_PORT;
 }
 
 export interface RepositoryConfiguration {
@@ -162,6 +175,8 @@ export interface EndpointProvider {
       name: string;
       role: string;
       provider: string;
+      host?: string;
+      basePort?: number;
     };
     worktree: {
       id: string;

--- a/packages/provider-fixed-host-port/index.ts
+++ b/packages/provider-fixed-host-port/index.ts
@@ -1,0 +1,1 @@
+export * from "./src/index";

--- a/packages/provider-fixed-host-port/package.json
+++ b/packages/provider-fixed-host-port/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@multiverse/provider-fixed-host-port",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./index.ts"
+  },
+  "dependencies": {
+    "@multiverse/provider-contracts": "workspace:*"
+  }
+}

--- a/packages/provider-fixed-host-port/src/index.ts
+++ b/packages/provider-fixed-host-port/src/index.ts
@@ -1,0 +1,62 @@
+import { createHash } from "node:crypto";
+import {
+  FIXED_HOST_PORT_PORT_RANGE,
+  isValidFixedHostPortBasePort,
+  type EndpointProvider,
+  type DerivedEndpointMapping,
+  type Refusal
+} from "@multiverse/provider-contracts";
+
+function derivePort(worktreeId: string, endpointName: string, basePort: number): number {
+  const hash = createHash("sha256").update(worktreeId).update(endpointName).digest();
+  const offset = hash.readUInt32BE(0) % FIXED_HOST_PORT_PORT_RANGE;
+  return basePort + offset;
+}
+
+function invalidConfiguration(reason: string): Refusal {
+  return {
+    category: "invalid_configuration",
+    reason
+  };
+}
+
+function unsafeScope(): Refusal {
+  return {
+    category: "unsafe_scope",
+    reason: "Safe worktree scope cannot be determined: worktree ID is absent."
+  };
+}
+
+export function createFixedHostPortProvider(): EndpointProvider {
+  return {
+    deriveEndpoint({ endpoint, worktree }): DerivedEndpointMapping | Refusal {
+      const { host, basePort } = endpoint;
+
+      if (!worktree.id) {
+        return unsafeScope();
+      }
+
+      if (typeof host !== "string" || host.trim().length === 0) {
+        return invalidConfiguration(
+          `Endpoint "${endpoint.name}" using provider "fixed-host-port" requires a non-empty host.`
+        );
+      }
+
+      if (!isValidFixedHostPortBasePort(basePort)) {
+        return invalidConfiguration(
+          `Endpoint "${endpoint.name}" using provider "fixed-host-port" requires an integer basePort in the safe TCP range.`
+        );
+      }
+
+      const port = derivePort(worktree.id, endpoint.name, basePort);
+
+      return {
+        endpointName: endpoint.name,
+        provider: endpoint.provider,
+        role: endpoint.role,
+        worktreeId: worktree.id,
+        address: `http://${host}:${port}`
+      };
+    }
+  };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@multiverse/provider-contracts':
         specifier: workspace:*
         version: link:packages/provider-contracts
+      '@multiverse/provider-fixed-host-port':
+        specifier: workspace:*
+        version: link:packages/provider-fixed-host-port
       '@multiverse/provider-local-port':
         specifier: workspace:*
         version: link:packages/provider-local-port
@@ -111,6 +114,12 @@ importers:
         version: link:../provider-contracts
 
   packages/provider-contracts: {}
+
+  packages/provider-fixed-host-port:
+    dependencies:
+      '@multiverse/provider-contracts':
+        specifier: workspace:*
+        version: link:../provider-contracts
 
   packages/provider-local-port:
     dependencies:

--- a/tests/acceptance/dev-slice-31.acceptance.test.ts
+++ b/tests/acceptance/dev-slice-31.acceptance.test.ts
@@ -1,0 +1,94 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { runCli, type ChildProcessRunner } from "../../apps/cli/src/index";
+
+describe("dev-slice-31: fixed-host-port endpoint provider", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(
+      tempDirs.map((dir) => rm(dir, { recursive: true, force: true }))
+    );
+    tempDirs.length = 0;
+  });
+
+  const providersModulePath = fileURLToPath(
+    new URL("./fixtures/fixed-host-port-test-providers.ts", import.meta.url)
+  );
+
+  async function writeConfig(config: unknown): Promise<string> {
+    const tempDir = await mkdtemp(path.join(tmpdir(), "multiverse-cli-fixed-host-port-"));
+    tempDirs.push(tempDir);
+    const configPath = path.join(tempDir, "multiverse.json");
+    await writeFile(configPath, JSON.stringify(config));
+    return configPath;
+  }
+
+  async function captureRunEnv(config: unknown, worktreeId: string): Promise<Record<string, string>> {
+    const configPath = await writeConfig(config);
+    let capturedEnv: Record<string, string> = {};
+    const runner: ChildProcessRunner = async ({ env }) => {
+      capturedEnv = { ...env };
+      return { exitCode: 0 };
+    };
+
+    const outcome = await runCli(
+      ["run", "--config", configPath, "--providers", providersModulePath,
+       "--worktree-id", worktreeId, "--", "node", "-e", "0"],
+      { runner, parentEnv: {} }
+    );
+
+    expect(outcome.exitCode).toBe(0);
+
+    return capturedEnv;
+  }
+
+  it("injects canonical, alias, and typed endpoint env vars while preserving deterministic worktree scoping", async () => {
+    const config = {
+      resources: [],
+      endpoints: [
+        {
+          name: "http",
+          role: "application-http",
+          provider: "fixed-host-port",
+          host: "127.0.0.1",
+          basePort: 5400,
+          appEnv: {
+            APP_HTTP_URL: "url",
+            PORT: "port"
+          }
+        },
+        {
+          name: "admin-api",
+          role: "admin-http",
+          provider: "fixed-host-port",
+          host: "127.0.0.1",
+          basePort: 5400,
+          appEnv: "ADMIN_API_URL"
+        }
+      ]
+    };
+
+    const worktreeAEnv = await captureRunEnv(config, "wt-fixed-host-a");
+    const worktreeBEnv = await captureRunEnv(config, "wt-fixed-host-b");
+
+    const httpUrlA = worktreeAEnv["MULTIVERSE_ENDPOINT_HTTP"];
+    const adminUrlA = worktreeAEnv["MULTIVERSE_ENDPOINT_ADMIN_API"];
+    const httpUrlB = worktreeBEnv["MULTIVERSE_ENDPOINT_HTTP"];
+    const adminUrlB = worktreeBEnv["MULTIVERSE_ENDPOINT_ADMIN_API"];
+
+    expect(httpUrlA).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/);
+    expect(adminUrlA).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/);
+    expect(worktreeAEnv["APP_HTTP_URL"]).toBe(httpUrlA);
+    expect(worktreeAEnv["PORT"]).toBe(new URL(httpUrlA).port);
+    expect(worktreeAEnv["ADMIN_API_URL"]).toBe(adminUrlA);
+    expect(httpUrlA).not.toBe(adminUrlA);
+    expect(httpUrlA).not.toBe(httpUrlB);
+    expect(adminUrlA).not.toBe(adminUrlB);
+  });
+});

--- a/tests/acceptance/fixtures/fixed-host-port-test-providers.ts
+++ b/tests/acceptance/fixtures/fixed-host-port-test-providers.ts
@@ -1,0 +1,11 @@
+import { createExplicitTestProviders } from "@multiverse/providers-testkit";
+import { createFixedHostPortProvider } from "@multiverse/provider-fixed-host-port";
+
+const base = createExplicitTestProviders();
+
+export const providers = {
+  resources: base.resources,
+  endpoints: {
+    "fixed-host-port": createFixedHostPortProvider()
+  }
+};

--- a/tests/contracts/endpoint-provider.derive.contract.test.ts
+++ b/tests/contracts/endpoint-provider.derive.contract.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import type { EndpointProvider, DerivedEndpointMapping, Refusal } from "@multiverse/provider-contracts";
 import { createLocalPortProvider } from "@multiverse/provider-local-port";
+import { createFixedHostPortProvider } from "@multiverse/provider-fixed-host-port";
 
 function isRefusal(value: DerivedEndpointMapping | Refusal): value is Refusal {
   return "category" in value && "reason" in value;
@@ -10,22 +11,64 @@ function isDerivedEndpointMapping(value: DerivedEndpointMapping | Refusal): valu
   return "endpointName" in value && "address" in value;
 }
 
-describe("endpoint provider contract: derive", () => {
-  const provider: EndpointProvider = createLocalPortProvider({ basePort: 4000 });
-
-  const validInput = {
+const providerCases: Array<{
+  name: string;
+  provider: EndpointProvider;
+  validInput: {
     endpoint: {
-      name: "app-base-url",
-      role: "application-base-url",
-      provider: "local-port"
-    },
+      name: string;
+      role: string;
+      provider: string;
+      host?: string;
+      basePort?: number;
+    };
     worktree: {
-      id: "feature-login",
-      label: "feature/login",
-      branch: "feature/login"
-    }
+      id: string;
+      label: string;
+      branch: string;
+    };
   };
+  addressPattern: RegExp;
+}> = [
+  {
+    name: "local-port",
+    provider: createLocalPortProvider({ basePort: 4000 }),
+    validInput: {
+      endpoint: {
+        name: "app-base-url",
+        role: "application-base-url",
+        provider: "local-port"
+      },
+      worktree: {
+        id: "feature-login",
+        label: "feature/login",
+        branch: "feature/login"
+      }
+    },
+    addressPattern: /^http:\/\/localhost:\d+$/
+  },
+  {
+    name: "fixed-host-port",
+    provider: createFixedHostPortProvider(),
+    validInput: {
+      endpoint: {
+        name: "app-base-url",
+        role: "application-base-url",
+        provider: "fixed-host-port",
+        host: "127.0.0.1",
+        basePort: 5400
+      },
+      worktree: {
+        id: "feature-login",
+        label: "feature/login",
+        branch: "feature/login"
+      }
+    },
+    addressPattern: /^http:\/\/127\.0\.0\.1:\d+$/
+  }
+];
 
+describe.each(providerCases)("endpoint provider contract: derive (%s)", ({ provider, validInput, addressPattern }) => {
   it("returns a DerivedEndpointMapping for valid input", () => {
     const result = provider.deriveEndpoint(validInput);
 
@@ -42,8 +85,7 @@ describe("endpoint provider contract: derive", () => {
     expect(result.provider).toBe(validInput.endpoint.provider);
     expect(result.role).toBe(validInput.endpoint.role);
     expect(result.worktreeId).toBe(validInput.worktree.id);
-    expect(typeof result.address).toBe("string");
-    expect(result.address.length).toBeGreaterThan(0);
+    expect(result.address).toMatch(addressPattern);
   });
 
   it("derives different addresses for different endpoint names in the same worktree", () => {
@@ -69,5 +111,17 @@ describe("endpoint provider contract: derive", () => {
     if (!isDerivedEndpointMapping(result1) || !isDerivedEndpointMapping(result2)) return;
 
     expect(result1.address).toBe(result2.address);
+  });
+
+  it("returns unsafe_scope when worktree identity is absent during derive", () => {
+    const result = provider.deriveEndpoint({
+      ...validInput,
+      worktree: {} as typeof validInput.worktree
+    });
+
+    expect(isRefusal(result)).toBe(true);
+    if (!isRefusal(result)) return;
+
+    expect(result.category).toBe("unsafe_scope");
   });
 });

--- a/tests/unit/endpoint-declaration-boundary.test.ts
+++ b/tests/unit/endpoint-declaration-boundary.test.ts
@@ -23,6 +23,27 @@ describe("endpoint declaration boundary validation", () => {
     });
   });
 
+  it("accepts a valid fixed-host-port endpoint declaration and returns trusted provider config", () => {
+    expect(
+      validateEndpointDeclaration({
+        name: "http",
+        role: "application-http",
+        provider: "fixed-host-port",
+        host: "127.0.0.1",
+        basePort: 5400
+      })
+    ).toEqual({
+      ok: true,
+      value: {
+        name: "http",
+        role: "application-http",
+        provider: "fixed-host-port",
+        host: "127.0.0.1",
+        basePort: 5400
+      }
+    });
+  });
+
   it("returns structured errors for missing required endpoint fields", () => {
     expect(
       validateEndpointDeclaration({
@@ -38,6 +59,88 @@ describe("endpoint declaration boundary validation", () => {
         {
           path: "provider",
           code: "required"
+        }
+      ]
+    });
+  });
+
+  it("requires host and basePort for fixed-host-port declarations", () => {
+    expect(
+      validateEndpointDeclaration({
+        name: "http",
+        role: "application-http",
+        provider: "fixed-host-port"
+      })
+    ).toEqual({
+      ok: false,
+      errors: [
+        {
+          path: "host",
+          code: "required"
+        },
+        {
+          path: "basePort",
+          code: "required"
+        }
+      ]
+    });
+  });
+
+  it("rejects an empty host for fixed-host-port declarations", () => {
+    expect(
+      validateEndpointDeclaration({
+        name: "http",
+        role: "application-http",
+        provider: "fixed-host-port",
+        host: "   ",
+        basePort: 5400
+      })
+    ).toEqual({
+      ok: false,
+      errors: [
+        {
+          path: "host",
+          code: "invalid_value"
+        }
+      ]
+    });
+  });
+
+  it("rejects a non-integer basePort for fixed-host-port declarations", () => {
+    expect(
+      validateEndpointDeclaration({
+        name: "http",
+        role: "application-http",
+        provider: "fixed-host-port",
+        host: "127.0.0.1",
+        basePort: 5400.5
+      })
+    ).toEqual({
+      ok: false,
+      errors: [
+        {
+          path: "basePort",
+          code: "invalid_value"
+        }
+      ]
+    });
+  });
+
+  it("rejects an out-of-range basePort for fixed-host-port declarations", () => {
+    expect(
+      validateEndpointDeclaration({
+        name: "http",
+        role: "application-http",
+        provider: "fixed-host-port",
+        host: "127.0.0.1",
+        basePort: 64537
+      })
+    ).toEqual({
+      ok: false,
+      errors: [
+        {
+          path: "basePort",
+          code: "invalid_value"
         }
       ]
     });

--- a/tests/unit/repository-configuration-boundary.test.ts
+++ b/tests/unit/repository-configuration-boundary.test.ts
@@ -97,4 +97,34 @@ describe("repository configuration boundary validation", () => {
     });
     expect(downstream).not.toHaveBeenCalled();
   });
+
+  it("prefixes fixed-host-port declaration errors with the endpoint index path", () => {
+    expect(
+      validateRepositoryConfiguration(
+        createValidRepositoryConfiguration({
+          endpoints: [
+            {
+              name: "http",
+              role: "application-http",
+              provider: "fixed-host-port",
+              host: "",
+              basePort: 70000
+            }
+          ]
+        })
+      )
+    ).toEqual({
+      ok: false,
+      errors: [
+        {
+          path: "endpoints[0].host",
+          code: "invalid_value"
+        },
+        {
+          path: "endpoints[0].basePort",
+          code: "invalid_value"
+        }
+      ]
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- implement dev-slice-31 / issue #90 with the fixed-host-port endpoint provider
- carry provider-owned host and basePort declaration fields through validation and derivation
- keep run endpoint env injection and appEnv mapping behavior unchanged for consumers

## Scope
- new @multiverse/provider-fixed-host-port workspace package
- acceptance, contract, and validation-boundary coverage for the new provider shape
- small repo-state doc updates for the first 0.4.x extensibility slice

## Validation
- scripts/codex-env.sh pnpm test:acceptance
- scripts/codex-env.sh pnpm test:contracts
- scripts/codex-env.sh pnpm test:unit
- scripts/codex-env.sh pnpm typecheck

## Deferred
- no shared cross-provider port-derivation helper extraction in this slice
