### PR TITLE
docs: close out 0.6.x and bump posture to 0.7.0-alpha.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Today’s repo includes:
 
 ## Current behavior being proven
 
-The current implementation proves the core loop for explicit declarations and deterministic derivation, the composed application consumer workflow, and a complete provider extensibility story. The `0.5.x` early outside-usability phase is complete: the documented second-engineer workflow is proven end-to-end, including real two-worktree auto-discovery/isolation and no-manual-`NODE_OPTIONS` TypeScript provider loading in workspace scope on compiled/global binary paths. `0.6.0-alpha.1` begins the semantic stability phase.
+The current implementation proves the core loop for explicit declarations and deterministic derivation, the composed application consumer workflow, and a complete provider extensibility story. The `0.6.x` semantic stability wave (Slices 44–49) is now complete: lifecycle semantics, refusal behavior and category naming, worktree identity scenario accuracy, and consumer integration boundaries are all aligned across spec, ADR, scenarios, and guide docs. `0.7.0-alpha.1` enters the public surface stability phase: CLI invocation patterns, help text, output format conventions, and guide consistency.
 
 1.0 remains intentionally narrow; outside-workspace packaging and distribution remain deferred.
 

--- a/docs/development/current-state.md
+++ b/docs/development/current-state.md
@@ -15,7 +15,7 @@ This is a short state-of-the-project document, not a full history.
 
 ## Current version posture
 
-Current version posture: **0.6.0-alpha.1**
+Current version posture: **0.7.0-alpha.1**
 
 Interpretation:
 
@@ -25,7 +25,8 @@ Interpretation:
 * the provider model is extensible: a second endpoint shape, a non-first-party authoring path, a parameterized compliance suite, and CLI-level invocation proof are all on `main`
 * all four 0.4.x roadmap exit criteria are met; the extensibility wave is complete
 * all 0.5.x exit criteria are met: the documented second-engineer workflow is proven end-to-end, including real two-worktree auto-discovery/isolation and no-manual-`NODE_OPTIONS` TypeScript provider loading in workspace scope; outside-workspace packaging and distribution remain explicitly deferred
-* `0.6.0-alpha.1` begins the semantic stability phase: the next honest proving question is whether lifecycle semantics, refusal behavior, and naming are consistent and trustworthy across providers, docs, and CLI output
+* all 0.6.x exit criteria are met: lifecycle semantics, refusal behavior, naming, worktree identity accuracy, and consumer integration boundaries are now aligned across spec, ADR, scenarios, and guide docs; the planned six-seam semantic stability wave (Slices 44–49) is complete
+* `0.7.0-alpha.1` enters the public surface stability phase: the next honest proving question is whether the CLI surface — invocation patterns, help output, output format conventions, and guide examples — is stable and intentional enough that users would not be forced to relearn it between minor versions
 * 1.0 expectations remain intentionally narrow
 
 ## What is already proven
@@ -327,17 +328,17 @@ boundary lies.
 
 The current priority is:
 
-**`0.6.x` semantic stability — lifecycle semantics, refusal behavior, and naming consistency across providers, docs, and CLI output. The `0.5.x` early outside-usability phase is complete. Outside-workspace packaging and distribution remain explicitly deferred.**
+**`0.7.x` public surface stability — CLI invocation patterns, help text, output format conventions, and guide consistency. The `0.6.x` semantic stability wave is complete. Outside-workspace packaging and distribution remain explicitly deferred.**
 
 ## What kinds of work are highest-value right now
 
-Examples of work that are strongly aligned with the current `0.6.x` phase:
+Examples of work that are strongly aligned with the current `0.7.x` phase:
 
-* tightening lifecycle definitions across provider types (reset, cleanup, validate semantics)
-* clarifying and testing refusal outcomes across all commands and providers
-* naming consistency across docs, code, and CLI output
-* making reset and cleanup behavior predictable for composed multi-provider applications
-* spec or ADR groundwork before any implementation work in this area
+* auditing and improving CLI help output (the current `--help` surface is a raw usage string, not a structured help system)
+* examining whether `validate-worktree` and `validate-repository` utility commands belong on the same surface as `derive`, `run`, `reset`, `cleanup`, `validate`
+* specifying expected output shape for each command in source-of-truth docs (no output-format spec exists for `derive`, `validate`, `reset`, `cleanup` result shapes)
+* aligning guide examples with actual invocation surface
+* reducing inconsistencies between repo-local (`pnpm cli`) and formal binary (`multiverse`) invocation paths in docs and guides
 
 ## What is intentionally deferred
 

--- a/docs/development/current-state.md
+++ b/docs/development/current-state.md
@@ -355,15 +355,16 @@ The following remain explicitly deferred:
 
 When deciding what to work on next, prefer work that answers the current proving question:
 
-**Are Multiverse lifecycle semantics, refusal behavior, and naming consistent and
-trustworthy across providers, docs, and CLI output?**
+**Is the public CLI surface — command names, flags, invocation patterns, help text, and
+output format conventions — stable and intentional enough that a user would not be forced
+to relearn it between minor versions?**
 
 Use this preference order:
 
-1. identify lifecycle or refusal behavior that is ambiguous or inconsistent across provider types
-2. establish clear definitions through spec or ADR work before writing implementation code
-3. validate that docs, code, and CLI output use consistent terminology
-4. only then broader surface polish or new capabilities
+1. audit the CLI surface before changing it — identify specific inconsistencies across help text, output shape, flag naming, and guide examples
+2. establish expected output shapes and invocation conventions in source-of-truth docs before modifying code
+3. assess whether utility commands (`validate-worktree`, `validate-repository`) belong on the same public surface as the primary commands
+4. only then implementation changes that align code with the stabilized surface spec
 
 ## Related documents
 

--- a/docs/development/roadmap.md
+++ b/docs/development/roadmap.md
@@ -26,7 +26,7 @@ Multiverse development continues under the same core assumptions:
 
 ## Current version posture
 
-Current version posture: **0.6.0-alpha.1**
+Current version posture: **0.7.0-alpha.1**
 
 What that means:
 
@@ -41,7 +41,8 @@ What that means:
 * the globally-linked binary path is proven within the workspace (Slice 41)
 * manual `NODE_OPTIONS` is no longer required for TypeScript providers on the compiled/global binary path in workspace scope (Slice 43)
 * all `0.5.x` exit criteria are met; the early outside-usability phase is complete in substance
-* `0.6.0-alpha.1` enters the semantic stability phase: lifecycle semantics, refusal behavior, and naming consistency are the next proving target
+* all `0.6.x` exit criteria are met; the semantic stability wave (Slices 44–49) is complete: lifecycle semantics, refusal behavior and category naming, worktree identity scenario accuracy, and consumer integration boundary classification are all aligned across spec, ADR, scenarios, and guide docs
+* `0.7.0-alpha.1` enters the public surface stability phase: CLI invocation patterns, help output, output format conventions, and guide consistency are the next proving target
 * outside-workspace packaging/distribution remains explicitly deferred
 
 ## Version roadmap
@@ -482,15 +483,19 @@ It should mean that the product is trustworthy in its intended scope.
 
 The current near-term direction is:
 
-* begin `0.6.x` semantic stability work through spec and ADR groundwork before any implementation
-* audit lifecycle semantics (reset, cleanup, validate) for consistency across provider types
-* clarify refusal behavior and ensure error/refusal messages are actionable and consistent
-* identify naming inconsistencies across docs, code, and CLI output
+* audit the CLI surface — help text, output format conventions, flag naming, and invocation patterns — for stability and intentionality
+* identify inconsistencies between repo-local and formal binary invocation paths in docs and guides
+* specify expected output shapes for each command in source-of-truth docs
+* assess whether the current `validate-worktree` and `validate-repository` utility commands belong on the same CLI surface as the primary `derive`, `validate`, `run`, `reset`, `cleanup` commands
 
-The `0.5.x` work is complete. The documented second-engineer workflow is proven and
-truth-aligned. The next honest proving question is whether lifecycle semantics, refusal
-behavior, and naming are consistent and trustworthy — not adding new product behaviors
-or broadening scope.
+The `0.6.x` semantic stability wave is complete. The six planned seams (lifecycle semantics,
+validate capability, refusal boundaries, naming/terminology, consumer integration boundaries,
+worktree identity alignment) are all addressed in source-of-truth documents. The next honest
+proving question is whether the public CLI surface is stable and intentional enough that
+users would not be forced to relearn it between minor versions.
+
+Each 0.7.x slice should begin with a targeted audit and task doc before any implementation.
+Broad CLI redesign without spec groundwork is not the right direction for this phase.
 
 Provider-ecosystem formalization and external distribution remain deferred.
 

--- a/docs/development/tasks/post-wave-44-49-assessment.md
+++ b/docs/development/tasks/post-wave-44-49-assessment.md
@@ -1,0 +1,80 @@
+# Post-Wave Assessment: 0.6.x Semantic Stability Complete
+
+## Purpose
+
+This document records the post-wave assessment performed after completing the planned
+`0.6.x` semantic-stability wave (Slices 44–49). Its purpose is to determine the honest
+next project posture and identify the highest-signal proving question for the next wave.
+
+## Wave summary
+
+Slices 44–49 addressed all six semantic seams identified in the planning pass:
+
+| Slice | Seam(s) | Outcome |
+|---|---|---|
+| 44 | All six | Planning baseline; six-seam audit; proposed slice sequence |
+| 45 | Seam 1, Seam 4 | Reset/cleanup intent and scope-confirmation vs effectful distinction added to spec, scenarios, guide |
+| 46 | Seam 2 | path-scoped `validateResource` implemented; `scopedValidate` added to spec; scenarios added |
+| 47 | Seam 3, Seam 4 | Refusal audit across all five commands — no conflation found; spec/contract naming split documented; `run` added to Operations Subject to Refusal; scenario added |
+| 48 | Seam 6 | Worktree identity scenarios aligned with ADR-0021; auto-discovery scenarios added; "recreated worktree" annotated as deferred |
+| 49 | Seam 5 | appEnv exclusion from `derive --format=env` explicitly classified as deferred in ADR-0018; external-demo-guide Step 6 corrected |
+
+## 0.6.x exit criteria assessment
+
+From `roadmap.md`:
+
+| Exit criterion | Evidence | Met? |
+|---|---|---|
+| Lifecycle semantics feel consistent and trustworthy | Slice 45 aligned spec + scenarios for reset/cleanup intent and scope-confirmation semantics | ✓ |
+| Refusal behavior understandable and predictable | Slice 47 audited all five commands; no conflation; spec/contract naming split documented | ✓ |
+| Major core terms stable across docs, code, and CLI output | "scope-confirmation," "effectful," refusal category names all now documented consistently | ✓ |
+| Users can infer what Multiverse will do without guesswork | Worktree identity scenarios corrected and complete; appEnv boundary classified | ✓ |
+| Consumer configuration model feels dependable | appEnv exclusion from derive classified as intentional and deferred; external-demo-guide corrected | ✓ |
+
+All five criteria are met in substance.
+
+## Remaining open items (not blockers)
+
+The following items are explicitly deferred and do not constitute uncompleted 0.6.x work:
+
+- **Refusal reporting format** (stdout vs stderr for `run`): in the spec's Open Areas; not
+  addressed without a spec decision
+- **User-facing messaging conventions**: in the spec's Open Areas
+- **appEnv in `derive --format=env`**: explicitly deferred in ADR-0018; no accepted follow-on ADR
+- **Validate for name-scoped, process-scoped, process-port-scoped**: not declared; validate
+  is provider-specific; no spec requirement for additional providers in the current scope
+- **Outside-workspace packaging/distribution**: always deferred; not part of 0.6.x
+
+## Recommendation: Outcome B
+
+Close out `0.6.x` and move to `0.7.0-alpha.1`.
+
+The planned 0.6.x wave is complete in substance. Remaining open items are correctly
+classified as deferred. There is no genuine 0.6.x semantic-stability gap that is both
+unaddressed and a blocker.
+
+## Next proving question: 0.7.x public surface stability
+
+From `roadmap.md`, the 0.7.x line is for stabilizing the public-facing product surface:
+command names, flags, invocation patterns, CLI help text, output conventions,
+installation/build/link expectations, and example consistency.
+
+The highest-signal proving question for 0.7.x is:
+
+**Does the CLI surface — flag naming, invocation patterns, help output, and output
+format conventions — feel intentional and stable enough that a user would not be
+forced to relearn it between minor versions?**
+
+Known signals that this question is live:
+- The CLI `--help` output is a single long usage string, not a structured help system
+- `validate-worktree` and `validate-repository` are internal utility commands exposed on
+  the same surface as `derive`, `run`, `reset`, `cleanup`, `validate` — it is not
+  obvious how they relate to each other
+- Output format is raw JSON with no per-command output specification documented in specs
+- `derive --format=env` and `derive` (JSON) are documented in the guide but not in any
+  spec or scenario that defines expected output shape
+- The repo-local (`pnpm cli`) and formal binary (`multiverse`) invocation paths both work
+  but their relationship is documented only in the guide, not in any spec
+
+No changes to these areas are included in this assessment document. They are identified
+as the next proving target for 0.7.x work. Each will require its own slice and task doc.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "multiverse",
-  "version": "0.6.0-alpha.1",
+  "version": "0.7.0-alpha.1",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.33.0",


### PR DESCRIPTION
## Summary

Post-wave assessment completed for the `0.6.x` semantic-stability wave (Slices 44–49). All five exit criteria are met in substance. This PR bumps the project posture to `0.7.0-alpha.1` and records the assessment.

## Scope

- `package.json`: version `0.6.0-alpha.1` → `0.7.0-alpha.1`
- `README.md`: updated "Current behavior being proven" paragraph for 0.7.x posture
- `docs/development/current-state.md`: version posture, priority, and highest-value work updated for 0.7.x
- `docs/development/roadmap.md`: current version posture and immediate direction updated for 0.7.x
- `docs/development/tasks/post-wave-44-49-assessment.md`: new — wave summary, exit criteria evidence, recommendation (Outcome B), next proving question

## Validation

- `pnpm test:contracts`: 81 tests pass
- `pnpm test:acceptance`: 199 tests pass

## 0.6.x exit criteria

| Criterion | Evidence | Met? |
|---|---|---|
| Lifecycle semantics consistent and trustworthy | Slice 45 aligned spec + scenarios for reset/cleanup intent | ✓ |
| Refusal behavior understandable and predictable | Slice 47 audited all five commands; spec/contract naming split documented | ✓ |
| Major core terms stable across docs, code, CLI | Refusal category names and scope-confirmation semantics documented consistently | ✓ |
| Users can infer what Multiverse will do | Worktree identity scenarios corrected per ADR-0021; appEnv boundary classified | ✓ |
| Consumer configuration model feels dependable | appEnv exclusion from derive classified as intentional and deferred in ADR-0018 | ✓ |

## Deferred (not blockers)

- Refusal reporting format (stdout vs stderr for `run`): in spec's Open Areas
- appEnv in `derive --format=env`: explicitly deferred in ADR-0018
- Outside-workspace packaging/distribution: always deferred

## Next phase

`0.7.x` public surface stability: CLI help text, output format conventions, flag naming, invocation patterns, and guide consistency. Each slice begins with a targeted audit and task doc before any implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)