### PR TITLE
slice-51: output-shape spec for primary CLI commands

### DIFF
--- a/docs/development/current-state.md
+++ b/docs/development/current-state.md
@@ -337,6 +337,21 @@ separate question deferred to a later 0.7.x slice. Acceptance tests were added f
 and `-h` exit code and output routing; the Slice 41 tests for usage string content were
 updated to work with multi-line output.
 
+**Is there a source-of-truth spec for the output shapes of primary CLI commands, and are they
+executable as tests?**
+
+Slice 51 answers yes, after two additions. (1) A new spec document,
+`docs/spec/cli-output-shapes.md`, records the stable output contract for `derive`, `validate`,
+`reset`, `cleanup`, and `run`: per-command success and failure shapes, the shared refusal shape
+and four categories, output routing (stdout vs stderr), the one-JSON-line-per-invocation rule,
+and the `derive --format=env` KEY=VALUE convention. The `run` stdout/stderr asymmetry (refusal
+to stderr, unlike other commands) is documented explicitly; it was identified in Slice 47 and
+intentionally preserved. (2) A new acceptance test file,
+`tests/acceptance/cli-output-shapes.acceptance.test.ts`, makes the spec executable: it verifies
+field names, output routing, and exit codes for every primary command in both success and failure
+paths. No production code was changed. Deferred: `validate-worktree`/`validate-repository`
+output shape classification; per-command help; utility-command surface classification.
+
 ## Current priority
 
 The current priority is:

--- a/docs/development/tasks/dev-slice-51-task-01.md
+++ b/docs/development/tasks/dev-slice-51-task-01.md
@@ -1,0 +1,92 @@
+# Dev Slice 51 — Task 01
+
+## Title
+
+Public surface stability — output-shape specification for primary CLI commands
+
+## Sources of truth
+
+- `docs/development/current-state.md` — 0.7.x gap: "specifying expected output shape for
+  each command in source-of-truth docs (no output-format spec exists for `derive`, `validate`,
+  `reset`, `cleanup` result shapes)"
+- `docs/development/roadmap.md` — 0.7.x primary goals: "output conventions", "common command
+  flows feel intentional rather than provisional"
+- `packages/provider-contracts/src/index.ts` — canonical type definitions for all output shapes
+- `packages/core/src/orchestration.ts` — return types that determine output JSON structure
+
+## Audit findings
+
+### No source-of-truth spec for CLI output shapes
+
+All primary commands emit structured output, but that structure is only implicitly proven by
+existing acceptance tests. There is no spec document a user or script author can consult to
+understand what field names are stable, what the refusal shape looks like, or which output goes
+to stdout vs stderr.
+
+This creates a public-surface stability risk: a minor version could silently change a field
+name (e.g. `resourcePlans` → `plans`) without violating any explicit stability promise.
+
+### Behavioral asymmetry between `run` and other commands (documented, not changed)
+
+All primary commands (`derive`, `validate`, `reset`, `cleanup`) write both success and refusal
+JSON to **stdout**. `run` is the exception: on refusal, it writes JSON to **stderr** and leaves
+stdout empty. This was identified in Slice 47 as "in the spec's explicitly open area" and was
+not changed. The output-shape spec should document this asymmetry truthfully.
+
+### Deferred candidates
+
+- `validate-worktree` / `validate-repository` surface classification — Slice 50 visually
+  separated them in help text; further action requires a design decision about whether to
+  remove/move them, which is not yet supported by a source-of-truth directive
+- Per-command help text
+- Changing any output shape (this slice documents the existing shapes; shape changes are a
+  separate product decision)
+
+## In scope
+
+- `docs/spec/cli-output-shapes.md` (new)
+  - General output conventions: stdout vs stderr, exit codes, one-JSON-line-per-invocation rule
+  - Refusal shape (shared across all commands)
+  - Per-command success output shapes: `derive` (json), `derive` (env), `validate`, `reset`,
+    `cleanup`, `run`
+  - Shared object shapes: DerivedResourcePlan, DerivedEndpointMapping, ResourceValidation,
+    ResourceReset, ResourceCleanup
+  - The `run` stdout/stderr asymmetry documented explicitly
+
+- `tests/acceptance/cli-output-shapes.acceptance.test.ts` (new)
+  - Acceptance tests that make the output-shape spec executable:
+    - `derive` JSON success: `ok: true`, `resourcePlans` array, `endpointMappings` array
+    - `derive` JSON failure: `ok: false`, `refusal.category`, `refusal.reason`, to stdout
+    - `derive --format=env` success: KEY=VALUE lines, one per resource/endpoint
+    - `validate` success: `ok: true`, adds `resourceValidations` array
+    - `reset` success: `ok: true`, `resourcePlans`, `resourceResets`
+    - `cleanup` success: `ok: true`, `resourcePlans`, `resourceCleanups`
+    - `run` success: stdout empty, stderr empty
+    - `run` refusal: stderr has refusal JSON, stdout empty
+
+- `docs/development/tasks/dev-slice-51-task-01.md` (this file)
+
+- `docs/development/current-state.md`
+  - Add Slice 51 proving result
+
+## Out of scope
+
+- Changing any CLI output shape or field name
+- Adding per-command help text
+- `validate-worktree` / `validate-repository` surface classification
+- Output shape for `validate-worktree` or `validate-repository` (utility commands)
+- New commands or flags
+- Output format other than JSON and KEY=VALUE env format
+
+## Acceptance criteria
+
+- `docs/spec/cli-output-shapes.md` exists and documents all primary command output shapes
+  including the `run` stdout/stderr asymmetry
+- Acceptance tests explicitly verify the shape contract properties for all primary commands
+- All existing tests remain green
+- `pnpm test:acceptance` and `pnpm test` pass
+
+## Safety / refusal expectations
+
+No refusal behavior is modified. No CLI code is changed. This slice is documentation and test
+coverage only.

--- a/docs/spec/cli-output-shapes.md
+++ b/docs/spec/cli-output-shapes.md
@@ -1,0 +1,334 @@
+# CLI Output Shapes
+
+## Purpose
+
+This document specifies the stable output contract for the Multiverse CLI primary commands.
+
+It exists so that users and script authors can rely on output field names and structure remaining
+stable between minor versions, and so that contributors understand which shapes are public
+contracts rather than incidental implementation details.
+
+## Scope
+
+This document covers the five primary CLI commands:
+
+- `derive`
+- `validate`
+- `reset`
+- `cleanup`
+- `run`
+
+It does not cover `validate-worktree` or `validate-repository`.
+
+---
+
+## General conventions
+
+### Output stream routing
+
+| Situation | stdout | stderr | Exit code |
+|---|---|---|---|
+| Success (all commands except `run`) | JSON result | empty | 0 |
+| Success (`run`) | empty (transparent) | empty (transparent) | child's exit code |
+| Refusal (all commands except `run`) | JSON refusal | empty | 1 |
+| Refusal (`run`) | empty | JSON refusal | 1 |
+| Usage error (bad flag, missing separator) | empty | plain-text message | 1 |
+
+**`run` is the exception for refusal routing.** All other commands write both success and
+refusal JSON to stdout. `run` writes refusal JSON to stderr and leaves stdout empty. This
+preserves the child process's stdin/stdout/stderr contract: if `run` could not start the
+child process, no child output would pollute stdout.
+
+### JSON output format
+
+Each command that produces JSON output writes exactly **one line** to stdout. The line is a
+compact JSON object followed by a newline. There is no additional whitespace, newlines within
+the object, or trailing content.
+
+### `derive --format=env` exception
+
+When `derive` is invoked with `--format=env`, success output is **not JSON**. Instead, it
+writes one `KEY=VALUE` line per declared resource and endpoint. See the `derive` section
+below for details.
+
+---
+
+## Shared object shapes
+
+These shapes appear as array elements within command results.
+
+### `DerivedResourcePlan`
+
+Produced by every command that touches a resource.
+
+```json
+{
+  "resourceName": "<declared resource name>",
+  "provider": "<provider name from multiverse.json>",
+  "isolationStrategy": "name-scoped | path-scoped | process-scoped | process-port-scoped",
+  "worktreeId": "<resolved worktree identity>",
+  "handle": "<provider-derived isolation handle>"
+}
+```
+
+### `DerivedEndpointMapping`
+
+Produced by `derive` and `validate`.
+
+```json
+{
+  "endpointName": "<declared endpoint name>",
+  "provider": "<provider name from multiverse.json>",
+  "role": "<declared endpoint role>",
+  "worktreeId": "<resolved worktree identity>",
+  "address": "<provider-derived address, e.g. http://localhost:5100>"
+}
+```
+
+### `ResourceValidation`
+
+Produced by `validate` for each resource that declares `scopedValidate: true`.
+
+```json
+{
+  "resourceName": "<name>",
+  "provider": "<provider>",
+  "worktreeId": "<id>",
+  "capability": "validate"
+}
+```
+
+### `ResourceReset`
+
+Produced by `reset` for each resource that declares `scopedReset: true`.
+
+```json
+{
+  "resourceName": "<name>",
+  "provider": "<provider>",
+  "worktreeId": "<id>",
+  "capability": "reset"
+}
+```
+
+### `ResourceCleanup`
+
+Produced by `cleanup` for each resource that declares `scopedCleanup: true`.
+
+```json
+{
+  "resourceName": "<name>",
+  "provider": "<provider>",
+  "worktreeId": "<id>",
+  "capability": "cleanup"
+}
+```
+
+---
+
+## Refusal shape
+
+A refusal is the structured output produced when a command cannot safely proceed. The refusal
+shape is shared across all primary commands.
+
+```json
+{
+  "ok": false,
+  "refusal": {
+    "category": "<category>",
+    "reason": "<human-readable explanation>"
+  }
+}
+```
+
+### Refusal categories
+
+| Category | Meaning |
+|---|---|
+| `unsafe_scope` | The worktree scope cannot be safely determined |
+| `unsupported_capability` | The requested operation is not supported by the declared provider |
+| `invalid_configuration` | The repository configuration or provider setup is invalid |
+| `provider_failure` | A provider-level failure occurred during the operation |
+
+---
+
+## `derive`
+
+Derives isolated runtime values for the resolved worktree without starting any child process.
+
+### JSON format (default or `--format=json`)
+
+**Success (exit 0, stdout):**
+
+```json
+{
+  "ok": true,
+  "resourcePlans": [DerivedResourcePlan, ...],
+  "endpointMappings": [DerivedEndpointMapping, ...]
+}
+```
+
+`resourcePlans` contains one entry per declared resource, in declaration order.
+`endpointMappings` contains one entry per declared endpoint, in declaration order.
+
+**Failure (exit 1, stdout):**
+
+```json
+{
+  "ok": false,
+  "refusal": { "category": "...", "reason": "..." }
+}
+```
+
+### Env format (`--format=env`)
+
+**Success (exit 0, stdout):**
+
+One line per declared resource:
+```
+MULTIVERSE_RESOURCE_<NAME>=<handle>
+```
+
+One line per declared endpoint:
+```
+MULTIVERSE_ENDPOINT_<NAME>=<address>
+```
+
+Name transformation: the declared name is uppercased and hyphens are replaced with
+underscores. For example, `app-db` becomes `APP_DB`, producing `MULTIVERSE_RESOURCE_APP_DB`.
+
+Lines appear in declaration order: all resource lines first, then all endpoint lines.
+
+`appEnv` aliases are **not** included in `derive --format=env` output. They are injected
+only by `run` at process-launch time.
+
+**Failure (exit 1, stdout):**
+
+The refusal JSON is written to stdout (same as the JSON format failure). The output is a
+single JSON line, not KEY=VALUE.
+
+---
+
+## `validate`
+
+Derives values and validates resources that declare `scopedValidate: true`.
+
+**Success (exit 0, stdout):**
+
+```json
+{
+  "ok": true,
+  "resourcePlans": [DerivedResourcePlan, ...],
+  "endpointMappings": [DerivedEndpointMapping, ...],
+  "resourceValidations": [ResourceValidation, ...]
+}
+```
+
+`resourceValidations` contains one entry per resource that declared `scopedValidate: true`
+and whose provider successfully validated the derived scope. It is an empty array if no
+resources declare `scopedValidate: true`.
+
+**Failure (exit 1, stdout):**
+
+```json
+{
+  "ok": false,
+  "refusal": { "category": "...", "reason": "..." }
+}
+```
+
+---
+
+## `reset`
+
+Resets isolated state for resources that declare `scopedReset: true`.
+
+**Success (exit 0, stdout):**
+
+```json
+{
+  "ok": true,
+  "resourcePlans": [DerivedResourcePlan, ...],
+  "resourceResets": [ResourceReset, ...]
+}
+```
+
+`resourcePlans` contains only the resources that declared `scopedReset: true` (not all
+declared resources). `resourceResets` contains one entry per reset resource.
+
+**Failure (exit 1, stdout):**
+
+```json
+{
+  "ok": false,
+  "refusal": { "category": "...", "reason": "..." }
+}
+```
+
+---
+
+## `cleanup`
+
+Permanently removes isolated state for resources that declare `scopedCleanup: true`.
+
+**Success (exit 0, stdout):**
+
+```json
+{
+  "ok": true,
+  "resourcePlans": [DerivedResourcePlan, ...],
+  "resourceCleanups": [ResourceCleanup, ...]
+}
+```
+
+`resourcePlans` contains only the resources that declared `scopedCleanup: true` (not all
+declared resources). `resourceCleanups` contains one entry per cleaned-up resource.
+
+**Failure (exit 1, stdout):**
+
+```json
+{
+  "ok": false,
+  "refusal": { "category": "...", "reason": "..." }
+}
+```
+
+---
+
+## `run`
+
+Starts a user-supplied child process with derived values injected as environment variables.
+
+**Success (exit = child's exit code):**
+
+- stdout: empty (child's stdout passes through unchanged)
+- stderr: empty (child's stderr passes through unchanged)
+- exit code: the child process's exit code
+
+Multiverse itself produces no stdout or stderr output when the child process launches
+successfully.
+
+**Failure — refusal (exit 1):**
+
+Refusal is written to **stderr**, not stdout. This is intentional: `run` launches a child
+process and passes its stdout through unchanged. Writing refusal to stderr preserves the
+stdout contract for downstream consumers.
+
+```
+stderr:
+{"ok":false,"refusal":{"category":"...","reason":"..."}}
+```
+
+stdout: empty.
+
+The child process is never started when a refusal occurs.
+
+---
+
+## Stability guarantee
+
+The field names and shapes documented here are stable within the 0.7.x version line and
+are intended to remain stable through 1.0.
+
+Changes to output shapes will be documented explicitly in release notes and will not be
+introduced silently in minor versions.

--- a/tests/acceptance/cli-output-shapes.acceptance.test.ts
+++ b/tests/acceptance/cli-output-shapes.acceptance.test.ts
@@ -1,0 +1,514 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { runCli, type ChildProcessRunner } from "../../apps/cli/src/index";
+
+/**
+ * Acceptance tests for Slice 51: CLI output-shape specification.
+ *
+ * These tests make the output contract in docs/spec/cli-output-shapes.md
+ * executable. They verify field names, output routing (stdout vs stderr),
+ * and the one-JSON-line-per-invocation rule for each primary command.
+ */
+describe("CLI output shapes (Slice 51)", () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(
+      tempDirs.map((dir) => rm(dir, { recursive: true, force: true }))
+    );
+    tempDirs.length = 0;
+  });
+
+  const providersModulePath = fileURLToPath(
+    new URL("./fixtures/explicit-test-providers.ts", import.meta.url)
+  );
+
+  async function writeRepositoryConfig(config: unknown): Promise<string> {
+    const tempDir = await mkdtemp(path.join(tmpdir(), "multiverse-shapes-"));
+    tempDirs.push(tempDir);
+    const configPath = path.join(tempDir, "repository.json");
+    await writeFile(configPath, JSON.stringify(config));
+    return configPath;
+  }
+
+  const baseConfig = {
+    resources: [
+      {
+        name: "app-db",
+        provider: "test-resource-provider",
+        isolationStrategy: "name-scoped",
+        scopedValidate: false,
+        scopedReset: false,
+        scopedCleanup: false
+      }
+    ],
+    endpoints: [
+      {
+        name: "http",
+        role: "application-http",
+        provider: "test-endpoint-provider"
+      }
+    ]
+  };
+
+  const validateConfig = {
+    resources: [
+      {
+        name: "app-db",
+        provider: "test-resource-provider",
+        isolationStrategy: "name-scoped",
+        scopedValidate: true,
+        scopedReset: false,
+        scopedCleanup: false
+      }
+    ],
+    endpoints: [
+      {
+        name: "http",
+        role: "application-http",
+        provider: "test-endpoint-provider"
+      }
+    ]
+  };
+
+  const resetConfig = {
+    resources: [
+      {
+        name: "app-db",
+        provider: "test-resource-provider-with-reset",
+        isolationStrategy: "name-scoped",
+        scopedValidate: false,
+        scopedReset: true,
+        scopedCleanup: false
+      }
+    ],
+    endpoints: []
+  };
+
+  const cleanupConfig = {
+    resources: [
+      {
+        name: "app-db",
+        provider: "test-resource-provider-with-cleanup",
+        isolationStrategy: "name-scoped",
+        scopedValidate: false,
+        scopedReset: false,
+        scopedCleanup: true
+      }
+    ],
+    endpoints: []
+  };
+
+  // ── derive (JSON format) ──────────────────────────────────────────────────
+
+  describe("derive (JSON format)", () => {
+    it("success: one JSON line to stdout, exit 0, stderr empty", async () => {
+      const configPath = await writeRepositoryConfig(baseConfig);
+
+      const outcome = await runCli([
+        "derive",
+        "--config", configPath,
+        "--worktree-id", "wt-shape-derive",
+        "--providers", providersModulePath
+      ]);
+
+      expect(outcome.exitCode).toBe(0);
+      expect(outcome.stderr).toHaveLength(0);
+      expect(outcome.stdout).toHaveLength(1);
+      expect(() => JSON.parse(outcome.stdout[0]!)).not.toThrow();
+    });
+
+    it("success: top-level shape has ok, resourcePlans, endpointMappings", async () => {
+      const configPath = await writeRepositoryConfig(baseConfig);
+
+      const outcome = await runCli([
+        "derive",
+        "--config", configPath,
+        "--worktree-id", "wt-shape-derive",
+        "--providers", providersModulePath
+      ]);
+
+      const parsed = JSON.parse(outcome.stdout[0]!);
+      expect(parsed.ok).toBe(true);
+      expect(Array.isArray(parsed.resourcePlans)).toBe(true);
+      expect(Array.isArray(parsed.endpointMappings)).toBe(true);
+    });
+
+    it("success: DerivedResourcePlan has required fields", async () => {
+      const configPath = await writeRepositoryConfig(baseConfig);
+
+      const outcome = await runCli([
+        "derive",
+        "--config", configPath,
+        "--worktree-id", "wt-shape-derive",
+        "--providers", providersModulePath
+      ]);
+
+      const parsed = JSON.parse(outcome.stdout[0]!);
+      const plan = parsed.resourcePlans[0];
+      expect(plan).toHaveProperty("resourceName");
+      expect(plan).toHaveProperty("provider");
+      expect(plan).toHaveProperty("isolationStrategy");
+      expect(plan).toHaveProperty("worktreeId");
+      expect(plan).toHaveProperty("handle");
+    });
+
+    it("success: DerivedEndpointMapping has required fields", async () => {
+      const configPath = await writeRepositoryConfig(baseConfig);
+
+      const outcome = await runCli([
+        "derive",
+        "--config", configPath,
+        "--worktree-id", "wt-shape-derive",
+        "--providers", providersModulePath
+      ]);
+
+      const parsed = JSON.parse(outcome.stdout[0]!);
+      const mapping = parsed.endpointMappings[0];
+      expect(mapping).toHaveProperty("endpointName");
+      expect(mapping).toHaveProperty("provider");
+      expect(mapping).toHaveProperty("role");
+      expect(mapping).toHaveProperty("worktreeId");
+      expect(mapping).toHaveProperty("address");
+    });
+
+    it("failure (refusal): one JSON line to stdout, exit 1, stderr empty", async () => {
+      const configPath = await writeRepositoryConfig({
+        resources: [
+          {
+            name: "app-db",
+            provider: "nonexistent-provider",
+            isolationStrategy: "name-scoped",
+            scopedValidate: false,
+            scopedReset: false,
+            scopedCleanup: false
+          }
+        ],
+        endpoints: []
+      });
+
+      const outcome = await runCli([
+        "derive",
+        "--config", configPath,
+        "--worktree-id", "wt-shape-derive-fail",
+        "--providers", providersModulePath
+      ]);
+
+      expect(outcome.exitCode).toBe(1);
+      expect(outcome.stderr).toHaveLength(0);
+      expect(outcome.stdout).toHaveLength(1);
+      const parsed = JSON.parse(outcome.stdout[0]!);
+      expect(parsed.ok).toBe(false);
+      expect(parsed.refusal).toHaveProperty("category");
+      expect(parsed.refusal).toHaveProperty("reason");
+      expect(typeof parsed.refusal.category).toBe("string");
+      expect(typeof parsed.refusal.reason).toBe("string");
+    });
+  });
+
+  // ── derive (env format) ───────────────────────────────────────────────────
+
+  describe("derive (--format=env)", () => {
+    it("success: KEY=VALUE lines to stdout, exit 0, stderr empty", async () => {
+      const configPath = await writeRepositoryConfig(baseConfig);
+
+      const outcome = await runCli([
+        "derive",
+        "--config", configPath,
+        "--worktree-id", "wt-shape-env",
+        "--providers", providersModulePath,
+        "--format", "env"
+      ]);
+
+      expect(outcome.exitCode).toBe(0);
+      expect(outcome.stderr).toHaveLength(0);
+      expect(outcome.stdout.length).toBeGreaterThan(0);
+    });
+
+    it("success: resource lines use MULTIVERSE_RESOURCE_ prefix", async () => {
+      const configPath = await writeRepositoryConfig(baseConfig);
+
+      const outcome = await runCli([
+        "derive",
+        "--config", configPath,
+        "--worktree-id", "wt-shape-env",
+        "--providers", providersModulePath,
+        "--format", "env"
+      ]);
+
+      const resourceLine = outcome.stdout.find((l) => l.startsWith("MULTIVERSE_RESOURCE_"));
+      expect(resourceLine).toBeDefined();
+      expect(resourceLine).toContain("=");
+    });
+
+    it("success: endpoint lines use MULTIVERSE_ENDPOINT_ prefix", async () => {
+      const configPath = await writeRepositoryConfig(baseConfig);
+
+      const outcome = await runCli([
+        "derive",
+        "--config", configPath,
+        "--worktree-id", "wt-shape-env",
+        "--providers", providersModulePath,
+        "--format", "env"
+      ]);
+
+      const endpointLine = outcome.stdout.find((l) => l.startsWith("MULTIVERSE_ENDPOINT_"));
+      expect(endpointLine).toBeDefined();
+      expect(endpointLine).toContain("=");
+    });
+  });
+
+  // ── validate ─────────────────────────────────────────────────────────────
+
+  describe("validate", () => {
+    it("success: one JSON line to stdout, exit 0, stderr empty", async () => {
+      const configPath = await writeRepositoryConfig(validateConfig);
+
+      const outcome = await runCli([
+        "validate",
+        "--config", configPath,
+        "--worktree-id", "wt-shape-validate",
+        "--providers", providersModulePath
+      ]);
+
+      expect(outcome.exitCode).toBe(0);
+      expect(outcome.stderr).toHaveLength(0);
+      expect(outcome.stdout).toHaveLength(1);
+      expect(() => JSON.parse(outcome.stdout[0]!)).not.toThrow();
+    });
+
+    it("success: shape has ok, resourcePlans, endpointMappings, resourceValidations", async () => {
+      const configPath = await writeRepositoryConfig(validateConfig);
+
+      const outcome = await runCli([
+        "validate",
+        "--config", configPath,
+        "--worktree-id", "wt-shape-validate",
+        "--providers", providersModulePath
+      ]);
+
+      const parsed = JSON.parse(outcome.stdout[0]!);
+      expect(parsed.ok).toBe(true);
+      expect(Array.isArray(parsed.resourcePlans)).toBe(true);
+      expect(Array.isArray(parsed.endpointMappings)).toBe(true);
+      expect(Array.isArray(parsed.resourceValidations)).toBe(true);
+    });
+
+    it("success: ResourceValidation entries have resourceName, provider, worktreeId, capability", async () => {
+      const configPath = await writeRepositoryConfig(validateConfig);
+
+      const outcome = await runCli([
+        "validate",
+        "--config", configPath,
+        "--worktree-id", "wt-shape-validate",
+        "--providers", providersModulePath
+      ]);
+
+      const parsed = JSON.parse(outcome.stdout[0]!);
+      const validation = parsed.resourceValidations[0];
+      expect(validation).toHaveProperty("resourceName");
+      expect(validation).toHaveProperty("provider");
+      expect(validation).toHaveProperty("worktreeId");
+      expect(validation.capability).toBe("validate");
+    });
+  });
+
+  // ── reset ─────────────────────────────────────────────────────────────────
+
+  describe("reset", () => {
+    it("success: one JSON line to stdout, exit 0, stderr empty", async () => {
+      const configPath = await writeRepositoryConfig(resetConfig);
+
+      const outcome = await runCli([
+        "reset",
+        "--config", configPath,
+        "--worktree-id", "wt-shape-reset",
+        "--providers", providersModulePath
+      ]);
+
+      expect(outcome.exitCode).toBe(0);
+      expect(outcome.stderr).toHaveLength(0);
+      expect(outcome.stdout).toHaveLength(1);
+      expect(() => JSON.parse(outcome.stdout[0]!)).not.toThrow();
+    });
+
+    it("success: shape has ok, resourcePlans, resourceResets", async () => {
+      const configPath = await writeRepositoryConfig(resetConfig);
+
+      const outcome = await runCli([
+        "reset",
+        "--config", configPath,
+        "--worktree-id", "wt-shape-reset",
+        "--providers", providersModulePath
+      ]);
+
+      const parsed = JSON.parse(outcome.stdout[0]!);
+      expect(parsed.ok).toBe(true);
+      expect(Array.isArray(parsed.resourcePlans)).toBe(true);
+      expect(Array.isArray(parsed.resourceResets)).toBe(true);
+    });
+
+    it("success: ResourceReset entries have resourceName, provider, worktreeId, capability", async () => {
+      const configPath = await writeRepositoryConfig(resetConfig);
+
+      const outcome = await runCli([
+        "reset",
+        "--config", configPath,
+        "--worktree-id", "wt-shape-reset",
+        "--providers", providersModulePath
+      ]);
+
+      const parsed = JSON.parse(outcome.stdout[0]!);
+      const resetEntry = parsed.resourceResets[0];
+      expect(resetEntry).toHaveProperty("resourceName");
+      expect(resetEntry).toHaveProperty("provider");
+      expect(resetEntry).toHaveProperty("worktreeId");
+      expect(resetEntry.capability).toBe("reset");
+    });
+  });
+
+  // ── cleanup ───────────────────────────────────────────────────────────────
+
+  describe("cleanup", () => {
+    it("success: one JSON line to stdout, exit 0, stderr empty", async () => {
+      const configPath = await writeRepositoryConfig(cleanupConfig);
+
+      const outcome = await runCli([
+        "cleanup",
+        "--config", configPath,
+        "--worktree-id", "wt-shape-cleanup",
+        "--providers", providersModulePath
+      ]);
+
+      expect(outcome.exitCode).toBe(0);
+      expect(outcome.stderr).toHaveLength(0);
+      expect(outcome.stdout).toHaveLength(1);
+      expect(() => JSON.parse(outcome.stdout[0]!)).not.toThrow();
+    });
+
+    it("success: shape has ok, resourcePlans, resourceCleanups", async () => {
+      const configPath = await writeRepositoryConfig(cleanupConfig);
+
+      const outcome = await runCli([
+        "cleanup",
+        "--config", configPath,
+        "--worktree-id", "wt-shape-cleanup",
+        "--providers", providersModulePath
+      ]);
+
+      const parsed = JSON.parse(outcome.stdout[0]!);
+      expect(parsed.ok).toBe(true);
+      expect(Array.isArray(parsed.resourcePlans)).toBe(true);
+      expect(Array.isArray(parsed.resourceCleanups)).toBe(true);
+    });
+
+    it("success: ResourceCleanup entries have resourceName, provider, worktreeId, capability", async () => {
+      const configPath = await writeRepositoryConfig(cleanupConfig);
+
+      const outcome = await runCli([
+        "cleanup",
+        "--config", configPath,
+        "--worktree-id", "wt-shape-cleanup",
+        "--providers", providersModulePath
+      ]);
+
+      const parsed = JSON.parse(outcome.stdout[0]!);
+      const cleanupEntry = parsed.resourceCleanups[0];
+      expect(cleanupEntry).toHaveProperty("resourceName");
+      expect(cleanupEntry).toHaveProperty("provider");
+      expect(cleanupEntry).toHaveProperty("worktreeId");
+      expect(cleanupEntry.capability).toBe("cleanup");
+    });
+  });
+
+  // ── run ───────────────────────────────────────────────────────────────────
+
+  describe("run", () => {
+    it("success: stdout and stderr empty (transparent pass-through)", async () => {
+      const configPath = await writeRepositoryConfig(baseConfig);
+      const runner: ChildProcessRunner = async () => ({ exitCode: 0 });
+
+      const outcome = await runCli(
+        [
+          "run",
+          "--config", configPath,
+          "--worktree-id", "wt-shape-run",
+          "--providers", providersModulePath,
+          "--",
+          "node",
+          "-e",
+          ""
+        ],
+        { runner }
+      );
+
+      expect(outcome.exitCode).toBe(0);
+      expect(outcome.stdout).toHaveLength(0);
+      expect(outcome.stderr).toHaveLength(0);
+    });
+
+    it("success: exit code reflects child process exit code", async () => {
+      const configPath = await writeRepositoryConfig(baseConfig);
+      const runner: ChildProcessRunner = async () => ({ exitCode: 42 });
+
+      const outcome = await runCli(
+        [
+          "run",
+          "--config", configPath,
+          "--worktree-id", "wt-shape-run-exit",
+          "--providers", providersModulePath,
+          "--",
+          "node",
+          "-e",
+          "process.exit(42)"
+        ],
+        { runner }
+      );
+
+      expect(outcome.exitCode).toBe(42);
+      expect(outcome.stdout).toHaveLength(0);
+      expect(outcome.stderr).toHaveLength(0);
+    });
+
+    it("refusal: JSON written to stderr, stdout empty, exit 1", async () => {
+      // Refusal is triggered by an invalid provider reference
+      const configPath = await writeRepositoryConfig({
+        resources: [
+          {
+            name: "app-db",
+            provider: "nonexistent-provider",
+            isolationStrategy: "name-scoped",
+            scopedValidate: false,
+            scopedReset: false,
+            scopedCleanup: false
+          }
+        ],
+        endpoints: []
+      });
+
+      const outcome = await runCli([
+        "run",
+        "--config", configPath,
+        "--worktree-id", "wt-shape-run-refusal",
+        "--providers", providersModulePath,
+        "--",
+        "node",
+        "-e",
+        ""
+      ]);
+
+      expect(outcome.exitCode).toBe(1);
+      expect(outcome.stdout).toHaveLength(0);
+      expect(outcome.stderr).toHaveLength(1);
+      const parsed = JSON.parse(outcome.stderr[0]!);
+      expect(parsed.ok).toBe(false);
+      expect(parsed.refusal).toHaveProperty("category");
+      expect(parsed.refusal).toHaveProperty("reason");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Second 0.7.x slice. Audit identified that no source-of-truth spec exists for CLI output shapes — `current-state.md` names this explicitly as a 0.7.x gap: "no output-format spec exists for `derive`, `validate`, `reset`, `cleanup` result shapes." Without a spec, output field names are implicit and could silently change in a minor version.

## Scope

- `docs/spec/cli-output-shapes.md` — new spec document covering all primary commands: success/failure JSON shapes, shared object shapes (`DerivedResourcePlan`, `DerivedEndpointMapping`, `ResourceValidation`, `ResourceReset`, `ResourceCleanup`), refusal shape and four categories, output routing (stdout vs stderr), the one-JSON-line-per-invocation rule, `derive --format=env` KEY=VALUE convention, and the `run` stdout/stderr asymmetry (refusal to stderr, unlike other commands — documented explicitly, not changed)
- `tests/acceptance/cli-output-shapes.acceptance.test.ts` — 20 acceptance tests that make the spec executable: field presence, output routing, exit codes, and JSON parseability for all primary commands in success and failure paths
- `docs/development/tasks/dev-slice-51-task-01.md` — task doc
- `docs/development/current-state.md` — Slice 51 proving result

No production code was changed.

## Validation

- `pnpm test:acceptance` — 225/225 pass
- `pnpm test` — 349/349 pass

## Deferred

- `validate-worktree` / `validate-repository` output shape and surface classification — needs a design decision about removal/move/keep; the Slice 50 help text already visually separates them from primary commands
- Per-command help text
- Changing any output shape (this slice documents existing shapes; shape changes are a separate product decision)

🤖 Generated with [Claude Code](https://claude.com/claude-code)