### PR TITLE
docs: close out 0.7.x and bump posture to 0.8.0-alpha.1

### DIFF
--- a/docs/development/current-state.md
+++ b/docs/development/current-state.md
@@ -15,7 +15,7 @@ This is a short state-of-the-project document, not a full history.
 
 ## Current version posture
 
-Current version posture: **0.7.0-alpha.1**
+Current version posture: **0.8.0-alpha.1**
 
 Interpretation:
 
@@ -26,7 +26,8 @@ Interpretation:
 * all four 0.4.x roadmap exit criteria are met; the extensibility wave is complete
 * all 0.5.x exit criteria are met: the documented second-engineer workflow is proven end-to-end, including real two-worktree auto-discovery/isolation and no-manual-`NODE_OPTIONS` TypeScript provider loading in workspace scope; outside-workspace packaging and distribution remain explicitly deferred
 * all 0.6.x exit criteria are met: lifecycle semantics, refusal behavior, naming, worktree identity accuracy, and consumer integration boundaries are now aligned across spec, ADR, scenarios, and guide docs; the planned six-seam semantic stability wave (Slices 44–49) is complete
-* `0.7.0-alpha.1` enters the public surface stability phase: the next honest proving question is whether the CLI surface — invocation patterns, help output, output format conventions, and guide examples — is stable and intentional enough that users would not be forced to relearn it between minor versions
+* all 0.7.x exit criteria are met: the CLI surface is coherent and stable — `--help`/`-h` works correctly, output shapes are specified and tested, help text is complete, documentation examples are consistent with actual usage, and common command flows feel intentional; the planned seven-slice public-surface stability wave (Slices 50–56) is complete
+* `0.8.0-alpha.1` enters the support boundary definition phase: the next honest proving question is whether Multiverse's support boundaries can be made explicit enough that a user can tell what the tool officially supports for 1.0, without reading the source code
 * 1.0 expectations remain intentionally narrow
 
 ## What is already proven
@@ -379,7 +380,7 @@ were required.
 
 The current priority is:
 
-**`0.7.x` public surface stability — CLI invocation patterns, help text, output format conventions, and guide consistency. The `0.6.x` semantic stability wave is complete. Outside-workspace packaging and distribution remain explicitly deferred.**
+**`0.8.x` support boundary definition — making Multiverse's 1.0 support boundaries explicit enough that a user can tell what the tool officially supports without reading the source code. The `0.7.x` public-surface stability wave is complete. Outside-workspace packaging and distribution remain explicitly deferred.**
 
 ## What kinds of work are highest-value right now
 
@@ -451,22 +452,25 @@ The following remain explicitly deferred:
 
 When deciding what to work on next, prefer work that answers the current proving question:
 
-**Is the public CLI surface — command names, flags, invocation patterns, help text, and
-output format conventions — stable and intentional enough that a user would not be forced
-to relearn it between minor versions?**
+**Can Multiverse's support boundaries be made explicit enough that a user can tell what the
+tool officially supports for 1.0, without reading the source code?**
 
-The `0.7.x` public surface stability wave is complete in substance (Slices 50–56).
-The CLI surface is now intentional: primary commands, one utility command
-(`validate-repository`), structured help text, output-shape spec, and aligned docs/guide.
+Use this preference order:
 
-Do not attempt Slices 50–56 work as if it were pending — it is complete.
-Post-0.7.x candidates: `validate-repository` guide docs, utility-command subcommand
-restructuring (deferred), outside-workspace packaging (always deferred).
+1. audit which of the six first-party providers (name-scoped, path-scoped, process-scoped,
+   process-port-scoped, local-port, fixed-host-port) are first-class for 1.0 vs experimental
+   vs deferred — produce an explicit support classification
+2. define which workflows are part of the officially supported common case for 1.0
+3. make the core/extension boundary explicit as a 1.0 support statement
+4. state explicitly what consumer integration model is officially supported (appEnv,
+   runtime-config boundary) vs what remains experimental
 
-If the decision is made:
+Each item requires its own slice and task doc before any implementation changes.
+Begin with audit and classification work; do not invent new providers or workflows.
 
-- **Option B chosen:** implement the removal slice following the scope in the memo
-- **Option D chosen (defer):** update the memo status and move the question to the post-0.7.x backlog
+Do not attempt Slices 50–56 work as if it were pending — the 0.7.x wave is complete.
+0.8.x post-wave candidates (not current work): `validate-repository` guide docs,
+utility-command subcommand restructuring, outside-workspace packaging (always deferred).
 
 ## Related documents
 

--- a/docs/development/roadmap.md
+++ b/docs/development/roadmap.md
@@ -26,7 +26,7 @@ Multiverse development continues under the same core assumptions:
 
 ## Current version posture
 
-Current version posture: **0.7.0-alpha.1**
+Current version posture: **0.8.0-alpha.1**
 
 What that means:
 
@@ -42,7 +42,8 @@ What that means:
 * manual `NODE_OPTIONS` is no longer required for TypeScript providers on the compiled/global binary path in workspace scope (Slice 43)
 * all `0.5.x` exit criteria are met; the early outside-usability phase is complete in substance
 * all `0.6.x` exit criteria are met; the semantic stability wave (Slices 44–49) is complete: lifecycle semantics, refusal behavior and category naming, worktree identity scenario accuracy, and consumer integration boundary classification are all aligned across spec, ADR, scenarios, and guide docs
-* `0.7.0-alpha.1` enters the public surface stability phase: CLI invocation patterns, help output, output format conventions, and guide consistency are the next proving target
+* all `0.7.x` exit criteria are met; the public-surface stability wave (Slices 50–56) is complete: `--help`/`-h` exit 0, structured usage, output-shape spec, Options section, guide/README alignment, utility-command classification, and `validate-worktree` removal
+* `0.8.0-alpha.1` enters the support boundary definition phase: the next proving target is making Multiverse's 1.0 support boundaries explicit — which providers are first-class, which workflows are officially supported, and what remains experimental or deferred
 * outside-workspace packaging/distribution remains explicitly deferred
 
 ## Version roadmap

--- a/docs/development/roadmap.md
+++ b/docs/development/roadmap.md
@@ -483,19 +483,20 @@ It should mean that the product is trustworthy in its intended scope.
 
 The current near-term direction is:
 
-* audit the CLI surface — help text, output format conventions, flag naming, and invocation patterns — for stability and intentionality
-* identify inconsistencies between repo-local and formal binary invocation paths in docs and guides
-* specify expected output shapes for each command in source-of-truth docs
-* assess whether the current `validate-worktree` and `validate-repository` utility commands belong on the same CLI surface as the primary `derive`, `validate`, `run`, `reset`, `cleanup` commands
+* produce an explicit support classification for the six first-party providers — which are first-class for 1.0, which are experimental, which are deferred
+* define which developer workflows are part of the officially supported common case for 1.0
+* make the core/extension boundary explicit as a 1.0 support statement in source-of-truth docs
+* state explicitly which consumer integration model (appEnv, runtime-config boundary) is officially supported for 1.0
 
-The `0.6.x` semantic stability wave is complete. The six planned seams (lifecycle semantics,
-validate capability, refusal boundaries, naming/terminology, consumer integration boundaries,
-worktree identity alignment) are all addressed in source-of-truth documents. The next honest
-proving question is whether the public CLI surface is stable and intentional enough that
-users would not be forced to relearn it between minor versions.
+The `0.7.x` public-surface stability wave is complete. The seven planned slices (50–56)
+addressed help text, output-shape specification, guide/README alignment, utility-command
+classification, and CLI surface cleanup. The next honest proving question is whether the
+product's support boundaries can be made explicit enough that a user can identify what
+Multiverse officially supports for 1.0 without reading the source code.
 
-Each 0.7.x slice should begin with a targeted audit and task doc before any implementation.
-Broad CLI redesign without spec groundwork is not the right direction for this phase.
+Each 0.8.x slice should begin with a targeted audit and task doc before any implementation.
+Broad redefinition of what Multiverse is without clear source-of-truth grounding is not
+the right direction for this phase.
 
 Provider-ecosystem formalization and external distribution remain deferred.
 

--- a/docs/development/tasks/post-wave-50-56-assessment.md
+++ b/docs/development/tasks/post-wave-50-56-assessment.md
@@ -1,0 +1,88 @@
+# Post-Wave Assessment: 0.7.x Public Surface Stability Complete
+
+## Purpose
+
+This document records the post-wave assessment performed after completing the planned
+`0.7.x` public-surface stability wave (Slices 50–56). Its purpose is to determine the
+honest next project posture and identify the highest-signal proving question for the next wave.
+
+## Wave summary
+
+Slices 50–56 addressed every item listed in the roadmap's "Immediate direction" for 0.7.x:
+
+| Slice | Focus | Outcome |
+|---|---|---|
+| 50 | `--help`/`-h` correctness and usage structure | Exit 0 for help flags; raw blob replaced with structured multi-line USAGE_LINES |
+| 51 | Output-shape specification | `docs/spec/cli-output-shapes.md` + 20 executable acceptance tests across all 5 primary commands |
+| 52 | Help Options completeness | `--help`/`-h` and `--format` added to Options subsections; acceptance tests |
+| 53 | README and guide alignment | README Common commands fixed; `cli-output-shapes.md` in Key docs; guide Reference and Step 6 updated |
+| 54 | Utility-command classification | `"Utility commands (declaration validation):"` label in USAGE_LINES; spec exclusion note expanded |
+| 55 | Utility-command decision memo | Explicit options A–D framed; Option B recommended; product decision solicited |
+| 56 | `validate-worktree` removal | Command removed; rationale anchored to ADR-0021; tests updated; `validate-repository` retained |
+
+## 0.7.x exit criteria assessment
+
+From `roadmap.md`:
+
+| Exit criterion | Evidence | Met? |
+|---|---|---|
+| The CLI surface feels coherent and stable | 5 primary commands + 1 labeled utility command; consistent flag structure; auto-discovery for `--worktree-id`; `--help`/`-h` works correctly | ✓ |
+| Documentation examples are consistent with actual usage | README and guide aligned (Slice 53); `cli-output-shapes.md` linked from README; help text matches dispatch | ✓ |
+| Common command flows feel intentional rather than provisional | Output-shape spec provides stability guarantee; USAGE_LINES structured and complete; Options section documents all flags | ✓ |
+| Users are not forced to relearn the surface between minor milestones | Stability contract explicit in `cli-output-shapes.md`; flag naming stable; invocation patterns consistent | ✓ |
+
+All four exit criteria are met in substance.
+
+## Remaining open items (not blockers)
+
+The following items are explicitly deferred and do not constitute uncompleted 0.7.x work:
+
+- **`validate-repository` guide documentation**: optional; no user workflow depends on it
+  being in the guide; the command works and is labeled
+- **Utility command subcommand restructuring**: explicitly deferred to post-0.7.x; no ADR
+  or spec requires it for 1.0
+- **Outside-workspace packaging and distribution**: always deferred; not part of 0.7.x
+
+## Roadmap "immediate direction" items — all addressed
+
+The roadmap listed four near-term directions for 0.7.x:
+
+1. "audit the CLI surface — help text, output format conventions, flag naming, and invocation
+   patterns — for stability and intentionality" → **Done** (Slices 50–52, 54)
+2. "identify inconsistencies between repo-local and formal binary invocation paths in docs and
+   guides" → **Done** (Slice 53)
+3. "specify expected output shapes for each command in source-of-truth docs" → **Done** (Slice 51)
+4. "assess whether the current `validate-worktree` and `validate-repository` utility commands
+   belong on the same CLI surface as the primary commands" → **Done** (Slices 54–56)
+
+## Recommendation: close out 0.7.x and move to 0.8.0-alpha.1
+
+The planned wave is complete in substance. Remaining open items are correctly classified as
+deferred. There is no genuine 0.7.x public-surface gap that is both unaddressed and a blocker.
+
+## Next proving question: 0.8.x support boundary definition
+
+From `roadmap.md`, the 0.8.x line is for defining what Multiverse officially supports for 1.0:
+which providers are first-class, which workflows are part of the supported common case, which
+behaviors remain experimental, what belongs in core versus extensions, and what is intentionally
+deferred.
+
+The highest-signal proving question for 0.8.x is:
+
+**Can Multiverse's support boundaries be made explicit enough that a user can tell what the
+tool officially supports for 1.0, without reading the source code?**
+
+Known signals that this question is live:
+
+- The six first-party providers (name-scoped, path-scoped, process-scoped, process-port-scoped,
+  local-port endpoint, fixed-host-port endpoint) all work, but no source-of-truth doc makes
+  an explicit statement about which are "officially supported" vs experimental vs deferred
+- The common-case developer workflow is proven end-to-end (Slice 42), but no doc states what
+  the official supported workflow is for 1.0
+- The core/extension boundary is implicit in the code and ADRs but has not been stated as an
+  explicit 1.0 support boundary
+- The consumer integration model (appEnv, runtime-config boundary) is proven but not stated
+  as "officially supported for 1.0" vs "experimental"
+
+No changes to these areas are included in this assessment. They are identified as the next
+proving target for 0.8.x work. Each will require its own slice and task doc.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "multiverse",
-  "version": "0.7.0-alpha.1",
+  "version": "0.8.0-alpha.1",
   "private": true,
   "type": "module",
   "packageManager": "pnpm@10.33.0",


### PR DESCRIPTION
## Summary

Post-wave assessment and version posture bump after completing the 0.7.x public-surface stability wave (Slices 50–56).

## 0.7.x exit criteria — all met

| Criterion | Evidence |
|---|---|
| CLI surface feels coherent and stable | 5 primary + 1 utility command; consistent flags; `--help`/`-h` works; utility command clearly labeled |
| Documentation examples consistent with actual usage | README and guide aligned (Slice 53); `cli-output-shapes.md` linked; help text matches dispatch |
| Common command flows feel intentional | Output-shape spec with stability guarantee; USAGE_LINES structured and complete; all flags documented |
| Users not forced to relearn between minor milestones | Stability contract explicit in `cli-output-shapes.md`; flag naming and invocation patterns stable |

## Roadmap "immediate direction" items — all addressed

1. Audit CLI surface → Slices 50–52, 54
2. Identify repo-local vs formal binary inconsistencies → Slice 53
3. Specify output shapes → Slice 51
4. Assess utility-command surface → Slices 54–56

## Scope

- `docs/development/tasks/post-wave-50-56-assessment.md` — post-wave assessment (new)
- `docs/development/current-state.md` — version posture → 0.8.0-alpha.1; priority and Practical instruction updated for 0.8.x
- `docs/development/roadmap.md` — Immediate direction updated to 0.8.x items
- `package.json` — version → 0.8.0-alpha.1

## 0.8.x proving question

**"Can Multiverse's support boundaries be made explicit enough that a user can tell what the tool officially supports for 1.0, without reading the source code?"**

Next work: provider support classification, official workflow definition, core/extension boundary statement, consumer integration model status.

## Validation

`pnpm test` — 349 tests passed. Docs-only change (plus version string); no behavioral change.