### PR TITLE
slice-53: align README and guide with established CLI surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ pnpm test:acceptance
 pnpm test:contracts
 pnpm test:unit
 pnpm typecheck
-pnpm cli
+pnpm cli --help
 ```
 
 ## CLI usage
@@ -204,6 +204,7 @@ Core product and architecture docs:
 * `docs/spec/provider-model.md`
 * `docs/spec/endpoint-model.md`
 * `docs/spec/safety-and-refusal.md`
+* `docs/spec/cli-output-shapes.md` — stable output contract for all primary commands (JSON shapes, field names, output routing)
 * `docs/adr/0001-git-worktrees-only-1.0.md`
 * `docs/adr/0004-resource-isolation-strategies.md`
 * `docs/adr/0005-providers-implement-isolation-contracts.md`

--- a/docs/development/current-state.md
+++ b/docs/development/current-state.md
@@ -362,6 +362,19 @@ for `--help`/`-h` and "Options (derive only):" for `--format`. The `current-stat
 kinds of work" section was also updated to retire the two completed items (help-output and
 output-shape entries) and bring the "Practical instruction" guidance current.
 
+**Are the README and external-demo-guide aligned with the now-established CLI surface artifacts?**
+
+Slice 53 answers yes, after four targeted corrections. (1) `README.md` "Common commands" listed
+bare `pnpm cli` — which exits 1 with usage to stderr — alongside `pnpm test` and other useful
+bare invocations; corrected to `pnpm cli --help`. (2) `README.md` "Key docs" did not list
+`docs/spec/cli-output-shapes.md`, making the output-shape spec (Slice 51) undiscoverable from
+the repository entry point; added with a one-line description. (3) The guide Reference section
+documented all primary commands and common flags but omitted the `--help`/`-h` flag established
+in Slice 50; a sentence directing readers to `pnpm cli --help` is now included. (4) Guide Step 6
+showed `derive` in both output formats but provided no pointer to the JSON field contract; a
+sentence referencing `docs/spec/cli-output-shapes.md` is now included. No code or test changes
+were required.
+
 ## Current priority
 
 The current priority is:
@@ -376,11 +389,14 @@ The following 0.7.x items are complete:
 * ~~specifying expected output shape for each command in source-of-truth docs~~ — done (Slice 51): `docs/spec/cli-output-shapes.md` with executable acceptance tests
 * ~~completing the `--help` Options section~~ — done (Slice 52): `--help`/`-h` and `--format` now described in Options subsections
 
+The following 0.7.x items are also complete:
+
+* ~~aligning guide examples with actual invocation surface~~ — done (Slice 53): README and guide now reference `--help`/`-h`, `cli-output-shapes.md`, and use `pnpm cli --help` as the bare invocation entry point
+* ~~reducing inconsistencies between repo-local (`pnpm cli`) and formal binary (`multiverse`) invocation paths in docs~~ — done (Slice 53): README Common commands now shows `pnpm cli --help` rather than exit-1 bare `pnpm cli`
+
 Examples of work still aligned with the current `0.7.x` phase:
 
 * examining whether `validate-worktree` and `validate-repository` utility commands belong on the same surface as `derive`, `run`, `reset`, `cleanup`, `validate` (deferred — needs a design decision about removal/move; Slice 50 USAGE_LINES visually separates them)
-* aligning guide examples with actual invocation surface (guide is largely accurate after Slices 36–49; outstanding items are minor)
-* reducing inconsistencies between repo-local (`pnpm cli`) and formal binary (`multiverse`) invocation paths in docs and guides
 
 ## What is intentionally deferred
 
@@ -403,10 +419,12 @@ to relearn it between minor versions?**
 
 Use this preference order:
 
-1. audit the remaining guide and documentation surface for inconsistencies with the now-established help text (Slice 50), output shape spec (Slice 51), and complete Options section (Slice 52)
-2. assess whether utility commands (`validate-worktree`, `validate-repository`) belong on the same public surface as the primary commands — this requires a design decision; do not conflate it with guide cleanup
-3. address any remaining inconsistencies between repo-local (`pnpm cli`) and formal binary (`multiverse`) invocation paths in docs and guides
-4. implementation changes only when the spec or guide alignment work clearly requires them
+1. assess whether utility commands (`validate-worktree`, `validate-repository`) belong on the same public surface as the primary commands — this requires a design decision; do not conflate it with guide cleanup
+2. implementation changes only when the spec or guide alignment work clearly requires them
+
+Note: guide and README alignment with help text (Slice 50), output shape spec (Slice 51), Options
+section (Slice 52), and invocation surface (Slice 53) is now complete. Do not attempt these as
+pending work.
 
 ## Related documents
 

--- a/docs/development/tasks/dev-slice-53-task-01.md
+++ b/docs/development/tasks/dev-slice-53-task-01.md
@@ -1,0 +1,79 @@
+# Dev Slice 53 — Task 01
+
+## Title
+
+Guide and README alignment with established CLI surface (Slices 50–52)
+
+## Sources of truth
+
+- `docs/development/current-state.md` — "Practical instruction" step 1 lists "audit the remaining
+  guide and documentation surface for inconsistencies with the now-established help text (Slice 50),
+  output shape spec (Slice 51), and complete Options section (Slice 52)" as the top priority
+- `docs/development/roadmap.md` — 0.7.x goal: guide examples feel intentional rather than provisional
+- `README.md` — `pnpm cli` in Common commands block exits 1 with no args; `Key docs` omits
+  `docs/spec/cli-output-shapes.md`
+- `docs/guides/external-demo-guide.md` — Reference section does not mention `--help`/`-h`;
+  Step 6 does not point readers to the output-shape spec
+
+## Audit findings
+
+### `README.md` — Common commands block
+
+`pnpm cli` is listed alongside `pnpm test`, `pnpm test:acceptance`, etc. in the "Common commands"
+block. Unlike the others, `pnpm cli` with no arguments exits 1 and writes usage to stderr —
+it is not a useful bare invocation. `pnpm cli --help` is already shown in the "CLI usage" section
+below; the Common commands block should surface the same form.
+
+### `README.md` — Key docs section
+
+`docs/spec/cli-output-shapes.md` (added in Slice 51) is not listed. A contributor reading
+`README.md` cannot discover it from the Key docs section.
+
+### Guide — Reference section
+
+The Reference section documents all primary commands and common flags but does not mention
+`--help`/`-h`, which was added as a supported flag in Slice 50 and documented in Slice 52.
+
+### Guide — Step 6
+
+Step 6 shows `derive` in both JSON and env formats but does not point readers to
+`docs/spec/cli-output-shapes.md` for the authoritative JSON field contract. A reader
+wishing to parse the JSON output has no pointer to the spec.
+
+## In scope
+
+- `README.md`
+  - Change `pnpm cli` → `pnpm cli --help` in Common commands block
+  - Add `docs/spec/cli-output-shapes.md` to the "Core product and architecture docs" list
+    in the Key docs section
+
+- `docs/guides/external-demo-guide.md`
+  - Reference section: add a note that `pnpm cli --help` shows the full option list
+  - Step 6: add a sentence pointing to `docs/spec/cli-output-shapes.md` for JSON field details
+
+- `docs/development/current-state.md`
+  - Add Slice 53 proving result
+  - Update "What kinds of work are highest-value right now" to reflect that
+    guide/README alignment is now complete
+
+- `docs/development/tasks/dev-slice-53-task-01.md` (this file)
+
+## Out of scope
+
+- Utility-command classification (`validate-worktree`, `validate-repository`) — deferred
+- Per-command help text
+- Any CLI behavior or code changes
+- Test changes (no new executable contract introduced)
+- Guide restructuring or new guide sections
+
+## Acceptance criteria
+
+- `README.md` Common commands block contains `pnpm cli --help`, not bare `pnpm cli`
+- `README.md` Key docs section lists `docs/spec/cli-output-shapes.md`
+- Guide Reference section mentions `--help`/`-h`
+- Guide Step 6 references `docs/spec/cli-output-shapes.md`
+- `pnpm test` passes (no code changes; existing tests continue to pass)
+
+## Safety / refusal expectations
+
+No code changes. No refusal behavior is touched.

--- a/docs/guides/external-demo-guide.md
+++ b/docs/guides/external-demo-guide.md
@@ -320,6 +320,9 @@ The `--format env` output includes the canonical `MULTIVERSE_RESOURCE_*` and
 injected only by `pnpm cli run` at process-launch time. Use `derive --format=env` for
 inspection and scripting against canonical variable names.
 
+For the authoritative JSON field contract (field names, shapes, and output routing for all
+primary commands), see `docs/spec/cli-output-shapes.md`.
+
 ---
 
 ## Step 7 — Reset and clean up
@@ -347,6 +350,8 @@ Cleanup only affects resources that declare `scopedCleanup: true` in `multiverse
 ## Reference: CLI options
 
 All Multiverse commands use these options. `--config` and `--providers` default to `./multiverse.json` and `./providers.ts` respectively. `--worktree-id` is optional when invoked from inside a git worktree — Multiverse discovers the identity from the worktree path automatically. Pass `--worktree-id` explicitly to override. All flags accept both space form (`--flag value`) and equals form (`--flag=value`).
+
+Run `pnpm cli --help` (or `pnpm cli -h`) to print the full command and options list.
 
 ```
 pnpm cli run       [--config PATH] [--providers MODULE] [--worktree-id VALUE] -- <cmd> [args...]


### PR DESCRIPTION
## Summary

Aligns README and external-demo-guide with the CLI surface established in Slices 50–52.
Four targeted corrections — no code or test changes.

## Scope

- `README.md`: `pnpm cli` → `pnpm cli --help` in Common commands (bare `pnpm cli` exits 1 with usage to stderr); added `docs/spec/cli-output-shapes.md` to Key docs
- `docs/guides/external-demo-guide.md`: Reference section now mentions `pnpm cli --help`/`-h`; Step 6 now points to `docs/spec/cli-output-shapes.md` for JSON field contract
- `docs/development/current-state.md`: Slice 53 proving result; retired stale guide/README alignment bullets; updated Practical instruction
- `docs/development/tasks/dev-slice-53-task-01.md`: task doc

## Validation

`pnpm test` — 351 tests passed (54 test files). No code changes; all existing tests continue to pass.

## Deferred

- Utility-command classification (`validate-worktree`, `validate-repository`) — still needs a design decision