### PR TITLE
docs(workflow): tighten slice completion discipline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,8 @@ Do not invent behavior not supported by these sources.
 - do not introduce orchestration behavior unless explicitly required
 - do not silently resolve ambiguity by guessing
 - do not add speculative abstractions beyond the needs of the current slice
+- keep 1.0 narrow; capture broader ergonomics, ecosystem, or 2.0 ideas as
+  deferred follow-up work unless the active slice explicitly requires them
 
 ## Testing Rules
 
@@ -71,7 +73,34 @@ Each implementation task must define:
 - acceptance criteria
 - safety/refusal expectations
 
+Each implementation slice should normally also have a short task document under
+`docs/development/tasks/`, even when a slice document already exists.
+
+That task document may be brief, but it should make the active file set,
+acceptance target, and explicit out-of-scope boundary easy to review before
+coding starts.
+
 If a task is ambiguous, preserve existing boundaries rather than introducing new behavior.
+
+## Slice Completion Discipline
+
+Before considering a slice done or opening a PR, review whether truth-alignment
+updates are needed in:
+
+- the active ADR for the slice, if one exists
+- the active slice doc and any task doc used for implementation
+- nearby state/roadmap/repo-map docs that describe the implemented seam
+
+When doing that review:
+
+- distinguish clearly between the current project version posture and behavior
+  merely implemented on `main`
+- do not imply a release bump unless the version itself changed
+- describe narrow shared declaration or contract changes explicitly when they
+  occurred; do not describe them as "no contract change" if a small explicit
+  extension was introduced
+- record deferred items explicitly instead of smuggling them into the completed
+  slice
 
 ## Codex Environment Rules
 
@@ -128,6 +157,8 @@ When creating a PR, include:
 - the scope of changes
 - validation performed
 - notable deferred items or follow-up work
+- whether docs or status artifacts were updated as part of slice completion when
+  that is relevant
 
 Keep PR descriptions concise and factual.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,6 +49,8 @@ Do not invent behavior not supported by these sources.
 - do not introduce orchestration behavior unless explicitly required
 - do not silently resolve ambiguity by guessing
 - do not add speculative abstractions beyond the needs of the current slice
+- keep 1.0 narrow; capture broader ergonomics, ecosystem, or 2.0 ideas as
+  deferred follow-up work unless the active slice explicitly requires them
 
 ## Testing Rules
 
@@ -71,7 +73,34 @@ Each implementation task must define:
 - acceptance criteria
 - safety/refusal expectations
 
+Each implementation slice should normally also have a short task document under
+`docs/development/tasks/`, even when a slice document already exists.
+
+That task document may be brief, but it should make the active file set,
+acceptance target, and explicit out-of-scope boundary easy to review before
+coding starts.
+
 If a task is ambiguous, preserve existing boundaries rather than introducing new behavior.
+
+## Slice Completion Discipline
+
+Before considering a slice done or opening a PR, review whether truth-alignment
+updates are needed in:
+
+- the active ADR for the slice, if one exists
+- the active slice doc and any task doc used for implementation
+- nearby state/roadmap/repo-map docs that describe the implemented seam
+
+When doing that review:
+
+- distinguish clearly between the current project version posture and behavior
+  merely implemented on `main`
+- do not imply a release bump unless the version itself changed
+- describe narrow shared declaration or contract changes explicitly when they
+  occurred; do not describe them as "no contract change" if a small explicit
+  extension was introduced
+- record deferred items explicitly instead of smuggling them into the completed
+  slice
 
 ## Git Workflow Policy
 
@@ -115,6 +144,8 @@ When creating a PR, include:
 - the scope of changes
 - validation performed
 - notable deferred items or follow-up work
+- whether docs or status artifacts were updated as part of slice completion when
+  that is relevant
 
 Keep PR descriptions concise and factual.
 

--- a/docs/development/implementation-strategy.md
+++ b/docs/development/implementation-strategy.md
@@ -102,6 +102,14 @@ Do not create new packages for speculative reuse or abstract neatness.
 
 A new package should be introduced only when a real responsibility boundary or dependency-direction need requires it.
 
+The same discipline applies to product scope:
+
+- keep 1.0 narrow and explicit
+- do not pull broader ergonomics, ecosystem, or post-1.0 ideas into a slice
+  unless the current source-of-truth documents require them
+- capture those ideas as deferred follow-up work instead of widening the active
+  slice
+
 ## Expected Deliverables for the Initial Slice
 
 - executable acceptance tests for the selected in-scope behavior
@@ -159,6 +167,26 @@ Phase 3 in design (targeting 0.2.x):
   with process lifecycle management, exposing `host:port` as the public resource handle
 
 The purpose of this document is still to preserve implementation posture and first-phase boundaries, not to serve as the complete change log for every later slice.
+
+## Completion Discipline
+
+When a slice is implemented, the work is not complete until the repository's
+descriptive docs are checked for truth alignment.
+
+At minimum, closeout should review:
+
+- the active ADR, if the slice was driven by one
+- the slice doc and any task doc used during implementation
+- nearby docs such as `current-state.md`, `roadmap.md`, and `repo-map.md` when
+  they describe the changed seam
+
+That review should:
+
+- distinguish between the current project version posture and behavior merely
+  implemented on `main`
+- call narrow shared declaration or contract extensions what they are, rather
+  than implying "no contract change" when a small explicit extension occurred
+- keep deferred improvements explicit instead of absorbing them into the slice
 
 ## Refusal Requirements
 

--- a/docs/development/task-template.md
+++ b/docs/development/task-template.md
@@ -58,6 +58,17 @@ Use these as the source of truth:
 - contract tests only where needed by the slice
 - no unrelated refactors
 
+## Version and Status Check
+
+Before implementation starts, note whether this task is expected to:
+
+- change only behavior implemented on `main`
+- change the current project version posture
+- require ADR, slice-doc, roadmap, current-state, or repo-map updates when done
+
+If the task does not change the published version posture, say so explicitly and
+avoid wording that implies a release bump.
+
 ## Acceptance Criteria
 
 - [criterion 1]
@@ -73,5 +84,15 @@ Before making changes:
 2. confirm the change preserves current boundaries
 3. implement tests before broadening production code
 4. stop at the slice boundary
+
+Before considering the task complete:
+
+1. confirm a short task doc exists and still matches the implemented slice
+2. perform the bounded refactor pass required by the repo's TDD loop
+3. review whether the active ADR, slice doc, and nearby state docs need
+   truth-alignment updates
+4. distinguish clearly between "implemented on `main`" and any actual version
+   or release-posture change
+5. list deferred items explicitly in the PR summary instead of broadening scope
 
 When uncertain, prefer refusal and explicitness over convenience behavior.


### PR DESCRIPTION
## Summary
- add explicit slice-completion and truth-alignment guidance to the agent docs
- add a version-posture check and completion checklist to the task template
- document narrower 1.0 scope discipline so broader ergonomics or 2.0 ideas get captured as deferred work instead of widening active slices

## Scope
- AGENTS.md
- CLAUDE.md
- docs/development/task-template.md
- docs/development/implementation-strategy.md

## Validation
- git diff --check

## Deferred
- no code changes
- no version change
