### PR TITLE
slice-49: explicitly classify appEnv exclusion from derive --format=env as deferred

### DIFF
--- a/docs/adr/0018-explicit-app-native-env-mapping-for-run.md
+++ b/docs/adr/0018-explicit-app-native-env-mapping-for-run.md
@@ -46,7 +46,11 @@ Included:
 
 Excluded:
 
-- `derive --format=env`
+- `derive --format=env` — appEnv injection is scoped to `multiverse run` (run-time process
+  launch) only. `derive --format=env` is a derivation inspection tool that outputs canonical
+  `MULTIVERSE_*` variables; it does not include app-native aliases. This exclusion is
+  intentional and is not an oversight. Adding appEnv aliases to `derive --format=env` is
+  deferred; no follow-on ADR has been accepted for this.
 - provider contract changes
 - provider implementation changes
 - config-file overlays or mutation

--- a/docs/development/current-state.md
+++ b/docs/development/current-state.md
@@ -308,6 +308,21 @@ explicitly). (3) The "recreated worktree" scenario is now annotated as aspiratio
 deferred — ADR-0021 explicitly calls it out as requiring a persistent registry that does
 not yet exist.
 
+**Is the exclusion of appEnv from `derive --format=env` explicitly classified as an
+intentional deferred boundary rather than an accidental omission?**
+
+Slice 49 answers yes, after two narrow corrections. ADR-0018 and ADR-0019 both listed
+`derive --format=env` in their Excluded sections but gave no rationale, leaving a reader
+to wonder whether the exclusion was intentional or an oversight. ADR-0018 now includes an
+explicit note: appEnv is scoped to `multiverse run` (run-time process launch) only;
+`derive --format=env` is a derivation inspection tool for canonical `MULTIVERSE_*` vars;
+adding appEnv aliases to derive output is deferred with no accepted follow-on ADR. The
+second correction was in `docs/guides/external-demo-guide.md` Step 6, which stated "The
+`--format env` output uses the same variable names that `pnpm cli run` injects" — now
+misleading since `run` also injects appEnv aliases not present in derive output. The
+sentence is corrected to accurately describe what each command outputs and where the
+boundary lies.
+
 ## Current priority
 
 The current priority is:

--- a/docs/development/tasks/dev-slice-49-task-01.md
+++ b/docs/development/tasks/dev-slice-49-task-01.md
@@ -1,0 +1,75 @@
+# Dev Slice 49 — Task 01
+
+## Title
+
+Consumer integration alignment — explicit deferred classification for appEnv exclusion from `derive --format=env`
+
+## Sources of truth
+
+- `docs/development/dev-slice-44.md` — Seam 5 gap inventory
+- `docs/development/dev-slice-44-scenario-map.md` — Seam 5 gap details
+- `docs/adr/0018-explicit-app-native-env-mapping-for-run.md` — primary appEnv ADR
+- `docs/adr/0019-explicit-typed-endpoint-mapping.md` — typed endpoint appEnv ADR
+- `docs/guides/external-demo-guide.md` — consumer-facing usage guide
+
+## Audit findings
+
+**`derive --format=env` exclusion exists but is not classified.**
+
+Both ADR-0018 and ADR-0019 list `derive --format=env` in their Excluded sections. The
+exclusion is present, but neither ADR explains the rationale or classifies it as deferred
+vs permanent design. A second engineer reading the Excluded list might reasonably ask:
+"Was this intentionally left out, or is it an accidental omission?" — there is currently
+no answer in any source-of-truth doc.
+
+The design rationale: `appEnv` is a run-time process-launch concern — it produces
+app-native variable names for the child process environment at `run` time. `derive
+--format=env` is an inspection tool that outputs canonical `MULTIVERSE_*` variables for
+scripting and verification. Adding appEnv aliases to `derive --format=env` is technically
+possible and may make sense in the future, but the current slice explicitly scoped appEnv
+to `run` only. This exclusion was intentional, not an oversight.
+
+**`external-demo-guide.md` Step 6 is misleading.**
+
+The guide states: "The `--format env` output uses the same variable names that `pnpm cli
+run` injects."
+
+This was accurate when written (before ADR-0018 introduced appEnv aliases). After ADR-0018
+and ADR-0019, `pnpm cli run` also injects declared `appEnv` aliases (e.g. `DATABASE_PATH`,
+`PORT`) which are NOT present in `derive --format=env` output. The sentence creates a false
+impression of equivalence.
+
+## In scope
+
+- `docs/adr/0018-explicit-app-native-env-mapping-for-run.md`
+  - Add a brief note in the Excluded section explaining that `derive --format=env` is
+    excluded intentionally: appEnv is scoped to `run` (run-time process launch), not to
+    derivation inspection. Adding appEnv aliases to `derive --format=env` is deferred; no
+    follow-on ADR has been accepted for this.
+
+- `docs/guides/external-demo-guide.md`
+  - Fix the Step 6 sentence to accurately describe what `--format env` outputs (canonical
+    `MULTIVERSE_*` vars only) and note that `appEnv` aliases are injected by `run` but
+    not included in `derive --format=env` output.
+
+- `docs/development/tasks/dev-slice-49-task-01.md` (this file)
+
+- `docs/development/current-state.md`
+  - Add Slice 49 proving result entry
+
+## Out of scope
+
+- Changing `derive --format=env` behavior to include appEnv aliases
+- Changes to ADR-0019 (follows ADR-0018 on this exclusion)
+- New scenarios (Seam 5 is otherwise well-covered by ADR-0018/0019)
+- Consumer workflow redesign of any kind
+- Slice 48 work (already merged)
+
+## Acceptance criteria
+
+- ADR-0018 Excluded section explicitly states that the `derive --format=env` exclusion is
+  intentional and that appEnv-in-derive is deferred
+- `external-demo-guide.md` Step 6 accurately distinguishes what `derive --format=env`
+  outputs (canonical vars only) from what `pnpm cli run` injects (canonical vars + appEnv)
+- No implementation changes introduced
+- `pnpm test:contracts` and `pnpm test:acceptance` remain green (docs-only slice)

--- a/docs/guides/external-demo-guide.md
+++ b/docs/guides/external-demo-guide.md
@@ -315,7 +315,10 @@ pnpm cli derive --worktree-id feature-login --format env
 
 Both `--format env` (space form) and `--format=env` (equals form) are accepted.
 
-The `--format env` output uses the same variable names that `pnpm cli run` injects.
+The `--format env` output includes the canonical `MULTIVERSE_RESOURCE_*` and
+`MULTIVERSE_ENDPOINT_*` variables. It does not include `appEnv` aliases — those are
+injected only by `pnpm cli run` at process-launch time. Use `derive --format=env` for
+inspection and scripting against canonical variable names.
 
 ---
 


### PR DESCRIPTION
## Summary

Consumer integration alignment (Slice 49). Docs-only. Closes the Seam 5 gap identified in dev-slice-44: the `derive --format=env` exclusion for `appEnv` was present in both ADR-0018 and ADR-0019 but never explained, leaving a second engineer unable to distinguish intentional design from accidental omission.

**Two narrow corrections:**

1. **ADR-0018 Excluded section** — Added a rationale note for the `derive --format=env` exclusion: appEnv is scoped to `multiverse run` (run-time process launch) only; `derive --format=env` outputs canonical `MULTIVERSE_*` vars for inspection; adding appEnv aliases to derive output is deferred with no accepted follow-on ADR. This is intentional, not an oversight.

2. **`docs/guides/external-demo-guide.md` Step 6** — The sentence "The `--format env` output uses the same variable names that `pnpm cli run` injects" was accurate before ADR-0018 but became misleading once `run` started injecting `appEnv` aliases not present in derive output. Corrected to accurately describe what each command outputs and where the boundary lies.

## Scope

Docs-only. No implementation changes. No ADR-0019 changes (follows ADR-0018 on this exclusion). No scenario changes (Seam 5 is otherwise well-covered by ADR-0018/0019).

## Validation

- `pnpm test:contracts`: 81 tests pass (unchanged)
- `pnpm test:acceptance`: 199 tests pass (unchanged)

## Deferred

- appEnv injection in `derive --format=env` — explicitly deferred per ADR-0018 note added in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)