### PR TITLE
slice-50: --help exits 0 and structured usage text

### DIFF
--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -174,6 +174,28 @@ function findAppEnvConflict(
   return undefined;
 }
 
+const USAGE_LINES = [
+  "Usage: multiverse <command> [options]",
+  "",
+  "Commands:",
+  "  derive     [--config PATH] [--providers MODULE] [--worktree-id VALUE] [--format json|env]",
+  "  validate   [--config PATH] [--providers MODULE] [--worktree-id VALUE]",
+  "  reset      [--config PATH] [--providers MODULE] [--worktree-id VALUE]",
+  "  cleanup    [--config PATH] [--providers MODULE] [--worktree-id VALUE]",
+  "  run        [--config PATH] [--providers MODULE] [--worktree-id VALUE] -- <cmd> [args...]",
+  "  validate-worktree    --worktree-id VALUE",
+  "  validate-repository  --config PATH",
+  "",
+  "Options (derive, validate, reset, cleanup, run):",
+  "  --config PATH        Repository configuration file (default: ./multiverse.json)",
+  "  --providers MODULE   Providers module path (default: ./providers.ts)",
+  "  --worktree-id VALUE  Worktree identity (auto-discovered from git state when omitted)",
+];
+
+function help(): CliResult {
+  return { exitCode: 0, stdout: USAGE_LINES, stderr: [] };
+}
+
 function usage(message: string): CliResult {
   return {
     exitCode: 1,
@@ -627,6 +649,10 @@ export async function runCli(args: string[], options: RunCliOptions = {}): Promi
   const parentEnv = options.parentEnv ?? process.env;
   const [command] = args;
 
+  if (command === "--help" || command === "-h") {
+    return help();
+  }
+
   if (command === "validate-worktree") {
     return handleValidateWorktree(args);
   }
@@ -655,9 +681,7 @@ export async function runCli(args: string[], options: RunCliOptions = {}): Promi
     return handleRun(args, cwd, runner, parentEnv);
   }
 
-  return usage(
-    "Usage: multiverse <validate-worktree --worktree-id VALUE | validate-repository --config PATH | derive [--config PATH] [--providers MODULE] [--worktree-id VALUE] | validate [--config PATH] [--providers MODULE] [--worktree-id VALUE] | reset [--config PATH] [--providers MODULE] [--worktree-id VALUE] | cleanup [--config PATH] [--providers MODULE] [--worktree-id VALUE] | run [--config PATH] [--providers MODULE] [--worktree-id VALUE] -- <cmd> [args...]>"
-  );
+  return { exitCode: 1, stdout: [], stderr: USAGE_LINES };
 }
 
 export async function main(): Promise<void> {

--- a/docs/development/current-state.md
+++ b/docs/development/current-state.md
@@ -324,6 +324,19 @@ misleading since `run` also injects appEnv aliases not present in derive output.
 sentence is corrected to accurately describe what each command outputs and where the
 boundary lies.
 
+**Is the `--help` / `-h` flag behavior correct, and is the usage string readable?**
+
+Slice 50 answers yes, after two narrow fixes. (1) `--help` and `-h` previously fell through the
+unknown-command path and exited 1 — the guide explicitly documents `multiverse --help` as a
+verification step in the globally-linked binary section, so exit 1 was incorrect. Both flags
+now return exit 0 with help text written to stdout. (2) The usage string was a single 250+
+character unreadable blob. It is now a structured multi-line text showing primary commands and
+options in a scannable layout. The utility commands (`validate-worktree`,
+`validate-repository`) are retained in the help output; their surface classification is a
+separate question deferred to a later 0.7.x slice. Acceptance tests were added for `--help`
+and `-h` exit code and output routing; the Slice 41 tests for usage string content were
+updated to work with multi-line output.
+
 ## Current priority
 
 The current priority is:

--- a/docs/development/tasks/dev-slice-50-task-01.md
+++ b/docs/development/tasks/dev-slice-50-task-01.md
@@ -1,0 +1,93 @@
+# Dev Slice 50 — Task 01
+
+## Title
+
+Public surface stability — `--help` / `-h` flag behavior and structured usage text
+
+## Sources of truth
+
+- `docs/development/current-state.md` — 0.7.x priority statement; "auditing and improving CLI
+  help output (the current `--help` surface is a raw usage string, not a structured help system)"
+- `docs/development/roadmap.md` — 0.7.x primary goals: "CLI help text", "common command flows
+  feel intentional rather than provisional"
+- `docs/guides/external-demo-guide.md` — "Using the formal binary" section explicitly shows
+  `multiverse --help` as a step to verify the globally-linked binary is working
+
+## Audit findings
+
+### `--help` / `-h` exits 1
+
+Running `pnpm cli --help` or `multiverse --help` falls through the unknown-command path and
+returns exit code 1 with the usage blob written to stderr.
+
+The external-demo-guide uses `multiverse --help` as a verification step:
+```
+multiverse --help
+```
+
+A command that exits 1 when used for verification silently misleads the caller (shell scripts,
+CI verification steps, onboarding checklists). The standard expectation is exit 0.
+
+### Usage string is a single unreadable blob
+
+The current fallback message is a 250+ character single-line string:
+
+```
+Usage: multiverse <validate-worktree --worktree-id VALUE | validate-repository --config PATH | ...>
+```
+
+This is not scannable. Current-state.md names this gap explicitly.
+
+### Secondary gaps (deferred — not in this slice)
+
+- Whether `validate-worktree` and `validate-repository` belong on the same surface as primary
+  commands — kept in the structured help for now; their surface classification is a separate
+  design question
+- Per-command help (`multiverse derive --help`)
+- Output format specification for individual commands
+
+## In scope
+
+- `apps/cli/src/index.ts`
+  - Add `USAGE_LINES` constant: structured multi-line help text (array of strings)
+  - Add `--help` / `-h` handling at the start of `runCli`: returns `exitCode: 0`, prints
+    `USAGE_LINES` to stdout
+  - Replace the single-line unknown-command fallback with `USAGE_LINES` sent to stderr,
+    exit 1
+
+- `tests/acceptance/dev-slice-41.acceptance.test.ts`
+  - Update pattern assertions to join stderr lines before matching (currently assumes single
+    usage line; multi-line output breaks the find-one-line approach)
+
+- `tests/acceptance/cli-help-flag.acceptance.test.ts` (new)
+  - `--help` exits 0 and writes to stdout, not stderr
+  - `-h` exits 0 and writes to stdout, not stderr
+  - Help text contains each primary command name
+  - Unknown command exits 1 and writes to stderr
+
+- `docs/development/tasks/dev-slice-50-task-01.md` (this file)
+
+- `docs/development/current-state.md`
+  - Add Slice 50 proving result
+
+## Out of scope
+
+- Classifying or reclassifying `validate-worktree` / `validate-repository`
+- Per-command help text
+- Changing `usage()` error messages for specific option errors (missing --config, unknown --format, etc.)
+- Output format specification work
+- Any new commands or flags beyond `--help` / `-h`
+
+## Acceptance criteria
+
+- `runCli(["--help"])` returns `exitCode: 0` with non-empty stdout and empty stderr
+- `runCli(["-h"])` returns `exitCode: 0` with non-empty stdout and empty stderr
+- Help stdout contains the names of all primary commands: `derive`, `validate`, `reset`,
+  `cleanup`, `run`
+- Unknown command still exits 1 with usage text to stderr
+- All existing acceptance and unit tests remain green
+- `pnpm test:acceptance` and `pnpm test:unit` pass
+
+## Safety / refusal expectations
+
+No refusal behavior is touched. The `usage()` function for specific option errors is unchanged.

--- a/tests/acceptance/cli-help-flag.acceptance.test.ts
+++ b/tests/acceptance/cli-help-flag.acceptance.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import { runCli } from "../../apps/cli/src/index";
+
+/**
+ * Acceptance tests for Slice 50: --help / -h flag behavior.
+ *
+ * Proving:
+ * - --help and -h exit 0 (not 1)
+ * - Help text goes to stdout, not stderr
+ * - Help text names all primary commands
+ * - Unknown command still exits 1 with usage to stderr
+ */
+describe("CLI --help flag (Slice 50)", () => {
+  it("--help exits 0", async () => {
+    const outcome = await runCli(["--help"]);
+    expect(outcome.exitCode).toBe(0);
+  });
+
+  it("-h exits 0", async () => {
+    const outcome = await runCli(["-h"]);
+    expect(outcome.exitCode).toBe(0);
+  });
+
+  it("--help writes to stdout, not stderr", async () => {
+    const outcome = await runCli(["--help"]);
+    expect(outcome.stdout.length).toBeGreaterThan(0);
+    expect(outcome.stderr).toHaveLength(0);
+  });
+
+  it("-h writes to stdout, not stderr", async () => {
+    const outcome = await runCli(["-h"]);
+    expect(outcome.stdout.length).toBeGreaterThan(0);
+    expect(outcome.stderr).toHaveLength(0);
+  });
+
+  it("--help output contains primary command names", async () => {
+    const outcome = await runCli(["--help"]);
+    const text = outcome.stdout.join("\n");
+    expect(text).toContain("derive");
+    expect(text).toContain("validate");
+    expect(text).toContain("reset");
+    expect(text).toContain("cleanup");
+    expect(text).toContain("run");
+  });
+
+  it("unknown command still exits 1 with usage to stderr", async () => {
+    const outcome = await runCli(["not-a-command"]);
+    expect(outcome.exitCode).toBe(1);
+    expect(outcome.stderr.length).toBeGreaterThan(0);
+    expect(outcome.stderr.join("\n")).toContain("Usage:");
+  });
+});

--- a/tests/acceptance/dev-slice-41.acceptance.test.ts
+++ b/tests/acceptance/dev-slice-41.acceptance.test.ts
@@ -6,41 +6,44 @@ import { runCli } from "../../apps/cli/src/index";
  * Acceptance tests for Slice 41: stale usage string fix.
  *
  * Proving:
- * - The fallback usage string shown on unknown command reflects that
+ * - The fallback usage output shown on unknown command reflects that
  *   --worktree-id is optional (not required) for derive, validate, reset,
  *   cleanup, and run — as introduced by Slice 37 auto-discovery.
  * - validate-worktree still shows --worktree-id as required (it is).
+ *
+ * Slice 50 update: usage output is now multi-line. Tests join stderr lines
+ * before pattern matching instead of searching for a single usage line.
  */
 describe("CLI usage string accuracy (Slice 41)", () => {
   it("unknown command usage shows --worktree-id as optional for derive", async () => {
     const outcome = await runCli(["not-a-command"]);
 
     expect(outcome.exitCode).toBe(1);
-    const usageLine = outcome.stderr.find((l) => l.includes("Usage:"));
-    expect(usageLine).toBeDefined();
+    const stderrText = outcome.stderr.join("\n");
+    expect(stderrText).toContain("Usage:");
     // derive should show [--worktree-id VALUE] (optional, bracketed)
-    expect(usageLine).toMatch(/derive \[.*\[--worktree-id VALUE\]/);
+    expect(stderrText).toMatch(/derive\s+\[.*\[--worktree-id VALUE\]/);
     // must NOT show the old required form: derive ... --worktree-id VALUE without brackets
-    expect(usageLine).not.toMatch(/derive \[--config PATH\] \[--providers MODULE\] --worktree-id VALUE[^\]]/);
+    expect(stderrText).not.toMatch(/derive \[--config PATH\] \[--providers MODULE\] --worktree-id VALUE[^\]]/);
   });
 
   it("unknown command usage shows --worktree-id as optional for run", async () => {
     const outcome = await runCli(["not-a-command"]);
 
     expect(outcome.exitCode).toBe(1);
-    const usageLine = outcome.stderr.find((l) => l.includes("Usage:"));
-    expect(usageLine).toBeDefined();
+    const stderrText = outcome.stderr.join("\n");
+    expect(stderrText).toContain("Usage:");
     // run should show [--worktree-id VALUE] (optional, bracketed)
-    expect(usageLine).toMatch(/run \[.*\[--worktree-id VALUE\]/);
+    expect(stderrText).toMatch(/run\s+\[.*\[--worktree-id VALUE\]/);
   });
 
   it("unknown command usage still shows --worktree-id as required for validate-worktree", async () => {
     const outcome = await runCli(["not-a-command"]);
 
     expect(outcome.exitCode).toBe(1);
-    const usageLine = outcome.stderr.find((l) => l.includes("Usage:"));
-    expect(usageLine).toBeDefined();
+    const stderrText = outcome.stderr.join("\n");
+    expect(stderrText).toContain("Usage:");
     // validate-worktree still requires --worktree-id
-    expect(usageLine).toMatch(/validate-worktree --worktree-id VALUE/);
+    expect(stderrText).toMatch(/validate-worktree\s+--worktree-id VALUE/);
   });
 });


### PR DESCRIPTION
## Summary

First 0.7.x slice. Audit identified two related gaps in CLI help discoverability:

1. `--help` / `-h` exited 1 — the guide documents `multiverse --help` as a verification step in the globally-linked binary section, but it was treated as an unknown command
2. The usage string was a single 250+ character unreadable blob; `current-state.md` names this as a 0.7.x gap explicitly

## Scope

- `apps/cli/src/index.ts` — `USAGE_LINES` constant (structured multi-line help), `help()` returning exit 0, `--help`/`-h` dispatch before command handling, unknown-command fallback now uses `USAGE_LINES`
- `tests/acceptance/cli-help-flag.acceptance.test.ts` — new acceptance tests: `--help`/`-h` exit 0, stdout routing, command name coverage, unknown-command still exits 1
- `tests/acceptance/dev-slice-41.acceptance.test.ts` — updated to join `stderr` lines before pattern matching (multi-line output broke single-line find approach)
- `docs/development/tasks/dev-slice-50-task-01.md` — task doc
- `docs/development/current-state.md` — Slice 50 proving result

## Validation

- `pnpm test:acceptance` — 205/205 pass
- `pnpm test` — 329/329 pass
- `pnpm cli --help` verified: exits 0, structured output to stdout

## Deferred

- Whether `validate-worktree` / `validate-repository` belong on the same public surface as primary commands — retained in help text for now; surface classification is a separate 0.7.x question
- Per-command help (`multiverse derive --help`)
- Output format specification for individual commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)