### PR TITLE
docs: close out 0.5.x and bump posture to 0.6.0-alpha.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,9 @@ Today’s repo includes:
 
 ## Current behavior being proven
 
-The current implementation proves the core loop for explicit declarations and deterministic derivation, the composed application consumer workflow, and a complete provider extensibility story now captured in `0.5.0-alpha.1`.
+The current implementation proves the core loop for explicit declarations and deterministic derivation, the composed application consumer workflow, and a complete provider extensibility story. The `0.5.x` early outside-usability phase is complete: the documented second-engineer workflow is proven end-to-end, including real two-worktree auto-discovery/isolation and no-manual-`NODE_OPTIONS` TypeScript provider loading in workspace scope on compiled/global binary paths. `0.6.0-alpha.1` begins the semantic stability phase.
 
-`0.5.0-alpha.1` is the early outside-usability phase. The `0.4.x` extensibility proof is complete (new provider shapes, non-first-party authoring, CLI invocation proof), and the documented second-engineer workflow is now proven, including real two-worktree auto-discovery/isolation for Step 5 and no-manual-`NODE_OPTIONS` TypeScript provider loading in workspace scope on compiled/global binary paths. 1.0 remains intentionally narrow; outside-workspace packaging and distribution remain deferred.
+1.0 remains intentionally narrow; outside-workspace packaging and distribution remain deferred.
 
 That includes:
 

--- a/docs/development/current-state.md
+++ b/docs/development/current-state.md
@@ -15,7 +15,7 @@ This is a short state-of-the-project document, not a full history.
 
 ## Current version posture
 
-Current version posture: **0.5.0-alpha.1**
+Current version posture: **0.6.0-alpha.1**
 
 Interpretation:
 
@@ -24,7 +24,8 @@ Interpretation:
 * the composed application consumer workflow is established and stable
 * the provider model is extensible: a second endpoint shape, a non-first-party authoring path, a parameterized compliance suite, and CLI-level invocation proof are all on `main`
 * all four 0.4.x roadmap exit criteria are met; the extensibility wave is complete
-* `0.5.0-alpha.1` begins the early outside usability phase: the next honest proving question is whether a second engineer can follow the docs and succeed without live guidance
+* all 0.5.x exit criteria are met: the documented second-engineer workflow is proven end-to-end, including real two-worktree auto-discovery/isolation and no-manual-`NODE_OPTIONS` TypeScript provider loading in workspace scope; outside-workspace packaging and distribution remain explicitly deferred
+* `0.6.0-alpha.1` begins the semantic stability phase: the next honest proving question is whether lifecycle semantics, refusal behavior, and naming are consistent and trustworthy across providers, docs, and CLI output
 * 1.0 expectations remain intentionally narrow
 
 ## What is already proven
@@ -233,22 +234,24 @@ distribution remain deferred.
 
 The current priority is:
 
-**`0.5.x` early outside usability — the documented in-repo and within-workspace binary paths are proven, including real multi-worktree proof and no-manual-`NODE_OPTIONS` TypeScript provider loading in workspace scope. The remaining outside-workspace packaging/distribution gap is explicitly deferred.**
+**`0.6.x` semantic stability — lifecycle semantics, refusal behavior, and naming consistency across providers, docs, and CLI output. The `0.5.x` early outside-usability phase is complete. Outside-workspace packaging and distribution remain explicitly deferred.**
 
 ## What kinds of work are highest-value right now
 
-Examples of work that are strongly aligned with the current `0.5.x` phase:
+Examples of work that are strongly aligned with the current `0.6.x` phase:
 
-* bounded truth-alignment and documentation clarity for the now-proven 0.5.x
-  common workflow
-* targeted stability hardening that does not broaden scope or introduce new
-  product behavior
+* tightening lifecycle definitions across provider types (reset, cleanup, validate semantics)
+* clarifying and testing refusal outcomes across all commands and providers
+* naming consistency across docs, code, and CLI output
+* making reset and cleanup behavior predictable for composed multi-provider applications
+* spec or ADR groundwork before any implementation work in this area
 
 ## What is intentionally deferred
 
-The following remain explicitly lower priority for the `0.5.x` phase:
+The following remain explicitly deferred:
 
 * provider packaging and distribution outside the repository as standalone npm packages
+* globally-linked binary usability for non-workspace repositories
 * community-extension workflow optimization
 * generalized plugin/ecosystem framing
 * broad CLI redesign or new command surface
@@ -258,15 +261,14 @@ The following remain explicitly lower priority for the `0.5.x` phase:
 
 When deciding what to work on next, prefer work that answers the current proving question:
 
-**Can a second engineer follow the existing docs and successfully run a
-Multiverse-isolated application without live guidance?**
+**Are Multiverse lifecycle semantics, refusal behavior, and naming consistent and
+trustworthy across providers, docs, and CLI output?**
 
 Use this preference order:
 
-1. identify and close the most load-bearing cold-start friction in the current docs
-2. prove (by demonstration or test) that the documented common-case workflow is
-   reproducible from scratch
-3. truth-align docs where they reference stale posture or phase language
+1. identify lifecycle or refusal behavior that is ambiguous or inconsistent across provider types
+2. establish clear definitions through spec or ADR work before writing implementation code
+3. validate that docs, code, and CLI output use consistent terminology
 4. only then broader surface polish or new capabilities
 
 ## Related documents

--- a/docs/development/roadmap.md
+++ b/docs/development/roadmap.md
@@ -26,7 +26,7 @@ Multiverse development continues under the same core assumptions:
 
 ## Current version posture
 
-Current version posture: **0.5.0-alpha.1**
+Current version posture: **0.6.0-alpha.1**
 
 What that means:
 
@@ -40,6 +40,8 @@ What that means:
 * the documented external-demo-guide workflow is reproducible from scratch by a second engineer, including the real two-worktree Step 5 proof (Slice 42)
 * the globally-linked binary path is proven within the workspace (Slice 41)
 * manual `NODE_OPTIONS` is no longer required for TypeScript providers on the compiled/global binary path in workspace scope (Slice 43)
+* all `0.5.x` exit criteria are met; the early outside-usability phase is complete in substance
+* `0.6.0-alpha.1` enters the semantic stability phase: lifecycle semantics, refusal behavior, and naming consistency are the next proving target
 * outside-workspace packaging/distribution remains explicitly deferred
 
 ## Version roadmap
@@ -480,14 +482,15 @@ It should mean that the product is trustworthy in its intended scope.
 
 The current near-term direction is:
 
-* preserve and truth-align the now-proven second-engineer documented workflow
-* keep narrow usability hardening focused on the proven 0.5.x common path,
-  without broadening product scope
-* keep the `pnpm cli` in-repo path and formal binary path explicit and honest in docs
+* begin `0.6.x` semantic stability work through spec and ADR groundwork before any implementation
+* audit lifecycle semantics (reset, cleanup, validate) for consistency across provider types
+* clarify refusal behavior and ensure error/refusal messages are actionable and consistent
+* identify naming inconsistencies across docs, code, and CLI output
 
-The provider model and consumer workflow are now stable enough that the remaining
-0.5.x work is about usability, reproducibility, and honest documentation — not
-proving new product behaviors.
+The `0.5.x` work is complete. The documented second-engineer workflow is proven and
+truth-aligned. The next honest proving question is whether lifecycle semantics, refusal
+behavior, and naming are consistent and trustworthy — not adding new product behaviors
+or broadening scope.
 
 Provider-ecosystem formalization and external distribution remain deferred.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "multiverse",
-  "version": "0.5.0-alpha.1",
+  "version": "0.6.0-alpha.1",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.33.0",


### PR DESCRIPTION
## Summary

- Bumps `package.json` version from `0.5.0-alpha.1` to `0.6.0-alpha.1`
- Marks `0.5.x` early outside-usability phase as complete in substance across `README.md`, `current-state.md`, and `roadmap.md`
- Updates current priority, highest-value work, practical proving question, and immediate direction to target `0.6.x` semantic stability
- Adds globally-linked binary for non-workspace repositories to the explicit deferred list

## Scope

Docs and version posture only. No implementation changes, no new behavior, no spec rewrites. Deferred items preserved. 1.0 narrow scope unchanged.

## Validation

- `pnpm typecheck` passes

## Deferred

No new deferred items introduced. Existing deferred items (outside-workspace packaging, distribution, provider discovery, CLI redesign) remain explicitly deferred.

## Next

The next substantive work should be **0.6.x semantic stability planning** — spec or ADR groundwork for lifecycle semantics, refusal behavior consistency, and naming — not additional 0.5.x cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)