### PR TITLE
slice-52: complete Options section in --help and retire stale current-state guidance

### DIFF
--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -186,10 +186,16 @@ const USAGE_LINES = [
   "  validate-worktree    --worktree-id VALUE",
   "  validate-repository  --config PATH",
   "",
+  "Options:",
+  "  --help, -h           Show this help text and exit 0",
+  "",
   "Options (derive, validate, reset, cleanup, run):",
   "  --config PATH        Repository configuration file (default: ./multiverse.json)",
   "  --providers MODULE   Providers module path (default: ./providers.ts)",
   "  --worktree-id VALUE  Worktree identity (auto-discovered from git state when omitted)",
+  "",
+  "Options (derive only):",
+  "  --format json|env    Output format (default: json)",
 ];
 
 function help(): CliResult {

--- a/docs/development/current-state.md
+++ b/docs/development/current-state.md
@@ -352,6 +352,16 @@ field names, output routing, and exit codes for every primary command in both su
 paths. No production code was changed. Deferred: `validate-worktree`/`validate-repository`
 output shape classification; per-command help; utility-command surface classification.
 
+**Is the `--help` Options section complete — does it document all supported flags?**
+
+Slice 52 answers yes, after two additions to `USAGE_LINES`. The Options section introduced in
+Slice 50 omitted two flags: (1) `--help` / `-h` itself — the help text did not self-describe the
+flag that produces it; (2) `--format json|env` — visible in the derive command line but not
+described in the Options section. Both are now listed in named subsections: a global "Options:"
+for `--help`/`-h` and "Options (derive only):" for `--format`. The `current-state.md` "What
+kinds of work" section was also updated to retire the two completed items (help-output and
+output-shape entries) and bring the "Practical instruction" guidance current.
+
 ## Current priority
 
 The current priority is:
@@ -360,12 +370,16 @@ The current priority is:
 
 ## What kinds of work are highest-value right now
 
-Examples of work that are strongly aligned with the current `0.7.x` phase:
+The following 0.7.x items are complete:
 
-* auditing and improving CLI help output (the current `--help` surface is a raw usage string, not a structured help system)
-* examining whether `validate-worktree` and `validate-repository` utility commands belong on the same surface as `derive`, `run`, `reset`, `cleanup`, `validate`
-* specifying expected output shape for each command in source-of-truth docs (no output-format spec exists for `derive`, `validate`, `reset`, `cleanup` result shapes)
-* aligning guide examples with actual invocation surface
+* ~~auditing and improving CLI help output~~ — done (Slice 50): `--help`/`-h` exit 0, structured multi-line USAGE_LINES
+* ~~specifying expected output shape for each command in source-of-truth docs~~ — done (Slice 51): `docs/spec/cli-output-shapes.md` with executable acceptance tests
+* ~~completing the `--help` Options section~~ — done (Slice 52): `--help`/`-h` and `--format` now described in Options subsections
+
+Examples of work still aligned with the current `0.7.x` phase:
+
+* examining whether `validate-worktree` and `validate-repository` utility commands belong on the same surface as `derive`, `run`, `reset`, `cleanup`, `validate` (deferred — needs a design decision about removal/move; Slice 50 USAGE_LINES visually separates them)
+* aligning guide examples with actual invocation surface (guide is largely accurate after Slices 36–49; outstanding items are minor)
 * reducing inconsistencies between repo-local (`pnpm cli`) and formal binary (`multiverse`) invocation paths in docs and guides
 
 ## What is intentionally deferred
@@ -389,10 +403,10 @@ to relearn it between minor versions?**
 
 Use this preference order:
 
-1. audit the CLI surface before changing it — identify specific inconsistencies across help text, output shape, flag naming, and guide examples
-2. establish expected output shapes and invocation conventions in source-of-truth docs before modifying code
-3. assess whether utility commands (`validate-worktree`, `validate-repository`) belong on the same public surface as the primary commands
-4. only then implementation changes that align code with the stabilized surface spec
+1. audit the remaining guide and documentation surface for inconsistencies with the now-established help text (Slice 50), output shape spec (Slice 51), and complete Options section (Slice 52)
+2. assess whether utility commands (`validate-worktree`, `validate-repository`) belong on the same public surface as the primary commands — this requires a design decision; do not conflate it with guide cleanup
+3. address any remaining inconsistencies between repo-local (`pnpm cli`) and formal binary (`multiverse`) invocation paths in docs and guides
+4. implementation changes only when the spec or guide alignment work clearly requires them
 
 ## Related documents
 

--- a/docs/development/tasks/dev-slice-52-task-01.md
+++ b/docs/development/tasks/dev-slice-52-task-01.md
@@ -1,0 +1,84 @@
+# Dev Slice 52 — Task 01
+
+## Title
+
+Public surface stability — complete the `--help` Options section and retire stale guidance
+
+## Sources of truth
+
+- `docs/development/current-state.md` — "What kinds of work are highest-value right now"
+  lists "auditing and improving CLI help output" and "specifying expected output shape" as
+  pending; both are done (Slices 50–51) but the section was not updated
+- `docs/development/roadmap.md` — 0.7.x goal: "CLI help text" and "common command flows feel
+  intentional rather than provisional"
+- `apps/cli/src/index.ts` — `USAGE_LINES` constant introduced in Slice 50
+
+## Audit findings
+
+### `USAGE_LINES` Options section is incomplete
+
+Slice 50 introduced structured help text with an Options section that lists three common flags.
+Two flags are missing from the Options section:
+
+1. **`--help` / `-h`** — added in Slice 50, works correctly, but the help text does not
+   self-describe it. A user reading `--help` output cannot tell that `--help` is itself a
+   supported flag from the Options section.
+
+2. **`--format`** — visible in the derive command line as `[--format json|env]` but has no
+   entry in the Options section with a description or default. This makes the help text look
+   inconsistently structured.
+
+### `current-state.md` guidance section is stale
+
+The "What kinds of work are highest-value right now" section still lists two items as pending
+that are now complete:
+- "the current `--help` surface is a raw usage string, not a structured help system" (done, Slice 50)
+- "no output-format spec exists for `derive`, `validate`, `reset`, `cleanup` result shapes" (done, Slice 51)
+
+The "Practical instruction" numbered list references steps 1–4 in a sequence that was valid
+before Slices 50–51; steps 1 and 2 are now mostly done.
+
+Leaving these stale causes future contributors and coding agents to attempt work that is already
+complete.
+
+## In scope
+
+- `apps/cli/src/index.ts`
+  - Extend `USAGE_LINES` to include an "Options:" subsection for `--help`/`-h`
+  - Add a separate "Options (derive only):" subsection for `--format json|env` with a default
+    note
+  - No other code changes
+
+- `tests/acceptance/cli-help-flag.acceptance.test.ts`
+  - Add tests that the help text includes `--help` in the Options section
+  - Add tests that the help text includes `--format` in the Options section
+
+- `docs/development/current-state.md`
+  - Remove the two stale bullets from "What kinds of work are highest-value right now"
+    (help-output and output-shape items are done)
+  - Update "Practical instruction for contributors and agents" to reflect current state
+  - Add Slice 52 proving result
+
+- `docs/development/tasks/dev-slice-52-task-01.md` (this file)
+
+## Out of scope
+
+- Changing any flag names or CLI behavior
+- Utility-command classification (`validate-worktree`, `validate-repository`) — still deferred,
+  needs a design decision
+- Per-command help text
+- Guide updates (guide already accurately describes invocation; cross-referencing the output
+  spec is a possible future slice but is not the load-bearing gap here)
+- Output shape changes
+
+## Acceptance criteria
+
+- `runCli(["--help"]).stdout.join("\n")` contains `--help` in the Options section
+- `runCli(["--help"]).stdout.join("\n")` contains `--format` in the Options section
+- All existing `--help` exit-code and output-routing tests continue to pass
+- `current-state.md` "What kinds of work" no longer lists done items as pending
+- `pnpm test:acceptance` and `pnpm test` pass
+
+## Safety / refusal expectations
+
+No refusal behavior is touched. The `USAGE_LINES` change is additive only (new lines added).

--- a/tests/acceptance/cli-help-flag.acceptance.test.ts
+++ b/tests/acceptance/cli-help-flag.acceptance.test.ts
@@ -50,4 +50,17 @@ describe("CLI --help flag (Slice 50)", () => {
     expect(outcome.stderr.length).toBeGreaterThan(0);
     expect(outcome.stderr.join("\n")).toContain("Usage:");
   });
+
+  it("--help output includes --help / -h in the Options section", async () => {
+    const outcome = await runCli(["--help"]);
+    const text = outcome.stdout.join("\n");
+    expect(text).toContain("--help");
+    expect(text).toContain("-h");
+  });
+
+  it("--help output includes --format in the Options section", async () => {
+    const outcome = await runCli(["--help"]);
+    const text = outcome.stdout.join("\n");
+    expect(text).toMatch(/--format\s+json\|env/);
+  });
 });


### PR DESCRIPTION
## Summary

Third 0.7.x slice. Audit found two gaps introduced by Slice 50's structured help text:

1. `--help`/`-h` was not self-described in the Options section — a user reading `--help` output could not tell that `--help` is itself a supported flag
2. `--format json|env` was visible in the derive command line but had no Options-section entry with a description or default

Also: the `current-state.md` "What kinds of work are highest-value right now" section still listed the Slice 50 (help output) and Slice 51 (output shapes) items as pending, causing future contributors and agents to attempt already-completed work.

## Scope

- `apps/cli/src/index.ts` — extended `USAGE_LINES` with a global `Options:` subsection for `--help`/`-h` and a new `Options (derive only):` subsection for `--format json|env`
- `tests/acceptance/cli-help-flag.acceptance.test.ts` — two new tests: `--help` output contains `--help`/`-h` in Options; `--help` output contains `--format` in Options
- `docs/development/current-state.md` — Slice 52 proving result; retired completed "What kinds of work" bullets; updated "Practical instruction" sequence to reflect current state through Slice 52
- `docs/development/tasks/dev-slice-52-task-01.md` — task doc

## Validation

- `pnpm test:acceptance` — 227/227 pass
- `pnpm cli --help` verified: structured output, all three Options subsections present, exit 0

## Deferred

- Utility-command (`validate-worktree`/`validate-repository`) surface classification — still needs a design decision; noted in updated current-state guidance
- Per-command help text
- Guide cross-reference to output spec (guide is largely accurate; this is a minor enhancement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)