### PR TITLE
Slice 43: remove manual NODE_OPTIONS for TS providers on binary path

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Today’s repo includes:
 
 The current implementation proves the core loop for explicit declarations and deterministic derivation, the composed application consumer workflow, and a complete provider extensibility story now captured in `0.5.0-alpha.1`.
 
-`0.5.0-alpha.1` is the early outside-usability phase. The `0.4.x` extensibility proof is complete (new provider shapes, non-first-party authoring, CLI invocation proof), and the documented second-engineer workflow is now proven, including real two-worktree auto-discovery/isolation for Step 5. The remaining `0.5.x` usability gap is removing the manual `NODE_OPTIONS="--import tsx/esm"` requirement for TypeScript providers on the compiled/global binary path. 1.0 remains intentionally narrow.
+`0.5.0-alpha.1` is the early outside-usability phase. The `0.4.x` extensibility proof is complete (new provider shapes, non-first-party authoring, CLI invocation proof), and the documented second-engineer workflow is now proven, including real two-worktree auto-discovery/isolation for Step 5 and no-manual-`NODE_OPTIONS` TypeScript provider loading in workspace scope on compiled/global binary paths. 1.0 remains intentionally narrow; outside-workspace packaging and distribution remain deferred.
 
 That includes:
 

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@multiverse/core": "workspace:*",
-    "@multiverse/provider-contracts": "workspace:*"
+    "@multiverse/provider-contracts": "workspace:*",
+    "tsx": "^4.21.0"
   }
 }

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -348,16 +348,43 @@ function isProviderRegistry(value: unknown): value is ProviderRegistry {
   );
 }
 
+function isTypeScriptModulePath(modulePath: string): boolean {
+  const ext = path.extname(modulePath).toLowerCase();
+  return ext === ".ts" || ext === ".mts" || ext === ".cts";
+}
+
+async function importTypeScriptModuleWithTsx(
+  moduleUrl: string
+): Promise<{ default?: unknown; providers?: unknown }> {
+  const api = (await import("tsx/esm/api")) as {
+    tsImport: (specifier: string, options: string | { parentURL: string }) => Promise<unknown>;
+  };
+
+  const loaded = await api.tsImport(moduleUrl, import.meta.url);
+  return loaded as { default?: unknown; providers?: unknown };
+}
+
 async function loadProviderRegistry(
   providersModulePath: string
 ): Promise<ProviderRegistry | CliResult> {
+  const resolvedModulePath = path.resolve(providersModulePath);
+  const moduleUrl = pathToFileURL(resolvedModulePath).href;
   let moduleExports: { default?: unknown; providers?: unknown };
+
   try {
-    const moduleUrl = pathToFileURL(path.resolve(providersModulePath)).href;
     moduleExports = (await import(moduleUrl)) as { default?: unknown; providers?: unknown };
   } catch (err) {
-    const detail = err instanceof Error ? err.message : String(err);
-    return usage(`Cannot load providers module: ${providersModulePath}\n${detail}`);
+    if (isTypeScriptModulePath(resolvedModulePath)) {
+      try {
+        moduleExports = await importTypeScriptModuleWithTsx(moduleUrl);
+      } catch (tsxErr) {
+        const detail = tsxErr instanceof Error ? tsxErr.message : String(tsxErr);
+        return usage(`Cannot load providers module: ${providersModulePath}\n${detail}`);
+      }
+    } else {
+      const detail = err instanceof Error ? err.message : String(err);
+      return usage(`Cannot load providers module: ${providersModulePath}\n${detail}`);
+    }
   }
 
   const candidate = moduleExports.providers ?? moduleExports.default;

--- a/docs/development/current-state.md
+++ b/docs/development/current-state.md
@@ -219,20 +219,30 @@ worktree identities differ and produce non-colliding DB paths and ports. Step 5 
 uses the concrete sample-express command and documents auto-discovery for real
 worktrees, with `--worktree-id` retained as an explicit override.
 
+**Can the compiled/global binary path load TypeScript providers without manual `NODE_OPTIONS` in workspace scope?**
+
+Slice 43 answers yes. The CLI now applies a narrow TypeScript-provider loading
+fallback through `tsx/esm/api` when a TypeScript providers module is supplied on
+the compiled/global binary path. In current workspace scope, a second engineer can
+invoke `node apps/cli/bin/multiverse.js` or a globally-linked `multiverse` command
+with a TypeScript providers module without manually setting
+`NODE_OPTIONS="--import tsx/esm"`. Outside-workspace provider packaging and
+distribution remain deferred.
+
 ## Current priority
 
 The current priority is:
 
-**`0.5.x` early outside usability — all documented in-repo and within-workspace binary paths are proven; the remaining `0.5.x` question is whether `NODE_OPTIONS` can be eliminated for TypeScript providers.**
+**`0.5.x` early outside usability — the documented in-repo and within-workspace binary paths are proven, including real multi-worktree proof and no-manual-`NODE_OPTIONS` TypeScript provider loading in workspace scope. The remaining outside-workspace packaging/distribution gap is explicitly deferred.**
 
 ## What kinds of work are highest-value right now
 
 Examples of work that are strongly aligned with the current `0.5.x` phase:
 
-* eliminating the `NODE_OPTIONS` requirement for TypeScript providers with the
-  compiled binary (requires compiling workspace packages to JavaScript)
-* proving the globally-linked binary from outside the workspace (requires globally
-  installing tsx or publishing provider packages)
+* bounded truth-alignment and documentation clarity for the now-proven 0.5.x
+  common workflow
+* targeted stability hardening that does not broaden scope or introduce new
+  product behavior
 
 ## What is intentionally deferred
 

--- a/docs/development/repo-map.md
+++ b/docs/development/repo-map.md
@@ -27,7 +27,7 @@ The repository contains behavior-first design artifacts and a working implementa
 * a composed proving application in `apps/sample-compose/`
 * acceptance, contract, unit, and integration tests under `tests/`
 
-Implementation has progressed through 42 development slices. The core lifecycle
+Implementation has progressed through 43 development slices. The core lifecycle
 (derive, validate, reset, cleanup) is implemented across the current declared
 resource and endpoint model, with multi-resource and multi-endpoint support in
 place. The `0.3.x` work proved the main composed-application consumer workflow.
@@ -69,7 +69,10 @@ explicitly; also fixed the stale CLI usage string that showed `--worktree-id` as
 required after Slice 37 made it optional. Slice 42 adds a real-worktree acceptance
 proof for Step 5 of the external-demo-guide: a test-owned `git worktree add` checkout
 is created, `derive` is run from both directories without `--worktree-id`, and the
-resolved identities and derived DB path/port values are proven distinct.
+resolved identities and derived DB path/port values are proven distinct. Slice 43
+removes the remaining manual `NODE_OPTIONS` friction for TypeScript providers on
+compiled/global binary paths in workspace scope by adding a narrow provider-module
+loading fallback through `tsx/esm/api`.
 
 ## Implementation Model
 
@@ -303,7 +306,7 @@ Primary code targets in the current implementation phase include:
 
 Current implementation work should follow the active development slice and task documents under `docs/development/`.
 
-Slices 01–42 have been implemented. Subsequent work is tracked through current
+Slices 01–43 have been implemented. Subsequent work is tracked through current
 development documents and the repository’s open issues.
 
 Contributors and agents should use those sources to determine what behavior is currently in scope.

--- a/docs/development/roadmap.md
+++ b/docs/development/roadmap.md
@@ -39,7 +39,8 @@ What that means:
 * automatic worktree-id discovery is implemented (Slice 37); `--worktree-id` is now optional in common use
 * the documented external-demo-guide workflow is reproducible from scratch by a second engineer, including the real two-worktree Step 5 proof (Slice 42)
 * the globally-linked binary path is proven within the workspace (Slice 41)
-* the remaining `0.5.x` usability gap is eliminating the manual `NODE_OPTIONS` requirement for TypeScript providers on the compiled/global binary path
+* manual `NODE_OPTIONS` is no longer required for TypeScript providers on the compiled/global binary path in workspace scope (Slice 43)
+* outside-workspace packaging/distribution remains explicitly deferred
 
 ## Version roadmap
 
@@ -480,8 +481,8 @@ It should mean that the product is trustworthy in its intended scope.
 The current near-term direction is:
 
 * preserve and truth-align the now-proven second-engineer documented workflow
-* remove the highest remaining usability friction in that workflow: manual
-  `NODE_OPTIONS="--import tsx/esm"` for TypeScript providers on the compiled/global binary path
+* keep narrow usability hardening focused on the proven 0.5.x common path,
+  without broadening product scope
 * keep the `pnpm cli` in-repo path and formal binary path explicit and honest in docs
 
 The provider model and consumer workflow are now stable enough that the remaining

--- a/docs/development/tasks/dev-slice-43-task-01.md
+++ b/docs/development/tasks/dev-slice-43-task-01.md
@@ -1,0 +1,75 @@
+# Dev Slice 43 — Task 01
+
+## Title
+
+Compiled/global binary usability: no manual `NODE_OPTIONS` for TypeScript providers (workspace scope only)
+
+## Sources of truth
+
+- `docs/development/current-state.md` — current 0.5.x priority
+- `docs/development/roadmap.md` — 0.5.x usability direction
+- `docs/guides/external-demo-guide.md` — formal binary workflow
+- `docs/guides/provider-authoring-guide.md` — explicit provider loading boundary
+
+## Motivation
+
+After Slice 42 and the follow-up public truth-alignment pass, the documented
+second-engineer workflow is proven end-to-end on `main`.
+
+The highest-value remaining friction in current 0.5.x scope is that compiled and
+globally-linked binary invocation requires users to manually set:
+
+`NODE_OPTIONS="--import tsx/esm"`
+
+for TypeScript provider modules.
+
+This friction is procedural and avoidable in the current workspace model.
+
+## In scope
+
+- `tests/acceptance/dev-slice-43.acceptance.test.ts` (new)
+  - prove compiled binary invocation succeeds with TypeScript providers without
+    manually supplying `NODE_OPTIONS`
+  - keep proof in workspace scope only
+
+- `apps/cli/src/index.ts`
+  - add the narrowest safe provider-loading fallback needed to support
+    TypeScript provider modules without manual `NODE_OPTIONS` in the current
+    workspace model
+  - preserve existing explicit provider module behavior and refusal/error shape
+
+- `docs/guides/external-demo-guide.md`
+  - update formal binary guidance to reflect no manual `NODE_OPTIONS` requirement
+    in current workspace path if implementation is proven
+  - keep outside-workspace limitations explicit
+
+- `docs/development/current-state.md`
+- `docs/development/repo-map.md`
+  - truth-align slice completion and current 0.5.x status
+
+## Out of scope
+
+- Packaging/distribution redesign outside the workspace
+- Provider discovery or auto-registration
+- New provider shapes
+- Major CLI redesign
+- Claims that globally-linked binary use outside workspace is solved
+
+## Acceptance criteria
+
+- Compiled binary invocation (`node apps/cli/bin/multiverse.js ...`) can load
+  a TypeScript providers module in current workspace scope without requiring the
+  user to set `NODE_OPTIONS` manually
+- Existing CLI behavior is unchanged for explicit provider loading semantics
+- `scripts/codex-env.sh pnpm vitest run` passes
+
+## What this slice proves and what it does not
+
+**Proves:**
+- Within current workspace scope, TypeScript provider modules can be loaded on
+  compiled/global binary paths without users manually setting `NODE_OPTIONS`
+
+**Does not prove:**
+- Provider distribution/packaging outside the workspace
+- Full outside-workspace global-binary usability
+- Any new provider model behavior beyond loader usability

--- a/docs/guides/external-demo-guide.md
+++ b/docs/guides/external-demo-guide.md
@@ -381,15 +381,15 @@ The compiled binary and `pnpm cli` invoke the same underlying CLI logic. All com
 
 ### TypeScript providers within the workspace
 
-Workspace provider packages (`@multiverse/provider-path-scoped`, etc.) export TypeScript source directly. Node.js cannot import them natively through the compiled binary. To load TypeScript provider files within the current workspace setup, register the tsx loader:
+Workspace provider packages (`@multiverse/provider-path-scoped`, etc.) export TypeScript source directly. On the compiled and globally-linked binary paths, Multiverse now auto-loads TypeScript provider modules in workspace scope. Manual `NODE_OPTIONS` is not required.
 
 ```bash
-NODE_OPTIONS="--import tsx/esm" node apps/cli/bin/multiverse.js derive \
+node apps/cli/bin/multiverse.js derive \
   --config path/to/multiverse.json \
   --providers path/to/providers.ts
 ```
 
-`tsx` is available as a workspace devDependency when `pnpm install` has been run at the repo root.
+This relies on `tsx` being available in the workspace dependency graph (true after `pnpm install` at the multiverse repo root).
 
 ### Globally-linked binary (within-workspace proof)
 
@@ -426,10 +426,10 @@ This places a `multiverse` executable in `$PNPM_HOME`. Verify with:
 multiverse --help
 ```
 
-**Step 4** — Invoke with `NODE_OPTIONS` set:
+**Step 4** — Invoke:
 
 ```bash
-NODE_OPTIONS="--import tsx/esm" multiverse derive \
+multiverse derive \
   --config apps/sample-express/multiverse.json \
   --providers apps/sample-express/providers.ts
 ```
@@ -437,10 +437,7 @@ NODE_OPTIONS="--import tsx/esm" multiverse derive \
 All commands behave identically to `pnpm cli` and `node apps/cli/bin/multiverse.js`.
 
 **Structural limitation:** This path is proven within the multiverse workspace.
-`tsx` is a workspace devDependency — `NODE_OPTIONS="--import tsx/esm"` resolves
-it relative to the current directory. Outside the workspace directory, the tsx
-package cannot be found and the binary will fail to load TypeScript providers.
-Additionally, provider packages (`@multiverse/provider-path-scoped`, etc.) are
+Provider packages (`@multiverse/provider-path-scoped`, etc.) are
 workspace-local and not published to npm, so any `providers.ts` must import from
 the workspace regardless of where the binary is invoked from.
 
@@ -452,8 +449,7 @@ pnpm remove --global @multiverse/cli
 
 ### What is deferred
 
-- A globally-linked `multiverse` command usable from outside the multiverse workspace (requires either globally installing tsx, or compiling workspace packages to JavaScript)
-- A binary that loads TypeScript providers without `NODE_OPTIONS`
+- A globally-linked `multiverse` command usable for non-workspace repositories
 - Distribution outside the repository
 
 ---
@@ -482,4 +478,4 @@ Auto-discovery could not resolve a worktree identity from the current directory.
 
 **"Cannot load providers module" when using the compiled binary**
 
-The binary cannot import TypeScript files natively. Run with `NODE_OPTIONS="--import tsx/esm"` as described in the "Using the formal binary" section above.
+Ensure you are using a providers module whose imports resolve in the current workspace (for example `apps/sample-express/providers.ts` from the multiverse repo root). Outside-workspace provider packaging remains deferred.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       '@multiverse/provider-contracts':
         specifier: workspace:*
         version: link:../../packages/provider-contracts
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
 
   apps/sample-compose:
     dependencies:

--- a/tests/acceptance/dev-slice-43.acceptance.test.ts
+++ b/tests/acceptance/dev-slice-43.acceptance.test.ts
@@ -1,0 +1,79 @@
+import { execFile, execFileSync } from "node:child_process";
+import path from "node:path";
+import { promisify } from "node:util";
+
+import { describe, expect, it } from "vitest";
+
+const execFileAsync = promisify(execFile);
+
+interface CompiledCliResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+async function runCompiledCli(args: string[]): Promise<CompiledCliResult> {
+  const repoRoot = process.cwd();
+  const binaryPath = path.join(repoRoot, "apps/cli/bin/multiverse.js");
+  const env = { ...process.env };
+  delete env.NODE_OPTIONS;
+
+  try {
+    const { stdout, stderr } = await execFileAsync("node", [binaryPath, ...args], {
+      cwd: repoRoot,
+      env
+    });
+    return { exitCode: 0, stdout, stderr };
+  } catch (err) {
+    if (!(err instanceof Error)) {
+      throw err;
+    }
+    const failure = err as Error & {
+      code?: number;
+      stdout?: string;
+      stderr?: string;
+    };
+    return {
+      exitCode: failure.code ?? 1,
+      stdout: failure.stdout ?? "",
+      stderr: failure.stderr ?? failure.message
+    };
+  }
+}
+
+describe("dev-slice-43: compiled binary TypeScript provider loading without manual NODE_OPTIONS", () => {
+  it("loads a TypeScript providers module on the compiled binary path without NODE_OPTIONS (workspace scope)", async () => {
+    const repoRoot = process.cwd();
+
+    // Ensure the compiled binary reflects current source before invocation.
+    execFileSync(
+      "node",
+      ["node_modules/typescript/bin/tsc", "--project", "apps/cli/tsconfig.build.json"],
+      {
+        cwd: repoRoot,
+        stdio: "pipe"
+      }
+    );
+
+    const outcome = await runCompiledCli([
+      "derive",
+      "--config",
+      "apps/sample-express/multiverse.json",
+      "--providers",
+      "apps/sample-express/providers.ts",
+      "--worktree-id",
+      "wt-slice43"
+    ]);
+
+    expect(outcome.exitCode).toBe(0);
+    const parsed = JSON.parse(outcome.stdout.trim()) as {
+      ok: boolean;
+      resourcePlans: Array<{ worktreeId: string }>;
+      endpointMappings: Array<{ worktreeId: string }>;
+    };
+    expect(parsed.ok).toBe(true);
+    expect(parsed.resourcePlans[0]?.worktreeId).toBe("wt-slice43");
+    expect(parsed.endpointMappings[0]?.worktreeId).toBe("wt-slice43");
+    expect(outcome.stderr).toBe("");
+  });
+});

--- a/tests/acceptance/dev-slice-43.acceptance.test.ts
+++ b/tests/acceptance/dev-slice-43.acceptance.test.ts
@@ -65,7 +65,7 @@ describe("dev-slice-43: compiled binary TypeScript provider loading without manu
       "wt-slice43"
     ]);
 
-    expect(outcome.exitCode).toBe(0);
+    expect(outcome.exitCode, `binary exited ${outcome.exitCode}; stderr: ${outcome.stderr}`).toBe(0);
     const parsed = JSON.parse(outcome.stdout.trim()) as {
       ok: boolean;
       resourcePlans: Array<{ worktreeId: string }>;

--- a/tests/acceptance/dev-slice-43.acceptance.test.ts
+++ b/tests/acceptance/dev-slice-43.acceptance.test.ts
@@ -45,15 +45,20 @@ describe("dev-slice-43: compiled binary TypeScript provider loading without manu
   it("loads a TypeScript providers module on the compiled binary path without NODE_OPTIONS (workspace scope)", async () => {
     const repoRoot = process.cwd();
 
-    // Ensure the compiled binary reflects current source before invocation.
-    execFileSync(
-      "node",
-      ["node_modules/typescript/bin/tsc", "--project", "apps/cli/tsconfig.build.json"],
-      {
+    // Build the full compiled-binary dependency chain in topological order before invocation.
+    // @multiverse/core and @multiverse/provider-contracts export dist/index.js (not TS source),
+    // so they must be compiled before the CLI binary can run outside the tsx dev path.
+    const tsc = ["node_modules/typescript/bin/tsc"];
+    for (const [project] of [
+      ["packages/provider-contracts/tsconfig.build.json"],
+      ["packages/core/tsconfig.build.json"],
+      ["apps/cli/tsconfig.build.json"]
+    ]) {
+      execFileSync("node", [...tsc, "--project", project], {
         cwd: repoRoot,
         stdio: "pipe"
-      }
-    );
+      });
+    }
 
     const outcome = await runCompiledCli([
       "derive",


### PR DESCRIPTION
## Summary
Implements a narrow 0.5.x usability fix: compiled/global binary invocation can now load TypeScript providers in workspace scope without requiring users to manually set NODE_OPTIONS.

## Cause assessment
- The compiled/global binary path loaded providers modules via native dynamic import only.
- For TypeScript providers (and workspace provider packages exporting TypeScript source), native Node ESM import failed without a loader.
- Prior workflow required users to set NODE_OPTIONS="--import tsx/esm" manually.

## Scope
- add a TypeScript-provider-only fallback in CLI provider module loading using tsx/esm/api
- keep explicit provider loading semantics and refusal behavior unchanged
- add acceptance coverage proving compiled binary success without NODE_OPTIONS
- add Slice 43 task doc
- truth-align README/current-state/roadmap/repo-map/external-demo-guide
- declare tsx as an explicit @multiverse/cli dependency

## Validation
- scripts/codex-env.sh pnpm exec vitest run tests/acceptance/dev-slice-43.acceptance.test.ts
- scripts/codex-env.sh pnpm vitest run
- scripts/codex-env.sh pnpm typecheck
- scripts/codex-env.sh pnpm --filter @multiverse/cli build
- manual checks:
  - node apps/cli/bin/multiverse.js derive --config apps/sample-express/multiverse.json --providers apps/sample-express/providers.ts --worktree-id wt-slice43-manual-check
  - env NODE_OPTIONS="" node apps/cli/bin/multiverse.js derive --config apps/sample-express/multiverse.json --providers apps/sample-express/providers.ts --worktree-id wt-slice43-manual-check-empty-node-options

## Proves
- In workspace scope, compiled/global binary paths load TypeScript providers without manual NODE_OPTIONS.

## Still does not prove
- outside-workspace provider packaging/distribution
- globally-linked binary usability for non-workspace repositories
- provider discovery or auto-registration
- broad CLI redesign