### PR TITLE
docs: 0.6.x semantic stability planning pass (Slice 44)

### DIFF
--- a/docs/development/current-state.md
+++ b/docs/development/current-state.md
@@ -230,6 +230,17 @@ with a TypeScript providers module without manually setting
 `NODE_OPTIONS="--import tsx/esm"`. Outside-workspace provider packaging and
 distribution remain deferred.
 
+**What are the semantic stability gaps that constitute the 0.6.x proving wave?**
+
+Slice 44 establishes the planning baseline for `0.6.x`. A full provider lifecycle
+capability matrix, a six-seam stability audit, and a proposed follow-on slice sequence
+are documented in `docs/development/dev-slice-44.md`. The scenario-to-source-of-truth
+cross-reference is in `docs/development/dev-slice-44-scenario-map.md`. Key findings:
+no first-party provider implements `validateResource()` (spec gap); the scope-confirmation
+vs effectful lifecycle distinction is proven in code but absent from spec docs; the
+worktree identity scenario for the main checkout is inconsistent with ADR-0021
+auto-discovery behavior. Four follow-on slices (45–48) are proposed to close these gaps.
+
 ## Current priority
 
 The current priority is:

--- a/docs/development/dev-slice-44-scenario-map.md
+++ b/docs/development/dev-slice-44-scenario-map.md
@@ -189,7 +189,7 @@ Source-of-truth precedence order (from CLAUDE.md):
 
 ### Gaps and responsible slice
 
-- **Slice 48**: Add explicit deferred classification for `appEnv` injection in
+- **Slice 49**: Add explicit deferred classification for `appEnv` injection in
   `derive --format=env` to ADR-0018 or a brief follow-on note; clarify this was excluded
   by design and is not an oversight
 - The remainder of this seam is well-covered and stable
@@ -232,6 +232,7 @@ Source-of-truth precedence order (from CLAUDE.md):
 - The "recreated worktree" scenario remains aspirational and deferred (requires a persistent
   registry); no change needed
 
+
 ---
 
 ## Summary: gap inventory by slice
@@ -241,7 +242,8 @@ Source-of-truth precedence order (from CLAUDE.md):
 | 45 | Seam 1, Seam 4 | Spec + scenarios + guide update; docs-only |
 | 46 | Seam 2 | Decision + narrow implementation or explicit deferral |
 | 47 | Seam 3, Seam 4 | Docs + targeted CLI messaging audit; narrow fixes only |
-| 48 | Seam 5, Seam 6 | Docs-only; scenario annotation and deferred classification |
+| 48 | Seam 6 | Docs-only; worktree identity scenario annotation |
+| 49 | Seam 5 | Docs-only; appEnv/derive deferred classification |
 
 ## Items confirmed stable — no 0.6.x work required
 

--- a/docs/development/dev-slice-44-scenario-map.md
+++ b/docs/development/dev-slice-44-scenario-map.md
@@ -1,0 +1,259 @@
+# Dev Slice 44 — Scenario Map
+
+## Purpose
+
+This document maps each of the six 0.6.x semantic seams identified in `dev-slice-44.md`
+to their current source-of-truth coverage, identifies the gaps, and notes which follow-on
+slice addresses each gap.
+
+Source-of-truth precedence order (from CLAUDE.md):
+1. `docs/adr/`
+2. `docs/spec/`
+3. `docs/scenarios/`
+4. `docs/development/`
+
+---
+
+## Seam 1 — Lifecycle semantics across provider types
+
+### Relevant source-of-truth documents
+
+| Document | Relevance |
+|---|---|
+| `docs/spec/provider-model.md` | Defines derive, validate, reset, cleanup at the capability level |
+| `docs/spec/resource-isolation.md` | Defines scoped reset and cleanup at the resource level |
+| `docs/adr/0005-providers-implement-isolation-contracts.md` | Establishes optional capability pattern |
+| `docs/adr/0015-path-scoped-providers-manage-explicit-child-processes.md` | Governs process-scoped lifecycle semantics |
+| `docs/scenarios/provider-model.scenarios.md` | Scenarios for provider capability behavior |
+| `docs/scenarios/resource-isolation.scenarios.md` | Scenarios for scoped reset/cleanup isolation |
+| `docs/guides/provider-authoring-guide.md` | Practical implementation guidance for reset/cleanup |
+
+### Current coverage
+
+| Topic | Coverage status |
+|---|---|
+| Reset is optional and must be explicitly declared | ✓ Covered in spec and ADR-0005 |
+| Cleanup is optional and must be explicitly declared | ✓ Covered in spec and ADR-0005 |
+| Destructive action may not execute implicitly | ✓ Covered in spec and scenarios |
+| Destructive action refused when scope cannot be determined | ✓ Covered in spec, ADR-0008, and scenarios |
+| **Scope-confirmation vs effectful distinction** | **✗ Not in any spec or scenario doc** |
+| **Reset intent: prepare for next use vs cleanup intent: permanent removal** | **✗ Spec language is ambiguous ("reinitializes or destroys")** |
+| Process-scoped: reset re-launches; cleanup terminates only | Partially covered in ADR-0015 rules 3–4 |
+| **Process-scoped readiness: current contract is fixed 500ms wait** | **✗ Not documented anywhere** |
+| **`{PORT}` placeholder substitution in process-port-scoped** | **✗ Not in any spec, ADR, or guide** |
+| Name-scoped: reset/cleanup are scope-confirmation only | ✗ Not stated explicitly in spec or guide |
+
+### Gaps and responsible slice
+
+- **Slice 45**: Add scope-confirmation vs effectful distinction to `docs/spec/provider-model.md`
+  and `docs/guides/provider-authoring-guide.md`
+- **Slice 45**: Clarify reset vs cleanup intent in `docs/spec/provider-model.md`
+- **Slice 45**: Add scenarios for scope-confirmation and intent distinction to
+  `docs/scenarios/provider-model.scenarios.md`
+- **Slice 45**: Document process-scoped fixed-interval readiness and `{PORT}` substitution
+  in `docs/guides/provider-authoring-guide.md`
+
+---
+
+## Seam 2 — Validate capability
+
+### Relevant source-of-truth documents
+
+| Document | Relevance |
+|---|---|
+| `docs/spec/provider-model.md` | Lists validate as an optional provider capability |
+| `docs/spec/endpoint-model.md` | Lists validate as an optional endpoint provider capability |
+| `docs/spec/resource-isolation.md` | Lists resource declaration requirements (validate absent) |
+| `docs/spec/safety-and-refusal.md` | Lists validate as an operation subject to refusal |
+| `docs/adr/0005-providers-implement-isolation-contracts.md` | Establishes optional capability pattern |
+| `docs/adr/0008-unsafe-operations-are-refused-in-1-0.md` | Applies refusal to validate |
+| `docs/scenarios/provider-model.scenarios.md` | Has scenario for providers that declare validate |
+| `docs/scenarios/safety-and-refusal.scenarios.md` | Has scenario for unsafe scope during validation |
+| `docs/guides/provider-authoring-guide.md` | Does not show validate in capabilities example |
+
+### Current coverage
+
+| Topic | Coverage status |
+|---|---|
+| Validate is an optional provider capability | ✓ Covered in spec |
+| Validate is subject to refusal when scope unsafe | ✓ Covered in spec and scenarios |
+| Validate is provider-specific | ✓ Covered in spec |
+| **`scopedValidate` field in resource declarations** | **✗ Not listed in `docs/spec/resource-isolation.md`** |
+| **No first-party provider implements `validateResource()`** | **✗ Not documented as gap or deferral** |
+| **`scopedValidate: true` has no current effect** | **✗ Not documented** |
+| Validate in provider authoring guide capabilities example | ✗ Absent from guide |
+
+### Gaps and responsible slice
+
+- **Slice 46**: Decision required — implement path-scoped validate or explicitly defer
+- **Slice 46**: Add `scopedValidate` to `docs/spec/resource-isolation.md` declaration requirements
+- **Slice 46**: Update `docs/guides/provider-authoring-guide.md` to show validate in
+  capabilities section (either with implementation example or with explicit deferral note)
+- **Slice 46**: If deferring: add explicit notation to the spec that no first-party provider
+  currently implements validate, and what `scopedValidate: true` does in practice
+
+---
+
+## Seam 3 — Refusal and error-boundary semantics
+
+### Relevant source-of-truth documents
+
+| Document | Relevance |
+|---|---|
+| `docs/spec/safety-and-refusal.md` | Primary spec; defines four categories and all refusal rules |
+| `docs/adr/0008-unsafe-operations-are-refused-in-1-0.md` | Establishes refusal as first-class behavior |
+| `docs/adr/0009-core-provider-repository-and-application-boundaries-are-explicit.md` | Defines which layer owns refusal |
+| `docs/scenarios/safety-and-refusal.scenarios.md` | Scenarios for all four categories |
+| `@multiverse/provider-contracts` (Refusal type) | Machine-readable category identifiers |
+
+### Current coverage
+
+| Topic | Coverage status |
+|---|---|
+| Four refusal categories defined | ✓ In spec and ADR-0008 |
+| Core vs provider refusal responsibility | ✓ In spec and ADR-0009 |
+| All four categories covered in scenarios | ✓ In `safety-and-refusal.scenarios.md` |
+| Refusal applies to non-destructive operations | ✓ In spec and scenarios |
+| **Spec uses spaces; contract uses underscores; split not documented** | **✗ Split is correct but unexplained** |
+| **CLI output consistency per category across all commands** | **✗ Not audited; not in any doc** |
+| **All category × command combinations have scenario coverage** | **Partially — needs audit** |
+
+### Gaps and responsible slice
+
+- **Slice 47**: Add a note to `docs/spec/safety-and-refusal.md` documenting that category
+  names correspond to `category` field values in the provider `Refusal` type (underscore form)
+- **Slice 47**: Audit CLI output per category across all five commands
+- **Slice 47**: Fix any messages that conflate categories or are not actionable
+- **Slice 47**: Add scenario coverage for any missing category × command combinations
+
+---
+
+## Seam 4 — Naming and terminology
+
+### Relevant source-of-truth documents
+
+| Document | Relevance |
+|---|---|
+| `docs/spec/` (all) | Canonical terminology source |
+| `docs/adr/` (all) | Canonical decision language |
+| `docs/guides/provider-authoring-guide.md` | Guides use of terms for provider authors |
+| `docs/guides/external-demo-guide.md` | Consumer-facing terminology |
+
+### Current coverage
+
+| Term/concept | Coverage status |
+|---|---|
+| "worktree instance" (spec) vs "worktree" (common usage) | ✓ Spec uses "worktree instance" consistently |
+| "handle" for resources vs "address" for endpoints | ✓ Correctly distinct in spec and contracts |
+| `MULTIVERSE_*` env var naming convention (uppercase, hyphens → underscores) | ✓ In ADR-0013 and external-demo-guide |
+| Capability names: derive, validate, reset, cleanup | ✓ Consistent in spec and contracts |
+| **"scope-confirmation" semantic** | **✗ Implementation term not in any spec doc** |
+| **"effectful" lifecycle semantic** | **✗ Implementation term not in any spec doc** |
+| **Spec category names (spaces) vs contract `category` field (underscores)** | **✗ Split correct but undocumented** |
+| **`{PORT}` placeholder in process-port-scoped** | **✗ Absent from all source-of-truth docs** |
+
+### Gaps and responsible slice
+
+- **Slice 45**: Introduce "scope-confirmation" and "effectful" as documented concepts in
+  the provider authoring guide (or equivalent spec language for what these mean)
+- **Slice 47**: Document the spec/contract naming split
+- **Slice 45**: Document `{PORT}` placeholder
+
+---
+
+## Seam 5 — Consumer integration semantics
+
+### Relevant source-of-truth documents
+
+| Document | Relevance |
+|---|---|
+| `docs/adr/0018-explicit-app-native-env-mapping-for-run.md` | Establishes appEnv for resources and string-alias endpoints |
+| `docs/adr/0019-explicit-typed-endpoint-mapping.md` | Establishes typed endpoint appEnv mapping |
+| `docs/adr/0012-explicit-process-wrapper-run.md` | Establishes run semantics and env injection boundaries |
+| `docs/guides/external-demo-guide.md` | Documents consumer-facing usage patterns |
+| `apps/sample-compose/` | Proving app for mixed-provider consumer workflow |
+
+### Current coverage
+
+| Topic | Coverage status |
+|---|---|
+| `appEnv` string-alias for resources | ✓ ADR-0018; proven in sample-compose |
+| `appEnv` string-alias for endpoints | ✓ ADR-0018; proven in sample-compose |
+| `appEnv` typed mapping for endpoints (`url`, `port`) | ✓ ADR-0019; proven in sample-compose |
+| Conflict behavior (appEnv name collides with parent env) | ✓ ADR-0018/0019 |
+| Canonical `MULTIVERSE_*` vars always injected alongside appEnv | ✓ ADR-0018 |
+| **`appEnv` excluded from `derive --format=env`** | **✓ Excluded in ADR-0018, but not explicitly classified as deferred** |
+| **Typed resource appEnv mapping** | **✓ Explicitly deferred in ADR-0019** |
+| **Multiple appEnv aliases for one declaration** | **✓ Explicitly deferred in ADR-0018** |
+| Application-owned runtime-config boundary pattern | ✓ Proven in sample-compose; described in external-demo-guide |
+
+### Gaps and responsible slice
+
+- **Slice 48**: Add explicit deferred classification for `appEnv` injection in
+  `derive --format=env` to ADR-0018 or a brief follow-on note; clarify this was excluded
+  by design and is not an oversight
+- The remainder of this seam is well-covered and stable
+
+---
+
+## Seam 6 — Worktree identity scenario alignment
+
+### Relevant source-of-truth documents
+
+| Document | Relevance |
+|---|---|
+| `docs/scenarios/worktree-identity.scenarios.md` | Primary scenario coverage |
+| `docs/adr/0021-git-worktree-path-conventional-default-for-worktree-id.md` | Governs auto-discovery behavior |
+| `docs/adr/0002-branch-name-is-metadata.md` | Branch name is not identity |
+| `docs/adr/0003-main-checkout-uses-reserved-main-identity.md` | Main checkout reserved identity |
+| `docs/adr/0001-git-worktrees-only-1.0.md` | Scope constraint |
+
+### Current coverage
+
+| Topic | Coverage status |
+|---|---|
+| Main checkout identity is `"main"` (explicit flag case) | ✓ In scenarios; ADR-0003 |
+| Linked worktree receives unique identity | ✓ In scenarios |
+| Same branch, different worktrees → different identities | ✓ In scenarios |
+| Branch name is metadata only | ✓ In scenarios; ADR-0002 |
+| **Main checkout identity in auto-discovery = path basename, not guaranteed `"main"`** | **✗ Scenario does not reflect ADR-0021 behavior** |
+| **Auto-discovery success scenario** | **✗ Not in scenarios** |
+| **Auto-discovery refusal scenario (git unavailable, no matching path)** | **✗ Not in scenarios** |
+| **Recreated worktree gets new lifecycle identity** | ✗ In scenarios as aspirational; explicitly requires registry (deferred) |
+
+### Gaps and responsible slice
+
+- **Slice 48**: Annotate the "main checkout identity is `main`" scenario to clarify it
+  applies when `--worktree-id main` is explicitly supplied
+- **Slice 48**: Add a scenario for auto-discovery behavior: discovered id = path basename,
+  which may differ from `"main"` for the primary checkout
+- **Slice 48**: Add a scenario for auto-discovery refusal (git unavailable or no matching
+  worktree path)
+- The "recreated worktree" scenario remains aspirational and deferred (requires a persistent
+  registry); no change needed
+
+---
+
+## Summary: gap inventory by slice
+
+| Slice | Seams addressed | Nature of work |
+|---|---|---|
+| 45 | Seam 1, Seam 4 | Spec + scenarios + guide update; docs-only |
+| 46 | Seam 2 | Decision + narrow implementation or explicit deferral |
+| 47 | Seam 3, Seam 4 | Docs + targeted CLI messaging audit; narrow fixes only |
+| 48 | Seam 5, Seam 6 | Docs-only; scenario annotation and deferred classification |
+
+## Items confirmed stable — no 0.6.x work required
+
+The following areas were reviewed and are adequately covered by existing source-of-truth docs:
+
+- Core/provider/repository/application boundary rules (ADR-0009; spec confirmed consistent)
+- `run` process wrapper semantics (ADR-0012; no open issues)
+- `derive --format=env` behavior (ADR-0013; consistent)
+- `appEnv` for resources and endpoints including typed endpoint mapping (ADR-0018/0019; stable)
+- Conventional defaults for `--config`, `--providers`, `--worktree-id` (ADR-0014, ADR-0021; stable)
+- Deterministic derivation guarantees (product-spec; stable across all providers)
+- Worktree isolation guarantees (product-spec; stable)
+- Provider selection is explicit; no inference (ADR-0005; stable)
+- Process-scoped orchestration boundary (ADR-0015; stable)
+- Fixed-host-port provider model (ADR-0020; stable)

--- a/docs/development/dev-slice-44.md
+++ b/docs/development/dev-slice-44.md
@@ -272,26 +272,40 @@ No new refusal categories. No CLI redesign.
 
 ---
 
-### Slice 48 — Worktree identity and consumer integration alignment (docs-only)
+### Slice 48 — Worktree identity scenario alignment (docs-only)
 
-**Primary question**: Are the worktree identity scenarios consistent with ADR-0021 behavior,
-and is the appEnv/derive exclusion explicitly classified?
+**Primary question**: Are the worktree identity scenarios consistent with ADR-0021
+auto-discovery behavior?
 
 **Likely file changes**:
 - `docs/scenarios/worktree-identity.scenarios.md` — annotate the main checkout identity
   scenario to clarify it applies to the explicit `--worktree-id main` case; add a scenario
-  for auto-discovery behavior (discovered id = path basename, not guaranteed to be `"main"`)
-- ADR-0018 or a brief follow-on note — explicitly classify `appEnv` injection for
-  `derive --format=env` as deferred rather than as an oversight
-- Review consumer integration model docs for any remaining undocumented assumptions
+  for auto-discovery behavior (discovered id = path basename, not guaranteed to be `"main"`);
+  add a scenario for auto-discovery refusal (git unavailable or no matching worktree path)
 
-**Out of scope**: Implementation changes, new appEnv semantics, new discovery behavior.
+**Out of scope**: Implementation changes, new discovery behavior, consumer integration changes.
+
+---
+
+### Slice 49 — Consumer integration alignment (docs-only)
+
+**Primary question**: Is the `appEnv` exclusion from `derive --format=env` explicitly
+classified as a deliberate design decision rather than an oversight?
+
+**Likely file changes**:
+- ADR-0018 or a brief follow-on note — explicitly classify `appEnv` injection for
+  `derive --format=env` as deferred rather than as an oversight; note that the exclusion
+  was explicit and intentional in the 0.3.x scope decision
+- Review consumer integration model docs for any remaining undocumented assumptions
+  after the 0.5.x proving wave
+
+**Out of scope**: Implementation changes, new appEnv semantics, new derive output formats.
 
 ---
 
 ## Out of scope for this planning slice
 
-- Spec or scenario changes (belong to Slices 45–48)
+- Spec or scenario changes (belong to Slices 45–49)
 - ADR authoring (deferred to individual slices)
 - Implementation changes of any kind
 - New provider packages or provider shapes
@@ -302,7 +316,9 @@ and is the appEnv/derive exclusion explicitly classified?
 
 - `docs/development/dev-slice-44.md` (this file) is present and internally consistent
 - `docs/development/dev-slice-44-scenario-map.md` is present and maps all six seams
-- `docs/development/current-state.md` and `docs/development/roadmap.md` reflect
-  `0.6.0-alpha.1` posture and point to 0.6.x semantic stability as current priority
+- `docs/development/current-state.md` reflects `0.6.0-alpha.1` posture and the Slice 44
+  planning findings (updated in this PR)
+- `docs/development/roadmap.md` reflects `0.6.0-alpha.1` posture and immediate direction
+  pointing to 0.6.x semantic stability (updated in PR #110, already merged to main)
 - No implementation, spec, or ADR changes are introduced in this slice
-- The proposed slice sequence is narrow, bounded, and ordered by priority
+- The proposed slice sequence (Slices 45–49) is narrow, bounded, and ordered by priority

--- a/docs/development/dev-slice-44.md
+++ b/docs/development/dev-slice-44.md
@@ -1,0 +1,308 @@
+# Dev Slice 44 — 0.6.x Semantic Stability: Planning Pass
+
+## Type
+
+Planning and docs only. No implementation changes, no spec rewrites, no new ADRs.
+
+## Context
+
+The `0.5.x` early outside-usability phase is complete as of Slices 36–43. The documented
+second-engineer workflow is proven end-to-end. Version posture has advanced to
+`0.6.0-alpha.1`.
+
+The `0.6.x` line targets semantic stability: making lifecycle semantics, refusal behavior,
+and naming consistent and trustworthy across providers, docs, and CLI output. Before any
+implementation slices begin, this planning pass establishes the evidence base: what is
+stable, what needs alignment, what has genuine spec gaps, and what remains deferred.
+
+## What this slice delivers
+
+- `docs/development/dev-slice-44.md` — this planning document
+- `docs/development/dev-slice-44-scenario-map.md` — seam-to-source-of-truth cross-reference
+
+No spec, ADR, scenario, or implementation changes. Those belong to follow-on slices.
+
+## Semantic seams in scope for 0.6.x
+
+Six semantic seams have been identified for this wave:
+
+1. **Lifecycle semantics across provider types** — reset vs cleanup distinction;
+   scope-confirmation vs effectful provider behavior; provider-specific meanings
+2. **Validate capability** — spec gap; no first-party provider implements validate;
+   `scopedValidate` declaration field is parsed but has no current effect
+3. **Refusal and error-boundary semantics** — category correctness, message consistency,
+   intentional naming split between spec and contract
+4. **Naming and terminology** — undocumented concepts in specs and guides;
+   features present in code but absent from source-of-truth docs
+5. **Consumer integration semantics** — appEnv exclusion from `derive --format=env`;
+   explicit deferred classification for enhancement candidates
+6. **Worktree identity scenario alignment** — main checkout identity in scenarios
+   vs ADR-0021 auto-discovery behavior
+
+## Provider lifecycle capability matrix
+
+Verified from current source code across all six first-party providers:
+
+| Provider | derive | validate | reset | cleanup | Notes |
+|---|---|---|---|---|---|
+| name-scoped | ✓ required | ✗ not declared | ✓ scope-confirm | ✓ scope-confirm | Owns no state; reset/cleanup return scope metadata with no side effects |
+| path-scoped | ✓ required | ✗ not declared | ✓ effectful | ✓ effectful | Both delete the scoped directory; intent differs (see Seam 1 below) |
+| local-port | ✓ required | n/a (endpoint) | ✗ | ✗ | Endpoint provider; derive-only |
+| fixed-host-port | ✓ required | n/a (endpoint) | ✗ | ✗ | Endpoint provider; derive-only |
+| process-scoped | ✓ required | ✗ not declared | ✓ effectful | ✓ effectful | Reset terminates + re-spawns; cleanup terminates + removes state dir |
+| process-port-scoped | ✓ required | ✗ not declared | ✓ effectful | ✓ effectful | Same as process-scoped; adds `{PORT}` placeholder substitution in launch command |
+
+**Summary observations:**
+
+- No first-party resource provider declares or implements `validateResource()`
+- The `scopedValidate: true` configuration path is wired in core but exercised by no current provider
+- `path-scoped` reset and cleanup both delete the scoped directory; they differ in intent, not implementation
+- `name-scoped` reset and cleanup are scope-confirmation only — no state is owned or affected
+- `process-scoped` reset is distinctly different from cleanup: reset re-launches; cleanup terminates without re-launch
+- `process-port-scoped` adds a `{PORT}` placeholder substitution in the launch command; this feature is implemented but not documented in any spec, ADR, or guide
+
+---
+
+## Stability audit
+
+### Already-proven behavior that needs spec-level alignment
+
+These behaviors are correctly implemented and tested but are expressed only in implementation
+comments or `current-state.md`, not in `docs/spec/` or `docs/scenarios/`. A second engineer
+or future provider author cannot derive them from the source-of-truth documents.
+
+**1. Scope-confirmation vs effectful lifecycle semantics**
+
+The name-scoped provider declares `reset: true` and `cleanup: true` but performs no side
+effects. It returns scope-confirmation metadata to signal that the scope was recognized.
+This is correct design: a provider that owns no state has nothing to destroy.
+
+The path-scoped, process-scoped, and process-port-scoped providers perform real state changes
+under reset and cleanup.
+
+This distinction — scope-confirmation vs effectful — is a real and meaningful semantic
+boundary. It is not documented in `docs/spec/provider-model.md`, `docs/scenarios/provider-model.scenarios.md`,
+or `docs/guides/provider-authoring-guide.md`. A provider author following the guide would not
+know when scope-confirmation is an appropriate reset/cleanup implementation.
+
+**2. Reset vs cleanup intent distinction for path-scoped**
+
+For path-scoped, both reset and cleanup delete the scoped directory. The difference is intent:
+reset means "destroy state so the next run starts fresh" (the scoped path will be recreated
+on next use); cleanup means "permanently remove state because this worktree is no longer
+needed." The spec currently uses "reinitializes or destroys" for reset and "removes" for
+cleanup — language that does not capture the intent distinction for providers where the
+operations converge in implementation.
+
+For process-scoped, the distinction is visible: reset terminates then re-spawns the process;
+cleanup terminates without re-spawning. This makes intent clear in the implementation. The
+spec should express this intent consistently across both provider types.
+
+**3. Process-scoped readiness semantics**
+
+The current `process-scoped` provider's readiness check is a fixed 500ms wait after spawn.
+ADR-0015 requires readiness to be "explicit, observable, and provider-defined" and lists
+stronger options (port reachability, health check) as examples. The current implementation
+uses a fixed-interval wait, which satisfies the "explicit" requirement minimally.
+
+This readiness contract (fixed-interval wait after spawn) is not documented in any spec
+or guide. It should be documented explicitly as the current minimal implementation rather
+than left as implicit implementation detail.
+
+**4. `{PORT}` placeholder in process-port-scoped**
+
+The `process-port-scoped` provider substitutes a `{PORT}` placeholder in the user-supplied
+launch command with the derived port value. This feature is implemented and functional but
+is not mentioned in `docs/spec/`, `docs/adr/`, `docs/scenarios/`, or
+`docs/guides/provider-authoring-guide.md`. It represents undocumented behavior in a source
+that should be derivable from source-of-truth docs.
+
+---
+
+### Genuine spec gaps to close in 0.6.x
+
+These are areas where source-of-truth documents either explicitly mark items as open, are
+silent where they should be explicit, or contain statements that conflict with implemented
+behavior.
+
+**1. Validate capability (highest priority)**
+
+- `docs/spec/provider-model.md` and `docs/spec/endpoint-model.md` list validate as an
+  optional provider capability
+- `docs/spec/safety-and-refusal.md` lists validate as an operation subject to refusal
+- `docs/spec/resource-isolation.md` lists required resource declaration fields but does NOT
+  include `scopedValidate` (it lists `scopedReset` and `scopedCleanup` but omits validate)
+- `docs/guides/provider-authoring-guide.md` shows `reset` and `cleanup` in the capabilities
+  example but does not show `validate`
+- No first-party provider declares or implements `validateResource()`
+- The `scopedValidate` field is parsed in repository configuration and the core `validate`
+  command is wired to call `validateResource()` if the provider declares `validate: true`
+  — but no provider currently does
+
+**Current state**: Validate is defined at the concept level and wired in the implementation
+seam, but no first-party provider makes it functional. A user setting `scopedValidate: true`
+on a resource declaration will see no provider-side validation occur. This is neither
+documented as intentional nor as a known gap.
+
+**The 0.6.x decision**: Either implement `validateResource` for at least one provider
+(narrow, bounded), or explicitly classify provider-side validate as deferred for 1.0.
+The `scopedValidate` omission from `docs/spec/resource-isolation.md` must be resolved
+either way.
+
+**2. Worktree identity scenario inconsistency**
+
+`docs/scenarios/worktree-identity.scenarios.md` states:
+
+> "Given the main checkout / When the tool derives worktree identity / Then the Worktree ID is `main`"
+
+ADR-0021 states that auto-discovery resolves the primary checkout's identity as
+`path.basename(entry.path)`, which is the directory name of the checkout — this may or may
+not be `"main"` depending on where the repository was cloned. The scenario is only reliably
+true when `--worktree-id main` is explicitly supplied.
+
+The scenario needs annotation to clarify that it describes the explicit-flag case, and a
+companion scenario should be added for auto-discovery behavior (discovered id = path basename,
+not guaranteed to be `"main"`).
+
+**3. Refusal category naming**
+
+`docs/spec/safety-and-refusal.md` and ADR-0008 use human-readable names:
+"invalid configuration", "unsupported capability", "unsafe scope", "provider failure."
+
+The `Refusal` type in `@multiverse/provider-contracts` uses machine-readable identifiers:
+`invalid_configuration`, `unsupported_capability`, `unsafe_scope`, `provider_failure`.
+
+Both forms are used intentionally at their respective layers (spec is human-facing;
+contract type is code-facing). However, this split is not stated anywhere. A reader could
+conclude the two layers are inconsistent rather than intentionally different. The spec or
+contract should briefly note that the category names correspond to the contract's `category`
+field values.
+
+---
+
+### Explicitly deferred — not in scope for 0.6.x
+
+The following items have been reviewed and classified as deferred. They should not be
+pulled into 0.6.x:
+
+- Provider packaging and distribution outside the workspace as standalone npm packages
+- Globally-linked binary usability for non-workspace repositories
+- `appEnv` injection for `derive --format=env` (explicitly excluded in ADR-0018; no
+  follow-on ADR has been accepted; remains a post-1.0 candidate)
+- Additional endpoint value kinds beyond `url` and `port`
+- Multiple `appEnv` aliases for a single declaration (ADR-0018: "Richer shapes are deferred")
+- Typed resource `appEnv` mapping (ADR-0019 explicitly deferred; current resource appEnv
+  is string-alias only)
+- Richer process-scoped readiness (health check, port-reachability): remains deferred
+  per ADR-0015; appropriate as a focused future process-scoped extension slice
+- Registry-based worktree identity persistence ("recreated worktree gets new lifecycle
+  identity" scenario in worktree-identity.scenarios.md; requires a persistent registry,
+  explicitly not addressed by ADR-0021)
+- New provider packages
+- Broad CLI redesign or new command surface
+- New endpoint shapes
+
+---
+
+## Proposed 0.6.x follow-on slice sequence
+
+Four narrowly scoped slices follow this planning pass. Each needs its own task document
+before implementation begins. Order reflects priority and dependency.
+
+### Slice 45 — Lifecycle semantics spec alignment (docs-only)
+
+**Primary question**: Are the reset vs cleanup intent distinction and the scope-confirmation
+vs effectful provider distinction clearly stated in source-of-truth documents?
+
+**Likely file changes**:
+- `docs/spec/provider-model.md` — distinguish reset intent (prepare for next use) from
+  cleanup intent (permanent removal); add note on scope-confirmation semantics
+- `docs/scenarios/provider-model.scenarios.md` — add scenarios for scope-confirmation
+  vs effectful distinction; add scenarios for reset vs cleanup intent
+- `docs/guides/provider-authoring-guide.md` — document when scope-confirmation is a
+  correct reset/cleanup implementation; document process-scoped readiness current contract;
+  document `{PORT}` placeholder substitution in process-port-scoped
+- No implementation changes
+
+**Out of scope**: New ADRs (only if spec ambiguity cannot be resolved without one),
+implementation changes, new provider behaviors.
+
+---
+
+### Slice 46 — Validate capability resolution (spec decision + narrow implementation or deferral)
+
+**Primary question**: Is `scopedValidate` a working capability or deferred? If working,
+prove it through at least one first-party provider.
+
+**Decision required before implementation**:
+- **Option A (narrow implementation)**: Implement `validateResource` for `path-scoped`
+  (checks whether the scoped path exists and is accessible). Update `docs/spec/`,
+  `docs/scenarios/`, and `docs/guides/provider-authoring-guide.md`. This provides genuine
+  value for the common workflow (verify the database path exists before running the app).
+- **Option B (explicit deferral)**: Update `docs/spec/resource-isolation.md` to include
+  `scopedValidate` in the resource declaration requirements with explicit notation that
+  no first-party provider currently implements validate. Explicitly defer provider-side
+  validate implementations to a post-1.0 slice. Remove `scopedValidate: false` from the
+  external-demo-guide example if it creates confusion.
+
+Either option must resolve the `docs/spec/resource-isolation.md` omission.
+
+**Recommendation**: Option A (narrow path-scoped validate) is load-bearing for the
+composed workflow: it closes a real usability gap for a user who wants to confirm their
+database path is ready before starting their application. Option B is safe but leaves a
+wired-but-unproven path in the system.
+
+---
+
+### Slice 47 — Refusal boundary alignment (docs + targeted messaging audit)
+
+**Primary question**: Are refusal categories consistent and actionable in CLI output,
+and is the spec/contract naming split documented?
+
+**Likely file changes**:
+- `docs/spec/safety-and-refusal.md` — add a note that the four category names correspond
+  to `category` field values in the provider `Refusal` type
+- CLI refusal message audit across all five commands (derive, validate, run, reset, cleanup)
+- Fix any messages that conflate categories or are not actionable
+- `docs/scenarios/safety-and-refusal.scenarios.md` — add any missing category × command
+  combinations
+
+**Implementation scope**: Narrow CLI message fixes only if a genuine messaging gap is found.
+No new refusal categories. No CLI redesign.
+
+---
+
+### Slice 48 — Worktree identity and consumer integration alignment (docs-only)
+
+**Primary question**: Are the worktree identity scenarios consistent with ADR-0021 behavior,
+and is the appEnv/derive exclusion explicitly classified?
+
+**Likely file changes**:
+- `docs/scenarios/worktree-identity.scenarios.md` — annotate the main checkout identity
+  scenario to clarify it applies to the explicit `--worktree-id main` case; add a scenario
+  for auto-discovery behavior (discovered id = path basename, not guaranteed to be `"main"`)
+- ADR-0018 or a brief follow-on note — explicitly classify `appEnv` injection for
+  `derive --format=env` as deferred rather than as an oversight
+- Review consumer integration model docs for any remaining undocumented assumptions
+
+**Out of scope**: Implementation changes, new appEnv semantics, new discovery behavior.
+
+---
+
+## Out of scope for this planning slice
+
+- Spec or scenario changes (belong to Slices 45–48)
+- ADR authoring (deferred to individual slices)
+- Implementation changes of any kind
+- New provider packages or provider shapes
+- Provider packaging/distribution outside workspace scope
+- Broader CLI or command surface work
+
+## Acceptance criteria for this planning slice
+
+- `docs/development/dev-slice-44.md` (this file) is present and internally consistent
+- `docs/development/dev-slice-44-scenario-map.md` is present and maps all six seams
+- `docs/development/current-state.md` and `docs/development/roadmap.md` reflect
+  `0.6.0-alpha.1` posture and point to 0.6.x semantic stability as current priority
+- No implementation, spec, or ADR changes are introduced in this slice
+- The proposed slice sequence is narrow, bounded, and ordered by priority


### PR DESCRIPTION
## Summary

Establishes the planning baseline for the `0.6.x` semantic stability wave. Docs and current-state update only — no implementation, spec, or ADR changes.

## Scope

**New files:**
- `docs/development/dev-slice-44.md` — provider lifecycle capability matrix, six-seam stability audit, and proposed follow-on slice sequence (Slices 45–48)
- `docs/development/dev-slice-44-scenario-map.md` — seam-to-source-of-truth cross-reference for all six semantic seams

**Updated:**
- `docs/development/current-state.md` — Slice 44 proving result entry with key findings and references to new planning docs

## Key findings

- **Validate capability gap**: No first-party provider implements `validateResource()`; `scopedValidate` field is parsed and wired in core but has no effect in any current provider. Classified as a genuine spec gap for Slice 46 to resolve.
- **Scope-confirmation vs effectful**: The name-scoped provider's scope-confirmation lifecycle behavior is correct but undocumented in spec or guide. Slice 45 addresses this.
- **Worktree identity scenario inconsistency**: The main-checkout identity scenario says the Worktree ID is `"main"`, but ADR-0021 auto-discovery gives the path basename, which may differ. Slice 48 addresses this.
- **`{PORT}` placeholder**: process-port-scoped substitutes `{PORT}` in the launch command. Implemented but undocumented. Slice 45 addresses this.

## Proposed follow-on slice sequence

| Slice | Seams | Nature |
|---|---|---|
| 45 | Lifecycle semantics, naming | Spec + scenarios + guide; docs-only |
| 46 | Validate capability | Decision + narrow impl or explicit deferral |
| 47 | Refusal boundaries | Docs + targeted CLI messaging audit |
| 48 | Worktree identity, consumer integration | Docs-only |

## Validation

- `pnpm typecheck` passes
- Planning docs are internally consistent and reference only verified source-of-truth content

## Deferred

All items explicitly deferred in `dev-slice-44.md` remain deferred. No new behavior introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)