### PR TITLE
Docs: align 0.5.x public posture after Slice 42

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Today’s repo includes:
 
 The current implementation proves the core loop for explicit declarations and deterministic derivation, the composed application consumer workflow, and a complete provider extensibility story now captured in `0.5.0-alpha.1`.
 
-`0.5.0-alpha.1` marks the transition to early outside usability: the `0.4.x` extensibility proof is complete (new provider shapes, non-first-party authoring, CLI invocation proof), and the next proving question is whether a second engineer can follow the docs and succeed without live guidance. 1.0 remains intentionally narrow.
+`0.5.0-alpha.1` is the early outside-usability phase. The `0.4.x` extensibility proof is complete (new provider shapes, non-first-party authoring, CLI invocation proof), and the documented second-engineer workflow is now proven, including real two-worktree auto-discovery/isolation for Step 5. The remaining `0.5.x` usability gap is removing the manual `NODE_OPTIONS="--import tsx/esm"` requirement for TypeScript providers on the compiled/global binary path. 1.0 remains intentionally narrow.
 
 That includes:
 

--- a/docs/development/repo-map.md
+++ b/docs/development/repo-map.md
@@ -303,7 +303,7 @@ Primary code targets in the current implementation phase include:
 
 Current implementation work should follow the active development slice and task documents under `docs/development/`.
 
-Slices 01–31 have been implemented. Subsequent work is tracked through current
+Slices 01–42 have been implemented. Subsequent work is tracked through current
 development documents and the repository’s open issues.
 
 Contributors and agents should use those sources to determine what behavior is currently in scope.

--- a/docs/development/roadmap.md
+++ b/docs/development/roadmap.md
@@ -37,8 +37,9 @@ What that means:
 * a richer composed application workflow has now been proven through mixed-provider integration
 * the `0.4.x` extensibility wave is complete: new provider shapes, non-first-party authoring, CLI invocation proof
 * automatic worktree-id discovery is implemented (Slice 37); `--worktree-id` is now optional in common use
-* the documented external-demo-guide workflow is reproducible from scratch by a second engineer
-* `0.5.0-alpha.1` marks the early outside usability phase; the next proving question is the globally-linked binary path
+* the documented external-demo-guide workflow is reproducible from scratch by a second engineer, including the real two-worktree Step 5 proof (Slice 42)
+* the globally-linked binary path is proven within the workspace (Slice 41)
+* the remaining `0.5.x` usability gap is eliminating the manual `NODE_OPTIONS` requirement for TypeScript providers on the compiled/global binary path
 
 ## Version roadmap
 
@@ -478,12 +479,10 @@ It should mean that the product is trustworthy in its intended scope.
 
 The current near-term direction is:
 
-* prove that a second engineer can follow the existing docs and successfully run a
-  Multiverse-isolated application without live guidance
-* identify and close the most load-bearing cold-start friction in the current
-  documented common-case workflow
-* make the `pnpm cli` in-repo path and the formal `multiverse` binary path
-  explicit and honest in the docs
+* preserve and truth-align the now-proven second-engineer documented workflow
+* remove the highest remaining usability friction in that workflow: manual
+  `NODE_OPTIONS="--import tsx/esm"` for TypeScript providers on the compiled/global binary path
+* keep the `pnpm cli` in-repo path and formal binary path explicit and honest in docs
 
 The provider model and consumer workflow are now stable enough that the remaining
 0.5.x work is about usability, reproducibility, and honest documentation — not


### PR DESCRIPTION
## Summary
Align public docs to current 0.5.x truth on main after Slice 42.

## Scope
- update README 0.5.x posture wording to reflect that second-engineer workflow proof is now complete and the remaining gap is manual NODE_OPTIONS on compiled/global binary TS-provider path
- update roadmap current posture and immediate direction to match current-state
- fix stale repo-map development-slice alignment line (01–31 -> 01–42)

## Validation
- doc-only change; no behavior/code paths changed

## Deferred
- packaging/distribution redesign
- provider discovery/auto-registration
- new provider shapes
- major CLI redesign