### PR TITLE
slice-47: document spec/contract naming split and close refusal scenario gaps

### DIFF
--- a/docs/development/current-state.md
+++ b/docs/development/current-state.md
@@ -273,6 +273,25 @@ capabilities section. Four new contract tests in `resource-provider.path-scoped.
 .test.ts` cover: declares validate capability, succeeds when path exists, refuses on
 unsafe scope, refuses when path not accessible.
 
+**Are refusal categories consistent and actionable in CLI output, and is the spec/contract
+naming split documented clearly enough that a second engineer will not mistake it for
+inconsistency?**
+
+Slice 47 answers yes. A full refusal audit across all five commands (derive, validate, run,
+reset, cleanup) found no category conflation: every command emits the correct `category`
+value for every failure path. Three narrow gaps were closed. (1) `docs/spec/safety-and-
+refusal.md` now explicitly documents that the four category names correspond to `category`
+field values in `@multiverse/provider-contracts` `Refusal` type — the spec uses human-
+readable names (spaces) and the contract uses underscore identifiers; both refer to the
+same four categories at different layers. (2) `run` is now listed in "Operations Subject
+to Refusal" (it was technically covered by "but is not limited to" language but was not
+listed explicitly, even though `run` calls `deriveOne` and is refused on unsafe scope).
+(3) A scenario for "unsafe scope causes refusal during run" was added to
+`docs/scenarios/safety-and-refusal.scenarios.md`, consistent with the existing pattern for
+derive, validate, reset, and cleanup. The one observed behavioral asymmetry — `run` routes
+refusal output to stderr while other commands use stdout — is in the spec's explicitly open
+area ("refusal reporting format") and was not changed.
+
 ## Current priority
 
 The current priority is:

--- a/docs/development/tasks/dev-slice-47-task-01.md
+++ b/docs/development/tasks/dev-slice-47-task-01.md
@@ -1,0 +1,81 @@
+# Dev Slice 47 — Task 01
+
+## Title
+
+Refusal boundary alignment — document naming split and close scenario gaps
+
+## Sources of truth
+
+- `docs/development/dev-slice-44.md` — Seam 3 gap inventory
+- `docs/development/dev-slice-44-scenario-map.md` — Seam 3 and Seam 4 gap details
+- `docs/spec/safety-and-refusal.md` — primary spec for refusal rules
+- `docs/scenarios/safety-and-refusal.scenarios.md` — refusal scenario coverage
+- `@multiverse/provider-contracts` — `Refusal` type with `category` field
+
+## Audit findings
+
+A full refusal audit was performed across all five commands (derive, validate, run, reset, cleanup):
+
+**Category correctness**: All correct. No category conflation exists. Each command emits the
+correct `category` value for every failure path. The four categories (`invalid_configuration`,
+`unsupported_capability`, `unsafe_scope`, `provider_failure`) are used consistently throughout
+core and CLI code.
+
+**Message actionability**: Messages are generally actionable. The generic
+`"Repository configuration is invalid."` from the repository validation pass is less specific
+but lives in the spec's explicitly open area (messaging conventions are deferred).
+
+**CLI output channel**: The `run` command routes refusal output to stderr while derive,
+validate, reset, and cleanup put refusal JSON on stdout. This difference exists because `run`
+wraps a child process (stdout is taken by the child). This is in the spec's explicitly open
+area ("refusal reporting format") and is NOT changed here.
+
+**Real gaps identified:**
+
+1. **Spec/contract naming split undocumented**: `docs/spec/safety-and-refusal.md` uses
+   human-readable names ("invalid configuration", spaces, lowercase). The `Refusal` type in
+   `@multiverse/provider-contracts` uses machine-readable identifiers (`"invalid_configuration"`,
+   underscores). Both forms are intentional but the split is unexplained, creating an apparent
+   inconsistency for a reader.
+
+2. **`run` missing from Operations Subject to Refusal list**: The spec lists derive, validate,
+   reset, cleanup with "but is not limited to" language. `run` is a fifth command that can
+   refuse (because it internally calls derive and requires worktree ownership). Adding `run`
+   makes the spec explicitly match observable behavior.
+
+3. **No scenario for unsafe scope during run**: Scenarios exist for unsafe scope × derive,
+   validate, reset, and cleanup. No scenario exists for unsafe scope × run.
+
+## In scope
+
+- `docs/spec/safety-and-refusal.md`
+  - Add a paragraph under Failure Categories documenting that the four category names
+    correspond to `category` field values in the `Refusal` type (underscore form)
+  - Add `run` to the "Operations Subject to Refusal" list
+
+- `docs/scenarios/safety-and-refusal.scenarios.md`
+  - Add one scenario: "unsafe scope causes refusal during run"
+
+- `docs/development/tasks/dev-slice-47-task-01.md` (this file)
+
+- `docs/development/current-state.md`
+  - Add Slice 47 proving result entry
+
+## Out of scope
+
+- New refusal categories
+- Changes to CLI output format or channel (stdout vs stderr for run is deferred)
+- Improvements to generic error message text ("Repository configuration is invalid.")
+- CLI refusal message wording changes of any kind
+- Any implementation changes
+- Slice 48 or 49 work
+
+## Acceptance criteria
+
+- `docs/spec/safety-and-refusal.md` explicitly states that the four category names
+  correspond to `category` field values in `@multiverse/provider-contracts` `Refusal` type
+  (underscore form), and that spec uses human-readable form and contract uses code form
+- `docs/spec/safety-and-refusal.md` lists `run` in Operations Subject to Refusal
+- `docs/scenarios/safety-and-refusal.scenarios.md` has a scenario for unsafe scope during run
+- `pnpm test:contracts` and `pnpm test:acceptance` remain green (no code changes)
+- No CLI behavior or output changes introduced

--- a/docs/scenarios/safety-and-refusal.scenarios.md
+++ b/docs/scenarios/safety-and-refusal.scenarios.md
@@ -31,6 +31,13 @@ When the tool requests validation
 And safe worktree-instance ownership cannot be determined
 Then the operation is refused
 
+## Scenario: unsafe scope causes refusal during run
+
+Given a declared repository
+When the tool requests run
+And safe worktree-instance ownership cannot be determined
+Then the operation is refused
+
 ## Scenario: unsafe scope causes refusal during reset
 
 Given a declared repository object

--- a/docs/spec/safety-and-refusal.md
+++ b/docs/spec/safety-and-refusal.md
@@ -31,6 +31,20 @@ In 1.0, the tool distinguishes between the following business failure categories
 
 These categories are distinct and must not be treated as interchangeable.
 
+### Category names: spec form and contract form
+
+This document uses human-readable names (spaces, lowercase): "invalid configuration",
+"unsupported capability", "unsafe scope", "provider failure".
+
+The `Refusal` type in `@multiverse/provider-contracts` uses machine-readable identifiers
+(underscores): `"invalid_configuration"`, `"unsupported_capability"`, `"unsafe_scope"`,
+`"provider_failure"`.
+
+Both forms refer to the same four categories. The spec uses human-readable names because
+it is a business rules document. The contract type uses underscore identifiers because it
+is a code-level API. A reader seeing both forms in different documents is not seeing an
+inconsistency — they are seeing the same categories expressed at different layers.
+
 ### Invalid Configuration
 
 Invalid configuration occurs when repository declarations violate required business rules.
@@ -66,6 +80,7 @@ This includes, but is not limited to:
 
 - derive
 - validate
+- run
 - reset
 - cleanup
 

--- a/docs/spec/safety-and-refusal.md
+++ b/docs/spec/safety-and-refusal.md
@@ -157,4 +157,4 @@ The following remain to be specified elsewhere:
 - refusal reporting format
 - error surface design
 - user-facing messaging conventions
-- implementation-specific exception or return modelsF
+- implementation-specific exception or return models


### PR DESCRIPTION
## Summary

Refusal boundary alignment for Slice 47. A full audit across all five commands (derive, validate, run, reset, cleanup) found no category conflation — every command emits the correct `category` value for every failure path. Three narrow gaps closed:

1. **Spec/contract naming split documented** — `docs/spec/safety-and-refusal.md` now has a "Category names: spec form and contract form" subsection explaining that the four human-readable names (spaces) in the spec correspond to the underscore identifiers in the `Refusal` type in `@multiverse/provider-contracts`. A reader seeing both forms in different documents is not seeing an inconsistency — they are the same categories at different layers.

2. **`run` added to Operations Subject to Refusal** — `run` was technically covered by "but is not limited to" language but was not listed explicitly. `run` calls `deriveOne` internally and can refuse on unsafe scope (no worktree identity) or invalid configuration (appEnv extraction or conflict). Now listed.

3. **Unsafe scope × run scenario added** — `docs/scenarios/safety-and-refusal.scenarios.md` now has a scenario for "unsafe scope causes refusal during run", consistent with the existing pattern for derive, validate, reset, and cleanup.

## Scope

Docs-only. No CLI behavior changes. No new refusal categories. No output format changes.

The `run` command's asymmetry (refusal output on stderr vs stdout for other commands) is in the spec's explicitly open area ("refusal reporting format") and was not changed.

## Validation

- `pnpm test:contracts`: 81 tests pass (unchanged)
- `pnpm test:acceptance`: 199 tests pass (unchanged)

## Deferred

- Improving the generic `"Repository configuration is invalid."` message — lives in the spec's open area ("user-facing messaging conventions")
- Specifying the stdout vs stderr refusal reporting convention for `run` vs other commands — deferred per spec open area
- Slice 48 (worktree identity scenario alignment) and Slice 49 (appEnv/derive classification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)