### PR TITLE
slice-48: align worktree identity scenarios with ADR-0021 auto-discovery behavior

### DIFF
--- a/docs/development/current-state.md
+++ b/docs/development/current-state.md
@@ -292,6 +292,22 @@ derive, validate, reset, and cleanup. The one observed behavioral asymmetry — 
 refusal output to stderr while other commands use stdout — is in the spec's explicitly open
 area ("refusal reporting format") and was not changed.
 
+**Are the worktree identity scenarios consistent with ADR-0021 auto-discovery behavior and
+the current intended truthful scope?**
+
+Slice 48 answers yes, after corrections. The scenarios file had one false general statement
+and three missing scenarios. (1) The "main checkout identity" scenario previously stated the
+Worktree ID is `main` unconditionally — true only when `--worktree-id main` is supplied
+explicitly (ADR-0003); not true under auto-discovery, where the id is the directory basename
+and may differ from `"main"` (ADR-0021). The scenario is now annotated as the explicit
+override case. (2) Three new scenarios were added: auto-discovery success (id = directory
+basename of the matching worktree path), primary checkout identity under auto-discovery (not
+guaranteed to be `"main"`), and auto-discovery refusal (git unavailable or no matching
+worktree path → refuse with actionable message directing caller to supply `--worktree-id`
+explicitly). (3) The "recreated worktree" scenario is now annotated as aspirational /
+deferred — ADR-0021 explicitly calls it out as requiring a persistent registry that does
+not yet exist.
+
 ## Current priority
 
 The current priority is:

--- a/docs/development/tasks/dev-slice-48-task-01.md
+++ b/docs/development/tasks/dev-slice-48-task-01.md
@@ -1,0 +1,94 @@
+# Dev Slice 48 — Task 01
+
+## Title
+
+Worktree identity scenario alignment — distinguish explicit override from auto-discovery
+
+## Sources of truth
+
+- `docs/development/dev-slice-44.md` — Seam 6 gap inventory
+- `docs/development/dev-slice-44-scenario-map.md` — Seam 6 gap details
+- `docs/scenarios/worktree-identity.scenarios.md` — current scenario coverage (primary target)
+- `docs/adr/0021-git-worktree-path-conventional-default-for-worktree-id.md` — auto-discovery algorithm and relationship to ADR-0003
+- `docs/adr/0003-main-checkout-uses-reserved-main-identity.md` — reserved `main` identity rule
+- `docs/adr/0002-branch-name-is-metadata.md` — branch name is not identity
+
+## Audit findings
+
+**"main checkout identity" scenario is false as a general statement.**
+
+The scenario currently reads:
+```
+Given the main checkout
+When the tool derives worktree identity
+Then the Worktree ID is `main`
+```
+
+ADR-0021 (Section 1, "Relationship to ADR-0003") states:
+> ADR-0003 establishes `"main"` as the reserved worktree identity for the primary checkout
+> when supplied *explicitly* (via `--worktree-id main`). Auto-discovery does not enforce
+> that reserved value: the primary checkout's discovered id is its directory basename,
+> which may or may not be `"main"` depending on how the repository is checked out.
+
+The scenario is only true in the explicit override case. Under auto-discovery, the identity
+is `path.basename(primaryCheckout.path)` — which could be anything the user named their
+clone directory. The scenario needs to be split into:
+- Explicit case: `--worktree-id main` supplied → Worktree ID is `main` (ADR-0003, explicit)
+- Discovery case: `--worktree-id` omitted → discovered id is directory basename (ADR-0021)
+
+**Three missing scenarios.**
+
+1. Auto-discovery success: when `--worktree-id` is omitted and cwd is inside a known git
+   worktree, the discovered identity is the worktree directory basename (ADR-0021 Section 1).
+
+2. Primary checkout identity under auto-discovery: discovered id is the directory basename of
+   the primary checkout path, not guaranteed to be `"main"` (ADR-0021 relationship to ADR-0003).
+
+3. Auto-discovery refusal: when `--worktree-id` is omitted and git is unavailable, or no
+   worktree path matches cwd, the tool refuses with an actionable message directing the
+   caller to supply `--worktree-id` explicitly (ADR-0021 Section 3).
+
+**"recreated worktree" scenario is aspirational and needs annotation.**
+
+ADR-0021 explicitly calls out:
+> The "recreated worktree gets new lifecycle identity" scenario from
+> `worktree-identity.scenarios.md` is not addressed here — it requires a persistent
+> registry and is explicitly deferred.
+
+The scenario as written implies this is current behavior. It should be annotated as
+aspirational (requires a persistent registry) and deferred.
+
+## In scope
+
+- `docs/scenarios/worktree-identity.scenarios.md`
+  - Revise "main checkout identity" to specify it applies when `--worktree-id main` is
+    supplied explicitly (not under auto-discovery)
+  - Add scenario: auto-discovery resolves identity from git worktree path basename
+  - Add scenario: primary checkout identity under auto-discovery is directory basename,
+    not guaranteed to be `"main"`
+  - Add scenario: auto-discovery refuses when git unavailable or no matching worktree path
+  - Annotate "recreated worktree" scenario as aspirational / deferred
+
+- `docs/development/tasks/dev-slice-48-task-01.md` (this file)
+
+- `docs/development/current-state.md`
+  - Add Slice 48 proving result entry
+
+## Out of scope
+
+- Implementation changes of any kind
+- Changes to ADR-0003 or ADR-0021
+- Consumer integration / appEnv classification (Slice 49)
+- General CLI docs polish
+- New worktree identity semantics beyond what ADR-0021 already establishes
+
+## Acceptance criteria
+
+- "main checkout identity" scenario is true only in the explicit `--worktree-id main` case
+- A scenario exists for auto-discovery success (id = directory basename)
+- A scenario exists for the primary checkout identity under auto-discovery (not guaranteed
+  to be `"main"`)
+- A scenario exists for auto-discovery refusal (git unavailable or no matching path)
+- "recreated worktree" scenario is annotated as aspirational / deferred
+- No implementation changes introduced
+- `pnpm test:contracts` and `pnpm test:acceptance` remain green (docs-only slice)

--- a/docs/scenarios/worktree-identity.scenarios.md
+++ b/docs/scenarios/worktree-identity.scenarios.md
@@ -1,11 +1,36 @@
 # Worktree Identity Scenarios
 
-## Scenario: main checkout identity
+## Scenario: main checkout identity when --worktree-id is supplied explicitly
 
 Given the main checkout
+And --worktree-id main is supplied
 When the tool derives worktree identity
 Then the Worktree ID is `main`
 And the Worktree Label is `main`
+
+## Scenario: auto-discovery resolves worktree identity from git worktree path basename
+
+Given a git repository
+And the tool is invoked from within a known git worktree directory
+And --worktree-id is not supplied
+When the tool discovers worktree identity
+Then the discovered Worktree ID is the basename of the matching worktree's filesystem path
+
+## Scenario: primary checkout identity under auto-discovery is the directory basename
+
+Given the primary checkout
+And --worktree-id is not supplied
+When the tool discovers worktree identity
+Then the discovered Worktree ID is the basename of the primary checkout's filesystem path
+And that identity may or may not be "main" depending on how the repository was cloned
+
+## Scenario: auto-discovery refuses when worktree identity cannot be determined
+
+Given --worktree-id is not supplied
+When the tool attempts to discover worktree identity
+And git is unavailable or no worktree path matches the current working directory
+Then the operation is refused
+And the refusal message directs the caller to pass --worktree-id explicitly
 
 ## Scenario: linked worktree receives unique identity
 
@@ -21,6 +46,10 @@ When the tool derives worktree identity for each
 Then each worktree receives a different Worktree ID
 
 ## Scenario: recreated worktree gets new lifecycle identity
+
+NOTE: This scenario is aspirational. It requires a persistent worktree identity registry
+and is explicitly deferred. ADR-0021 confirms this is not addressed by the current
+auto-discovery algorithm and will require a future registry-based approach.
 
 Given a linked worktree that previously existed and was removed
 And a new linked worktree is later created from the same branch


### PR DESCRIPTION
## Summary

Worktree identity scenario alignment (Slice 48). Docs-only. Corrects one false general statement and adds three missing scenarios in `docs/scenarios/worktree-identity.scenarios.md`.

**What was wrong:**
- "main checkout identity" scenario stated Worktree ID is `main` unconditionally. This is only true when `--worktree-id main` is supplied explicitly (ADR-0003). Under auto-discovery, the id is `path.basename(primaryCheckout.path)` and may differ from `"main"` (ADR-0021).
- "recreated worktree" scenario read as current behavior; ADR-0021 explicitly calls it aspirational/deferred (requires a persistent registry).
- No scenarios existed for auto-discovery success, primary checkout identity under discovery, or auto-discovery refusal.

**What changed:**

1. **Revised "main checkout identity" scenario** — now specifies it applies when `--worktree-id main` is supplied explicitly, making ADR-0003 explicit-override scope unambiguous.

2. **Added: auto-discovery success scenario** — when `--worktree-id` is omitted and cwd is inside a known git worktree, the discovered identity is the worktree directory basename (ADR-0021 Section 1).

3. **Added: primary checkout identity under auto-discovery** — discovered id is the directory basename of the primary checkout path, not guaranteed to be `"main"` (ADR-0021, relationship to ADR-0003).

4. **Added: auto-discovery refusal scenario** — when `--worktree-id` is omitted and git is unavailable or no matching worktree path exists, the tool refuses with an actionable message directing the caller to supply `--worktree-id` explicitly (ADR-0021 Section 3).

5. **Annotated "recreated worktree" scenario** — marked as aspirational/deferred with reference to ADR-0021.

## Scope

Docs-only. No implementation changes. No ADR changes.

## Validation

- `pnpm test:contracts`: 81 tests pass (unchanged)
- `pnpm test:acceptance`: 199 tests pass (unchanged)

## Deferred

- Slice 49: appEnv/derive deferred classification (consumer integration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)