### PR TITLE
docs(slice-31): align fixed-host-port architecture docs

### DIFF
--- a/docs/adr/0020-explicit-fixed-host-port-endpoint-provider.md
+++ b/docs/adr/0020-explicit-fixed-host-port-endpoint-provider.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Draft
+Accepted
 
 ## Date
 
@@ -30,7 +30,7 @@ that endpoint extensibility is a credible platform seam.
 The first `0.4.x` slice should therefore add one additional endpoint provider
 shape while preserving:
 
-- the existing endpoint contract
+- the existing endpoint mapping/result contract
 - ADR 0018 and ADR 0019 semantics
 - explicit repository-owned configuration
 - refusal-first behavior
@@ -41,7 +41,7 @@ shape while preserving:
 Multiverse will add a second endpoint provider shape named `fixed-host-port`.
 
 This provider is an endpoint provider that returns a URL-shaped endpoint value
-through the existing endpoint contract.
+through the existing endpoint model.
 
 For this slice:
 
@@ -51,6 +51,8 @@ For this slice:
 - the emitted host is provider-owned and explicitly configured
 - the emitted port is worktree-derived from provider configuration plus worktree
   and endpoint identity
+- shared endpoint declaration and provider-input types are extended narrowly and
+  explicitly to carry `host` and `basePort` for this provider shape only
 
 This slice is intended to prove endpoint-provider extensibility without changing
 consumer workflow semantics.
@@ -61,6 +63,9 @@ Included:
 
 - one new endpoint provider named `fixed-host-port`
 - explicit repository declaration support for that provider's configuration
+- one narrow explicit shared declaration/provider-input extension for:
+  - `host`
+  - `basePort`
 - deterministic URL derivation using a configured host and base port
 - declaration validation for the provider's configuration
 - refusal behavior for invalid or unsafe provider configuration
@@ -69,7 +74,8 @@ Included:
 
 Excluded:
 
-- changes to the endpoint provider contract
+- broader endpoint-provider contract redesign beyond the narrow explicit
+  `host`/`basePort` extension required for this provider shape
 - redesign of `run`
 - redesign of endpoint `appEnv`
 - changes to ADR 0018 or ADR 0019 semantics
@@ -102,7 +108,9 @@ Configuration fields:
 - `host`: required non-empty hostname or IP literal
 - `basePort`: required integer base port
 
-No additional provider configuration fields are introduced in this slice.
+This configuration is carried through a narrow explicit extension to shared
+endpoint declaration and provider-input types. No broader endpoint-model
+redesign or provider-discovery behavior is introduced in this slice.
 
 ## URL ownership and derivation semantics
 
@@ -232,8 +240,9 @@ This slice preserves existing boundaries:
 - repository configuration explicitly selects the provider and supplies provider
   configuration
 - the provider owns technology-specific URL derivation rules for this shape
-- core owns declaration loading, validation coordination, provider dispatch, and
-  `run` environment injection
+- core owns declaration loading, validation coordination, provider dispatch, the
+  narrow shared contract carriage for explicit provider-owned fields, and `run`
+  environment injection
 - ADR 0018 and ADR 0019 behavior remains core-owned and unchanged
 
 This slice does not authorize moving consumer behavior into provider code.
@@ -277,16 +286,19 @@ Rejected for now.
 That broadens endpoint configuration without improving the core extensibility
 proof.
 
-## Follow-on implications
+## Implementation notes
 
-The implementation slice following this ADR may:
+The merged implementation for this ADR did:
 
 - add explicit declaration parsing and validation for `fixed-host-port`
 - add one provider package implementing derive-only endpoint behavior
+- extend shared endpoint declaration/provider-input types narrowly for
+  `host` and `basePort`
 - add contract and acceptance coverage proving the second endpoint shape
-- update roadmap and state docs to reflect the first `0.4.x` extensibility proof
+- update roadmap, state, and package-map docs for the first `0.4.x`
+  extensibility proof
 
-It should not:
+It did not:
 
 - redesign `run`
 - redesign `appEnv`

--- a/docs/development/current-state.md
+++ b/docs/development/current-state.md
@@ -23,7 +23,9 @@ Interpretation:
 * the usable core of Multiverse has moved beyond isolated seam proofs
 * a richer composed application workflow has now been demonstrated through mixed-provider integration
 * the product is still in active proving, but the consumer-workflow question is now materially narrower than it was before ADR 0018 and ADR 0019
-* the repository has now started the first `0.4.x` extensibility proof with a second endpoint-provider shape
+* the current published project version remains `0.3.0-alpha.3`, while `main`
+  now includes the first narrow `0.4.x` extensibility proof with a second
+  endpoint-provider shape
 
 ## What is already proven
 
@@ -82,23 +84,26 @@ The current composed proof also now demonstrates:
 * typed endpoint mapping for `PORT`
 * an application-owned runtime-config boundary in `sample-compose`
 
-## Current highest-priority proving question
+## Current highest-priority proving result
 
-The current highest-priority question is:
+The most recently answered proving question is:
 
 **Can a second explicit endpoint-provider shape be added without changing the established consumer workflow or weakening the core/provider boundary?**
 
-ADR 0018 and ADR 0019 established the consumer workflow strongly enough to move to this next question. ADR 0020 defines the first narrow extensibility proof.
+ADR 0018 and ADR 0019 established the consumer workflow strongly enough to move
+to this next question. ADR 0020 and Slice 31 now prove it once through
+`fixed-host-port`, with a narrow explicit `host`/`basePort` extension to shared
+endpoint declaration and provider-input types.
 
 ## Current priority
 
 The current priority is:
 
-**Executing and stabilizing the first `0.4.x` extensibility proof while preserving the now-proven consumer workflow**
+**Keeping the first `0.4.x` extensibility proof narrow, explicit, and well-documented while preserving the now-proven consumer workflow**
 
 That means work should preferentially strengthen:
 
-* the first additional provider shape under the existing endpoint contract
+* the first additional provider shape under the existing endpoint model
 * clarity of the line between repository-owned declaration config and provider-owned derivation rules
 * confidence that `run` and app-native endpoint mapping remain unchanged for consumers
 * docs and tests that make the new extensibility seam understandable without widening scope
@@ -107,9 +112,9 @@ That means work should preferentially strengthen:
 
 Examples of work that are strongly aligned with the current phase:
 
-* implementing one additional meaningful provider shape cleanly
+* documenting the now-implemented fixed-host-port slice accurately
+* bounded stabilization of the newly proven extension seam where needed
 * tightening docs around what belongs in core versus provider code
-* bounded stabilization of declaration validation and refusal behavior for the new seam
 * preserving the proven app-native mapping and runtime-config boundary story while extensibility grows
 
 ## What is intentionally deferred

--- a/docs/development/dev-slice-31.md
+++ b/docs/development/dev-slice-31.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Draft
+Implemented on `main`
 
 ## ADR
 
@@ -38,7 +38,8 @@ changing the consumer workflow established in `0.3.x`.
 
 ## Out of scope
 
-- changes to the endpoint provider contract
+- broader endpoint-provider contract redesign beyond the narrow explicit
+  `host`/`basePort` extension required for this provider shape
 - redesign of `run`
 - redesign of ADR 0018 or ADR 0019 semantics
 - resource-provider changes
@@ -81,16 +82,18 @@ changing the consumer workflow established in `0.3.x`.
 Likely implementation files:
 
 - `apps/cli/src/...` for minimal provider registration and declaration wiring
-- `packages/provider-contracts/src/index.ts` only if clarification is necessary;
-  no contract redesign is intended
+- `packages/provider-contracts/src/index.ts` for the narrow explicit
+  `host`/`basePort` extension needed to carry fixed-host-port declaration and
+  derive input through the shared seam
 - `packages/provider-fixed-host-port/src/index.ts`
 - `tests/contracts/endpoint-provider.derive.contract.test.ts`
 - one new acceptance test under `tests/acceptance/`
 
-Likely doc updates when the slice is implemented:
+Doc updates for the implemented slice:
 
 - `docs/development/roadmap.md`
 - `docs/development/current-state.md`
+- `docs/development/repo-map.md`
 - `README.md`
 
 ## Definition of done

--- a/docs/development/implementation-strategy.md
+++ b/docs/development/implementation-strategy.md
@@ -128,6 +128,8 @@ Current `main` includes implemented slices covering:
 - path-scoped provider with effectful reset and cleanup (filesystem state)
 - name-scoped provider with scope-confirmation reset and cleanup
 - local-port endpoint provider
+- fixed-host-port endpoint provider as the first narrow `0.4.x`
+  extensibility proof
 - sample Express application for end-to-end integration proof
 - CI pipeline with acceptance, contract, unit, and integration test jobs
 - `derive --format=env` for shell-sourceable KEY=VALUE output

--- a/docs/development/repo-map.md
+++ b/docs/development/repo-map.md
@@ -18,14 +18,21 @@ The repository contains behavior-first design artifacts and a working implementa
 * development guidance under `docs/development/`
 * core business logic in `packages/core/`
 * provider contracts in `packages/provider-contracts/`
-* five concrete provider packages: `provider-name-scoped`, `provider-path-scoped`, `provider-local-port`, `provider-process-scoped`, and `provider-process-port-scoped`
+* six concrete provider packages: `provider-name-scoped`,
+  `provider-path-scoped`, `provider-local-port`, `provider-fixed-host-port`,
+  `provider-process-scoped`, and `provider-process-port-scoped`
 * a test provider registry in `packages/providers-testkit/`
 * a thin CLI in `apps/cli/`
 * a sample Express application in `apps/sample-express/`
 * a composed proving application in `apps/sample-compose/`
 * acceptance, contract, unit, and integration tests under `tests/`
 
-Implementation has progressed through 30 development slices. The core lifecycle (derive, validate, reset, cleanup) is implemented across the current declared resource and endpoint model, with multi-resource and multi-endpoint support in place, and the current `0.3.x` work has now proven the main composed-application consumer workflow.
+Implementation has progressed through 31 development slices. The core lifecycle
+(derive, validate, reset, cleanup) is implemented across the current declared
+resource and endpoint model, with multi-resource and multi-endpoint support in
+place. The `0.3.x` work proved the main composed-application consumer workflow,
+and Slice 31 added the first narrow `0.4.x` endpoint-provider extensibility
+proof.
 
 ## Implementation Model
 
@@ -80,6 +87,7 @@ Current packages:
 * `packages/provider-name-scoped/` — name-scoped resource isolation (derive, reset, cleanup confirmation only)
 * `packages/provider-path-scoped/` — path-scoped resource isolation (derive, effectful reset, effectful cleanup for provider-managed filesystem state)
 * `packages/provider-local-port/` — local-port endpoint isolation (derive)
+* `packages/provider-fixed-host-port/` — fixed-host plus derived-port endpoint isolation (derive)
 * `packages/provider-process-scoped/` — process-backed resource lifecycle as a declared isolation seam
 * `packages/provider-process-port-scoped/` — process-backed resource seam with deterministic local address handles
 
@@ -249,6 +257,7 @@ Primary code targets in the current implementation phase include:
 * `packages/provider-name-scoped/`
 * `packages/provider-path-scoped/`
 * `packages/provider-local-port/`
+* `packages/provider-fixed-host-port/`
 * `packages/provider-process-scoped/`
 * `packages/provider-process-port-scoped/`
 * `tests/`
@@ -257,7 +266,8 @@ Primary code targets in the current implementation phase include:
 
 Current implementation work should follow the active development slice and task documents under `docs/development/`.
 
-Slices 01–30 have been implemented. Subsequent work is tracked through current development documents and the repository’s open issues.
+Slices 01–31 have been implemented. Subsequent work is tracked through current
+development documents and the repository’s open issues.
 
 Contributors and agents should use those sources to determine what behavior is currently in scope.
 

--- a/docs/development/roadmap.md
+++ b/docs/development/roadmap.md
@@ -39,7 +39,9 @@ What that means:
   * explicit app-native env mapping for resources and endpoints
   * typed endpoint mapping for `url` and `port`
   * an application-owned runtime-config boundary proof in `sample-compose`
-* the common-case workflow is now credible enough that the first `0.4.x` extensibility slice can begin
+* the current published project version remains `0.3.0-alpha.3`
+* the common-case workflow is now credible enough that the first `0.4.x`
+  extensibility slice has been implemented on `main`
 
 ## Version roadmap
 

--- a/docs/spec/endpoint-model.md
+++ b/docs/spec/endpoint-model.md
@@ -105,6 +105,8 @@ The repository is responsible for declaring:
 - which endpoints exist
 - the intended role of each endpoint
 - which provider is assigned to each endpoint
+- any explicit provider-owned configuration required by the selected endpoint
+  provider shape
 
 The endpoint provider is responsible for implementing:
 

--- a/docs/spec/provider-model.md
+++ b/docs/spec/provider-model.md
@@ -44,7 +44,9 @@ A provider is not the same thing as a resource or an endpoint.
 
 In 1.0, provider selection is explicit.
 
-The repository configuration must declare which provider is used for each resource or endpoint.
+The repository configuration must declare which provider is used for each
+resource or endpoint, together with any explicit provider-owned configuration
+required by that provider shape.
 
 The core tool does not infer providers in 1.0.
 


### PR DESCRIPTION
## Summary
- align ADR 0020 and Slice 31 docs with the merged fixed-host-port implementation
- describe the shared declaration/provider-input change accurately as a narrow explicit host/basePort extension
- update nearby architecture/state docs so they reflect the implemented slice without implying a 0.4.x version bump

## Scope
- ADR 0020 status and wording
- Slice 31 status and implementation notes
- current-state, roadmap, repo-map, implementation-strategy, endpoint-model, and provider-model wording alignment

## Validation
- git diff --check

## Deferred
- no code changes; no version bump
