### PR TITLE
slice-56: remove validate-worktree from CLI surface (Option B)

### DIFF
--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -9,8 +9,7 @@ import {
   deriveAndValidateOne,
   resetOneResource,
   deriveOne,
-  validateRepositoryConfiguration,
-  validateWorktreeIdentity
+  validateRepositoryConfiguration
 } from "@multiverse/core";
 import type {
   DeriveOneResult,
@@ -185,7 +184,6 @@ const USAGE_LINES = [
   "  run        [--config PATH] [--providers MODULE] [--worktree-id VALUE] -- <cmd> [args...]",
   "",
   "Utility commands (declaration validation):",
-  "  validate-worktree    --worktree-id VALUE",
   "  validate-repository  --config PATH",
   "",
   "Options:",
@@ -521,19 +519,6 @@ async function defaultChildProcessRunner(input: {
   });
 }
 
-async function handleValidateWorktree(args: string[]): Promise<CliResult> {
-  const worktreeId = readRequiredOption(args, "--worktree-id");
-  if (isCliResult(worktreeId)) {
-    return worktreeId;
-  }
-
-  const result = validateWorktreeIdentity({
-    worktreeId
-  });
-
-  return result.ok ? success(result) : failure(result);
-}
-
 async function handleValidateRepository(args: string[]): Promise<CliResult> {
   const configPath = readRequiredOption(args, "--config");
   if (isCliResult(configPath)) {
@@ -659,10 +644,6 @@ export async function runCli(args: string[], options: RunCliOptions = {}): Promi
 
   if (command === "--help" || command === "-h") {
     return help();
-  }
-
-  if (command === "validate-worktree") {
-    return handleValidateWorktree(args);
   }
 
   if (command === "validate-repository") {

--- a/docs/adr/0021-git-worktree-path-conventional-default-for-worktree-id.md
+++ b/docs/adr/0021-git-worktree-path-conventional-default-for-worktree-id.md
@@ -6,6 +6,13 @@ Accepted
 
 Amends ADR-0014.
 
+Amended by Slice 56: the `validate-worktree` CLI command was removed. The rationale
+follows directly from this ADR — inline validation of worktree identity is now embedded
+in every primary command's path via `discoverWorktreeId` / `readCommonOptions`. The
+standalone command replicated existing behavior without adding user-facing value. The
+`validateWorktreeIdentity` core function is retained for internal use by the CLI's
+auto-discovery path.
+
 ## Context
 
 ADR-0014 established conventional defaults for `--config` and `--providers` but

--- a/docs/development/current-state.md
+++ b/docs/development/current-state.md
@@ -409,10 +409,32 @@ discovery, worktree identity validation is embedded in every primary command's p
 standalone command largely redundant; (2) whether to restructure these commands or document them
 as diagnostic tools in the guide.
 
-Examples of work still aligned with the current `0.7.x` phase:
+**Is `validate-worktree` removed, and is the CLI surface now fully intentional?**
 
-* determining whether `validate-worktree` should be retained or removed — now that auto-discovery (Slice 37) validates worktree identity inline, the standalone command has limited additional value; this requires a product decision
-* determining whether utility commands should be restructured (e.g., subcommand namespace) or documented in the guide as diagnostic tools — requires a product decision / new ADR
+Slice 56 answers yes. Option B from the utility-command decision memo was implemented.
+`validate-worktree` is removed from the CLI surface: its dispatch case, handler function,
+and import are removed from `apps/cli/src/index.ts`; its entry is removed from `USAGE_LINES`;
+affected acceptance tests are updated. The `validateWorktreeIdentity` core function is
+retained — it is still used internally by the CLI's auto-discovery path. The rationale note
+is added to ADR-0021: inline validation in primary commands (established by that ADR) makes
+the standalone command redundant. `validate-repository` is retained as the sole utility
+command; it provides standalone config-linting value that no primary command replicates.
+The decision memo status is updated to Resolved.
+
+The `0.7.x` public surface stability wave is now complete in substance:
+- `--help`/`-h` exit code and structured help text — Slice 50
+- CLI output-shape spec and executable acceptance tests — Slice 51
+- `--help` Options section completeness — Slice 52
+- README and guide alignment — Slice 53
+- Utility-command classification and section label — Slice 54
+- Utility-command decision memo and option framing — Slice 55
+- `validate-worktree` removal — Slice 56
+
+Remaining 0.7.x open items:
+
+* `validate-repository` guide documentation — optional; no urgency; no user workflow
+  currently depends on it being in the guide
+* utility command subcommand restructuring — explicitly deferred to post-0.7.x if desired
 
 ## What is intentionally deferred
 
@@ -433,12 +455,13 @@ When deciding what to work on next, prefer work that answers the current proving
 output format conventions — stable and intentional enough that a user would not be forced
 to relearn it between minor versions?**
 
-The decision memo at `docs/development/tasks/utility-command-surface-decision-memo.md`
-frames the remaining open product question and recommends Option B (keep `validate-repository`,
-remove `validate-worktree`). **That decision requires owner input before any implementation.**
+The `0.7.x` public surface stability wave is complete in substance (Slices 50–56).
+The CLI surface is now intentional: primary commands, one utility command
+(`validate-repository`), structured help text, output-shape spec, and aligned docs/guide.
 
-Do not implement command-surface changes without an explicit decision on this memo.
-Do not attempt guide/README/help-output work — those are complete (Slices 50–54).
+Do not attempt Slices 50–56 work as if it were pending — it is complete.
+Post-0.7.x candidates: `validate-repository` guide docs, utility-command subcommand
+restructuring (deferred), outside-workspace packaging (always deferred).
 
 If the decision is made:
 

--- a/docs/development/tasks/dev-slice-56-task-01.md
+++ b/docs/development/tasks/dev-slice-56-task-01.md
@@ -1,0 +1,85 @@
+# Dev Slice 56 — Task 01
+
+## Title
+
+Remove `validate-worktree` (Option B from utility-command decision memo)
+
+## Decision authority
+
+`docs/development/tasks/utility-command-surface-decision-memo.md` — Option B chosen.
+
+## Rationale
+
+`validate-worktree` validated that a worktree identity string is non-empty and non-blank.
+ADR-0021 (Slice 37) embedded that same validation into every primary command's path via
+`discoverWorktreeId` / `readCommonOptions`. A caller who passes an invalid or missing
+`--worktree-id` to any primary command receives an actionable refusal. The standalone
+command replicates existing inline behavior without adding user-facing value.
+
+`validate-repository` is retained: it lints a config file independently of providers,
+worktree identity, and git state. That capability has no equivalent elsewhere on the surface.
+
+The `validateWorktreeIdentity` function in `@multiverse/core` is NOT removed — it is still
+used internally by the CLI's auto-discovery path (`discoverWorktreeId`). Only the CLI
+command that exposed it as a standalone surface is removed.
+
+## In scope
+
+- `apps/cli/src/index.ts`
+  - Remove `validateWorktreeIdentity` from the named import
+  - Remove `handleValidateWorktree` function
+  - Remove `validate-worktree` dispatch case from `runCli()`
+  - Remove `"  validate-worktree    --worktree-id VALUE"` from `USAGE_LINES`
+
+- `tests/acceptance/dev-slice-10.acceptance.test.ts`
+  - Remove the two `validate-worktree` test cases
+  - Keep all `validate-repository` and `derive` test cases
+
+- `tests/acceptance/dev-slice-41.acceptance.test.ts`
+  - Remove the test that verifies `validate-worktree` appears in the usage string
+  - Update the file description comment
+
+- `tests/acceptance/cli-help-flag.acceptance.test.ts`
+  - Update the utility-section-label test to verify the label precedes
+    `validate-repository` only (not `validate-worktree`)
+
+- `docs/adr/0021-git-worktree-path-conventional-default-for-worktree-id.md`
+  - Add a short amendment note: `validate-worktree` removed; rationale follows from
+    this ADR (inline validation in primary commands makes standalone command redundant)
+
+- `docs/development/tasks/utility-command-surface-decision-memo.md`
+  - Mark the memo status as "Resolved — Option B implemented (Slice 56)"
+
+- `docs/development/current-state.md`
+  - Add Slice 56 proving result
+
+- `docs/development/tasks/dev-slice-56-task-01.md` (this file)
+
+## Out of scope
+
+- Removing `validateWorktreeIdentity` from `@multiverse/core` — internal function, still
+  used by `discoverWorktreeId` in the CLI
+- Removing unit tests in `tests/unit/worktree-identity-boundary.test.ts` — they test the
+  core function, not the CLI command
+- Renaming or restructuring `validate-repository`
+- Adding `validate-repository` to the guide
+- Any CLI behavior changes beyond the removal
+- Guide redesign or new doc sections
+
+## Acceptance criteria
+
+- `runCli(["validate-worktree", "--worktree-id", "x"])` returns exit 1 with usage
+  to stderr (unknown command fallback)
+- `runCli(["validate-repository", "--config", configPath])` still works correctly
+- `runCli(["--help"]).stdout.join("\n")` does not contain `validate-worktree`
+- `runCli(["--help"]).stdout.join("\n")` still contains `validate-repository`
+- `runCli(["--help"]).stdout.join("\n")` still contains the `Utility commands` label
+- `pnpm test` passes
+
+## Compatibility note
+
+This is a breaking change for any caller that uses `validate-worktree` directly.
+The command is not documented in the guide, has no scenario coverage, and has no
+established external user workflow. The blast radius is expected to be minimal.
+Callers that need worktree identity validation can run any primary command with the
+target worktree id and inspect the refusal if the id is invalid.

--- a/docs/development/tasks/utility-command-surface-decision-memo.md
+++ b/docs/development/tasks/utility-command-surface-decision-memo.md
@@ -2,7 +2,12 @@
 
 ## Status
 
-**Open — awaiting product decision.**
+**Resolved — Option B implemented (Slice 56).**
+
+`validate-worktree` removed; `validate-repository` retained. See
+`docs/development/tasks/dev-slice-56-task-01.md` and the ADR-0021 amendment.
+
+---
 
 This memo records the current truth, explicit options, and a recommendation
 for the `validate-worktree` / `validate-repository` surface question that

--- a/tests/acceptance/cli-help-flag.acceptance.test.ts
+++ b/tests/acceptance/cli-help-flag.acceptance.test.ts
@@ -64,15 +64,15 @@ describe("CLI --help flag (Slice 50)", () => {
     expect(text).toMatch(/--format\s+json\|env/);
   });
 
-  it("--help output includes a utility-commands section label before validate-worktree and validate-repository", async () => {
+  it("--help output includes a utility-commands section label before validate-repository", async () => {
     const outcome = await runCli(["--help"]);
     const text = outcome.stdout.join("\n");
     expect(text).toContain("Utility commands");
-    // label must appear before both utility commands
+    expect(text).toContain("validate-repository");
+    expect(text).not.toContain("validate-worktree");
+    // label must appear before validate-repository
     const labelIdx = text.indexOf("Utility commands");
-    const vtIdx = text.indexOf("validate-worktree");
     const vrIdx = text.indexOf("validate-repository");
-    expect(labelIdx).toBeLessThan(vtIdx);
     expect(labelIdx).toBeLessThan(vrIdx);
   });
 });

--- a/tests/acceptance/dev-slice-10.acceptance.test.ts
+++ b/tests/acceptance/dev-slice-10.acceptance.test.ts
@@ -21,52 +21,6 @@ describe("Development Slice 10 acceptance", () => {
     new URL("./fixtures/explicit-test-providers.ts", import.meta.url)
   );
 
-  it("accepts valid raw worktree identity input through the CLI", async () => {
-    const outcome = await runCli([
-      "validate-worktree",
-      "--worktree-id",
-      "wt-cli-valid"
-    ]);
-
-    expect(outcome).toEqual({
-      exitCode: 0,
-      stdout: [
-        JSON.stringify({
-          ok: true,
-          value: {
-            kind: "worktree_identity",
-            value: "wt-cli-valid"
-          }
-        })
-      ],
-      stderr: []
-    });
-  });
-
-  it("rejects invalid raw worktree identity input through the CLI", async () => {
-    const outcome = await runCli([
-      "validate-worktree",
-      "--worktree-id",
-      "   "
-    ]);
-
-    expect(outcome).toEqual({
-      exitCode: 1,
-      stdout: [
-        JSON.stringify({
-          ok: false,
-          errors: [
-            {
-              path: "worktreeId",
-              code: "invalid_value"
-            }
-          ]
-        })
-      ],
-      stderr: []
-    });
-  });
-
   it("accepts valid raw repository configuration input through the CLI", async () => {
     const tempDir = await mkdtemp(path.join(tmpdir(), "multiverse-cli-"));
     tempDirs.push(tempDir);

--- a/tests/acceptance/dev-slice-41.acceptance.test.ts
+++ b/tests/acceptance/dev-slice-41.acceptance.test.ts
@@ -9,10 +9,10 @@ import { runCli } from "../../apps/cli/src/index";
  * - The fallback usage output shown on unknown command reflects that
  *   --worktree-id is optional (not required) for derive, validate, reset,
  *   cleanup, and run — as introduced by Slice 37 auto-discovery.
- * - validate-worktree still shows --worktree-id as required (it is).
  *
  * Slice 50 update: usage output is now multi-line. Tests join stderr lines
  * before pattern matching instead of searching for a single usage line.
+ * Slice 56 update: validate-worktree removed from CLI surface; test removed.
  */
 describe("CLI usage string accuracy (Slice 41)", () => {
   it("unknown command usage shows --worktree-id as optional for derive", async () => {
@@ -37,13 +37,4 @@ describe("CLI usage string accuracy (Slice 41)", () => {
     expect(stderrText).toMatch(/run\s+\[.*\[--worktree-id VALUE\]/);
   });
 
-  it("unknown command usage still shows --worktree-id as required for validate-worktree", async () => {
-    const outcome = await runCli(["not-a-command"]);
-
-    expect(outcome.exitCode).toBe(1);
-    const stderrText = outcome.stderr.join("\n");
-    expect(stderrText).toContain("Usage:");
-    // validate-worktree still requires --worktree-id
-    expect(stderrText).toMatch(/validate-worktree\s+--worktree-id VALUE/);
-  });
 });


### PR DESCRIPTION
## Summary

Implements Option B from the utility-command decision memo (PR #123): remove `validate-worktree`, retain `validate-repository`.

**Rationale (sourced from ADR-0021):** `validate-worktree` validated that a worktree identity string is non-empty and non-blank. ADR-0021 (Slice 37) embedded that same validation into every primary command's path via auto-discovery. A caller who passes an invalid `--worktree-id` to any primary command receives an actionable refusal. The standalone command replicated existing behavior without adding user-facing value.

**`validate-repository` retained:** it lints a config file independently of providers, worktree identity, and git state — no equivalent exists elsewhere on the surface.

## Scope

- `apps/cli/src/index.ts`: remove `validateWorktreeIdentity` import, `handleValidateWorktree` function, dispatch case, and `USAGE_LINES` entry
- `tests/acceptance/dev-slice-10.acceptance.test.ts`: remove two `validate-worktree` test cases; `validate-repository` and `derive` cases kept
- `tests/acceptance/dev-slice-41.acceptance.test.ts`: remove `validate-worktree` usage-string test; update comment
- `tests/acceptance/cli-help-flag.acceptance.test.ts`: utility-section-label test updated to check `validate-repository` only (and explicitly asserts `validate-worktree` absent)
- `docs/adr/0021-git-worktree-path-conventional-default-for-worktree-id.md`: amendment note anchoring the removal rationale to this ADR
- `docs/development/tasks/utility-command-surface-decision-memo.md`: status → Resolved
- `docs/development/current-state.md`: Slice 56 proving result; 0.7.x wave declared complete in substance; Practical instruction updated
- `docs/development/tasks/dev-slice-56-task-01.md`: task doc

## Compatibility

Breaking change: `validate-worktree` now returns exit 1 (unknown command fallback). The command was not documented in the guide, had no scenario coverage, and had no established external user workflow.

`validateWorktreeIdentity()` in `@multiverse/core` is **not** removed — it is still used internally by the CLI's auto-discovery path.

## Validation

`pnpm test:acceptance` — 225 tests passed (39 test files). Full `pnpm test` — 349 tests passed (54 files). 3 tests removed (the validate-worktree acceptance cases).

## Deferred

- `validate-repository` guide documentation — optional, no urgency
- Utility-command subcommand restructuring — post-0.7.x if desired