### PR TITLE
docs(slice-45): lifecycle semantics spec alignment

### DIFF
--- a/docs/development/current-state.md
+++ b/docs/development/current-state.md
@@ -239,7 +239,21 @@ cross-reference is in `docs/development/dev-slice-44-scenario-map.md`. Key findi
 no first-party provider implements `validateResource()` (spec gap); the scope-confirmation
 vs effectful lifecycle distinction is proven in code but absent from spec docs; the
 worktree identity scenario for the main checkout is inconsistent with ADR-0021
-auto-discovery behavior. Four follow-on slices (45–48) are proposed to close these gaps.
+auto-discovery behavior. Four follow-on slices (45–49) are proposed to close these gaps.
+
+**Are the lifecycle semantics — reset vs cleanup intent and scope-confirmation vs effectful
+behavior — expressed clearly in source-of-truth documents?**
+
+Slice 45 answers yes. `docs/spec/provider-model.md` now clearly distinguishes reset
+intent ("prepare for fresh use; instance continues") from cleanup intent ("permanent
+removal; instance no longer expected in use"). A scope-confirmation pattern is defined
+for providers that own no mutable state: they may declare and implement reset/cleanup by
+returning scope metadata without side effects, which is the correct behavior for logical-
+identifier handles. `docs/scenarios/provider-model.scenarios.md` adds four scenarios
+covering these distinctions. `docs/guides/provider-authoring-guide.md` adds a practical
+scope-confirmation section with a code example, and a built-in provider reference
+documenting process-scoped readiness (fixed-interval wait after spawn) and the
+process-port-scoped `{PORT}` placeholder substitution.
 
 ## Current priority
 

--- a/docs/development/tasks/dev-slice-45-task-01.md
+++ b/docs/development/tasks/dev-slice-45-task-01.md
@@ -1,0 +1,73 @@
+# Dev Slice 45 — Task 01
+
+## Title
+
+Lifecycle semantics spec alignment — scope-confirmation vs effectful, reset vs cleanup intent
+
+## Sources of truth
+
+- `docs/development/dev-slice-44.md` — Slice 45 definition and scope
+- `docs/development/dev-slice-44-scenario-map.md` — Seam 1 and Seam 4 gap inventory
+- `docs/spec/provider-model.md` — capability definitions to update
+- `docs/scenarios/provider-model.scenarios.md` — scenarios to extend
+- `docs/guides/provider-authoring-guide.md` — guide sections to add
+
+## Motivation
+
+The planning pass (Slice 44) identified that correctly-implemented lifecycle behavior is
+absent from spec and guide docs. Specifically:
+
+1. The distinction between scope-confirmation and effectful reset/cleanup exists in code
+   but is not expressed in `docs/spec/provider-model.md` or the provider authoring guide.
+2. The reset vs cleanup intent distinction ("prepare for fresh use" vs "permanent removal")
+   is not clear in the current spec language ("reinitializes or destroys").
+3. Process-scoped readiness (fixed 500ms interval wait) is implemented but undocumented.
+4. The `{PORT}` placeholder substitution in process-port-scoped is implemented but absent
+   from all source-of-truth docs.
+
+## In scope
+
+- `docs/spec/provider-model.md`
+  - Clarify reset intent: prepare isolated state for fresh use
+  - Clarify cleanup intent: permanent removal; worktree no longer expected in use
+  - Add scope-confirmation semantics: providers with no owned state may return
+    scope-confirmation metadata from reset/cleanup without side effects
+
+- `docs/scenarios/provider-model.scenarios.md`
+  - Add scenario: scope-confirmation is a valid reset implementation for no-state providers
+  - Add scenario: scope-confirmation is a valid cleanup implementation for no-state providers
+  - Add scenario: reset intent — isolated state prepared for fresh use
+  - Add scenario: cleanup intent — isolated state permanently removed
+
+- `docs/guides/provider-authoring-guide.md`
+  - Add "Scope-confirmation lifecycle" section explaining when and how to use it; include
+    a code example; note that name-scoped uses this pattern
+  - Add "Built-in provider behavior reference" section documenting:
+    - process-scoped readiness: fixed-interval wait after spawn (minimal, current contract)
+    - process-port-scoped `{PORT}` placeholder substitution in launch command
+
+- `docs/development/current-state.md`
+  - Add Slice 45 proving result entry
+
+## Out of scope
+
+- Any implementation changes
+- New ADRs
+- Changes to validate capability (Slice 46)
+- Refusal boundary alignment (Slice 47)
+- Worktree identity scenarios (Slice 48)
+- appEnv/derive classification (Slice 49)
+- New provider behaviors or provider packages
+
+## Acceptance criteria
+
+- `docs/spec/provider-model.md` clearly distinguishes reset intent from cleanup intent
+- `docs/spec/provider-model.md` defines scope-confirmation as a valid lifecycle implementation
+  for providers that own no mutable state
+- `docs/scenarios/provider-model.scenarios.md` has scenarios covering both intent and
+  scope-confirmation semantics
+- `docs/guides/provider-authoring-guide.md` has a practical scope-confirmation section
+  with a code example
+- `docs/guides/provider-authoring-guide.md` documents process-scoped readiness and
+  `{PORT}` placeholder behavior
+- No implementation, ADR, or out-of-scope doc changes are introduced

--- a/docs/guides/provider-authoring-guide.md
+++ b/docs/guides/provider-authoring-guide.md
@@ -216,6 +216,41 @@ not support.
 Endpoint providers are derive-only in the current scope. Optional lifecycle
 capabilities for endpoint providers are not supported.
 
+### Scope-confirmation lifecycle
+
+A provider that owns no mutable state of its own may implement `resetResource` and
+`cleanupResource` as scope-confirmation operations. This is correct when the provider's
+derived handle is a logical identifier — a name, prefix, or label — rather than physical
+state that the provider manages directly.
+
+Scope-confirmation means returning the standard result metadata to confirm that the
+correct worktree scope was recognized, without performing any side effects.
+
+```typescript
+async resetResource({ resource, derived, worktree }) {
+  if (!worktree.id) {
+    return { category: "unsafe_scope", reason: "Worktree identity is required." };
+  }
+  // No state to destroy. Return scope-confirmation result.
+  return {
+    resourceName: resource.name,
+    provider: resource.provider,
+    worktreeId: derived.worktreeId,
+    capability: "reset"
+  };
+}
+```
+
+The built-in `name-scoped` provider uses this pattern: it derives a scoped name
+(`resourceName_worktreeId`) but owns no state — the underlying database or namespace
+is managed by the backing system, not by the provider. Declaring `reset: true` and
+`cleanup: true` with scope-confirmation implementations means the provider participates
+correctly in the lifecycle contract without claiming ownership of state it does not hold.
+
+Providers that do own physical state — filesystem paths, process instances — should
+perform the appropriate side effect during `resetResource` and `cleanupResource` rather
+than using scope-confirmation.
+
 ---
 
 ## Refusal behavior
@@ -353,3 +388,44 @@ What is **not** covered here:
   repository. That packaging workflow is not addressed in the current scope.
 - Provider discovery or auto-registration. Provider selection is always explicit
   in repository configuration.
+
+---
+
+## Built-in provider behavior reference
+
+The following documents specific behaviors of first-party providers shipped with
+Multiverse. This section is informational — it describes existing implementations,
+not requirements that apply to all custom providers.
+
+### process-scoped: readiness semantics
+
+The `provider-process-scoped` provider launches an explicit child process on
+`resetResource` and performs a readiness check after spawn. The current implementation
+uses a fixed-interval wait: after the process is spawned, the provider waits a short
+interval and checks that the process is still alive. If the process exits during that
+interval, the provider refuses.
+
+This is the current minimal readiness contract. ADR-0015 defines readiness as explicit
+and provider-defined and lists richer strategies (port reachability, health check) as
+possibilities; those remain deferred.
+
+### process-port-scoped: `{PORT}` placeholder
+
+The `provider-process-port-scoped` provider derives a deterministic port for the worktree
+instance. It substitutes a `{PORT}` placeholder in the user-supplied launch command with
+that derived port value at launch time. This allows the launched process to bind to its
+correct isolated port.
+
+Example provider configuration:
+
+```typescript
+createProcessPortScopedProvider({
+  baseDir: join(tmpdir(), "my-app"),
+  basePort: 6000,
+  command: ["node", "server.js", "--port", "{PORT}"]
+})
+```
+
+When the provider launches the process for a given worktree instance, `{PORT}` is replaced
+with the derived port value for that instance. The same port value is exposed as the
+`host:port` resource handle through `MULTIVERSE_RESOURCE_<NAME>`.

--- a/docs/scenarios/provider-model.scenarios.md
+++ b/docs/scenarios/provider-model.scenarios.md
@@ -70,3 +70,33 @@ Then the provider does not proceed silently with the destructive action
 Given a declared provider
 When the tool evaluates the provider's declared capabilities
 Then the provider does not claim support for a capability it cannot safely perform
+
+## Scenario: reset intent is to prepare isolated state for fresh use
+
+Given a declared provider with reset capability
+When the tool requests reset for a worktree instance
+Then the isolated state for that instance is prepared for fresh use
+And the worktree instance is expected to continue in use after reset
+
+## Scenario: cleanup intent is permanent removal of isolated state
+
+Given a declared provider with cleanup capability
+When the tool requests cleanup for a worktree instance
+Then the isolated state for that instance is permanently removed
+And the worktree instance is not expected to continue in use after cleanup
+
+## Scenario: provider with no owned state may implement reset as scope-confirmation
+
+Given a declared provider with reset capability
+And the provider owns no mutable state of its own
+When the tool requests reset for a worktree instance
+Then the provider may return scope-confirmation metadata without performing side effects
+And the worktree scope boundary is confirmed as correctly recognized
+
+## Scenario: provider with no owned state may implement cleanup as scope-confirmation
+
+Given a declared provider with cleanup capability
+And the provider owns no mutable state of its own
+When the tool requests cleanup for a worktree instance
+Then the provider may return scope-confirmation metadata without performing side effects
+And the worktree scope boundary is confirmed as correctly recognized

--- a/docs/spec/provider-model.md
+++ b/docs/spec/provider-model.md
@@ -84,15 +84,33 @@ Validation behavior is provider-specific and optional.
 
 ### Reset
 
+Reset prepares a worktree instance's isolated state for fresh use.
+
 Reset reinitializes or destroys only the isolated state belonging to one worktree instance.
+The intent of reset is that the worktree instance will continue in use: isolated state is
+cleared so the next run starts fresh, not permanently removed.
 
 Reset is destructive and optional.
 
+A provider that owns no mutable state may implement reset as a scope-confirmation operation:
+returning the standard reset result to confirm that the correct worktree scope was recognized,
+without performing any side effects. This is the correct behavior for a provider whose derived
+handle is a logical identifier rather than physical state the provider manages directly.
+
 ### Cleanup
 
-Cleanup removes tool-generated or provider-managed isolated state belonging only to one worktree instance when that state is no longer needed.
+Cleanup permanently removes tool-generated or provider-managed state belonging only to a
+single worktree instance when that worktree is no longer needed.
+
+The intent of cleanup is finality: the isolated state is removed with the expectation that
+the worktree instance will not continue in use. This distinguishes cleanup from reset —
+reset clears state so the next run can proceed; cleanup removes state because the next
+run is not expected.
 
 Cleanup may be destructive and is optional.
+
+A provider that owns no mutable state may implement cleanup as a scope-confirmation operation
+for the same reason as reset.
 
 ## Safety Rules
 


### PR DESCRIPTION
## Summary

Closes the Seam 1 (lifecycle semantics) and Seam 4 (naming/terminology) gaps identified in the 0.6.x planning pass (Slice 44). Docs-only — no implementation or ADR changes.

## Scope

**`docs/spec/provider-model.md`**
- Reset: intent is "prepare for fresh use; worktree instance continues in use"
- Cleanup: intent is "permanent removal; instance not expected to continue in use"
- Both: defines scope-confirmation as the correct reset/cleanup implementation for providers that own no mutable state (logical-identifier handles such as name-scoped)

**`docs/scenarios/provider-model.scenarios.md`** — four new scenarios:
- Reset intent: isolated state prepared for fresh use
- Cleanup intent: isolated state permanently removed
- No-state provider may implement reset as scope-confirmation
- No-state provider may implement cleanup as scope-confirmation

**`docs/guides/provider-authoring-guide.md`**
- New "Scope-confirmation lifecycle" section: explains the pattern, includes a code example, notes when it is vs is not appropriate; references name-scoped as the built-in example
- New "Built-in provider behavior reference" section: documents process-scoped fixed-interval readiness wait (current minimal contract per ADR-0015) and process-port-scoped `{PORT}` placeholder substitution in launch command (previously undocumented)

**`docs/development/current-state.md`** — Slice 45 proving result entry added

**`docs/development/tasks/dev-slice-45-task-01.md`** — new task doc

## Validation

- `pnpm typecheck` passes

## Deferred

- Validate capability (Slice 46)
- Refusal boundary alignment (Slice 47)
- Worktree identity scenarios (Slice 48)
- appEnv/derive deferred classification (Slice 49)
- Richer process-scoped readiness (ADR-0015; post-1.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)