### PR TITLE
slice-59: state officially supported 1.0 common-case workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,8 @@ Core product and architecture docs:
 * `docs/spec/endpoint-model.md`
 * `docs/spec/safety-and-refusal.md`
 * `docs/spec/cli-output-shapes.md` — stable output contract for all primary commands (JSON shapes, field names, output routing)
+* `docs/spec/provider-support-classification.md` — which first-party providers are first-class vs supported-with-constraints for 1.0
+* `docs/spec/supported-workflow.md` — the officially supported 1.0 common-case developer workflow and what is deferred
 * `docs/adr/0001-git-worktrees-only-1.0.md`
 * `docs/adr/0004-resource-isolation-strategies.md`
 * `docs/adr/0005-providers-implement-isolation-contracts.md`

--- a/docs/development/current-state.md
+++ b/docs/development/current-state.md
@@ -391,6 +391,22 @@ with limitations documented in their ADRs. No provider is deferred. Validate cap
 decisions, not missing features. `docs/spec/provider-model.md` now references the classification
 doc.
 
+**Is the officially supported 1.0 common-case developer workflow stated explicitly enough
+that a user can identify it without reading scattered guides or ADRs?**
+
+Slice 59 answers yes. A new source-of-truth spec, `docs/spec/supported-workflow.md`,
+explicitly states the 1.0 common-case workflow: a developer working inside a git worktree
+uses `pnpm cli run -- <cmd>` (from the multiverse workspace, with `multiverse.json` and
+`providers.ts` at CWD or via explicit flags) to derive isolated values and launch their
+application. Worktree identity is auto-discovered from git state (ADR-0021). The preferred
+consumer integration pattern is `appEnv` with typed endpoint mapping at one
+application-owned boundary. The doc also states explicitly: what is outside the common case
+but supported (explicit flag overrides, compiled binary, globally-linked binary,
+`validate`), and what is deferred (outside-workspace usage, standalone global binary,
+configuration inference, overlay files). The invocation-path limitation — provider packages
+are workspace-local and not published to npm — is stated honestly as a 1.0 deferred item,
+not obscured.
+
 ## Current priority
 
 The current priority is:

--- a/docs/development/roadmap.md
+++ b/docs/development/roadmap.md
@@ -485,7 +485,7 @@ It should mean that the product is trustworthy in its intended scope.
 The current near-term direction is:
 
 * ~~produce an explicit support classification for the six first-party providers~~ — done (Slice 58): `docs/spec/provider-support-classification.md` classifies all six providers into two tiers with rationale; no provider is deferred
-* define which developer workflows are part of the officially supported common case for 1.0
+* ~~define which developer workflows are part of the officially supported common case for 1.0~~ — done (Slice 59): `docs/spec/supported-workflow.md` states the common-case workflow, what is outside it but supported, and what is deferred; `appEnv` with typed endpoint mapping is stated as the preferred consumer pattern
 * make the core/extension boundary explicit as a 1.0 support statement in source-of-truth docs
 * state explicitly which consumer integration model (appEnv, runtime-config boundary) is officially supported for 1.0
 

--- a/docs/development/tasks/dev-slice-59-task-01.md
+++ b/docs/development/tasks/dev-slice-59-task-01.md
@@ -1,0 +1,67 @@
+# Task: Dev Slice 59 — Official Common-Case Workflow Statement
+
+## Slice
+
+59 — official common-case workflow statement for 1.0
+
+## Purpose
+
+Produce a source-of-truth document that explicitly states the officially supported 1.0
+common-case developer workflow. The goal is to let a user answer "what workflow does
+Multiverse officially support for 1.0?" without inferring it from the external-demo-guide
+or reading ADRs.
+
+This is a docs-only slice. No production code changes. No new providers. No workflow changes.
+
+## Active file set
+
+- `docs/spec/supported-workflow.md` — new workflow statement spec (primary deliverable)
+- `docs/development/tasks/dev-slice-59-task-01.md` — this task doc (new)
+- `docs/development/current-state.md` — add Slice 59 proving result
+- `docs/development/roadmap.md` — mark workflow item complete in Immediate direction
+
+## Pre-work audit performed
+
+The following source-of-truth docs were consulted: ADR-0012, ADR-0014, ADR-0017, ADR-0018,
+ADR-0019, ADR-0021, product-spec.md, external-demo-guide.md, README.md, current-state.md,
+roadmap.md, provider-support-classification.md, cli-output-shapes.md.
+
+## Workflow classification
+
+**Common-case (officially supported):**
+- `pnpm cli run -- <cmd>` from the multiverse workspace
+- `multiverse.json` and `providers.ts` at CWD (conventional defaults apply)
+- Worktree identity auto-discovered from git state (ADR-0021)
+- `appEnv` aliases with typed endpoint extraction as the preferred consumer pattern
+- Lifecycle: `pnpm cli reset`, `pnpm cli cleanup`
+- Inspection: `pnpm cli derive [--format env]`
+
+**Outside common case but supported:**
+- Explicit `--worktree-id`, `--config`, `--providers` overrides
+- Formal compiled binary (`node apps/cli/bin/multiverse.js`) — same behavior, requires build
+- Globally-linked `multiverse` binary — within-workspace proof only
+- `validate` command — supported but optional in the normal workflow
+
+**Deferred:**
+- Outside-workspace usage (provider packages not on npm)
+- Standalone global binary for non-workspace repos
+- Configuration overlay or profile selection
+
+## Explicit out-of-scope
+
+- No new invocation paths
+- No workflow changes
+- No new CLI commands or flags
+- No packaging or distribution work
+- No changes to existing ADRs or behavior
+
+## Acceptance criteria
+
+- `supported-workflow.md` exists at `docs/spec/`
+- The common-case workflow is stated explicitly as a bounded support statement
+- The invocation path limitation (workspace-only) is honest and documented
+- What is outside the common case but supported is listed separately
+- What is deferred is listed explicitly
+- `current-state.md` records the Slice 59 proving result
+- `roadmap.md` marks the workflow item complete
+- No production code is changed

--- a/docs/spec/supported-workflow.md
+++ b/docs/spec/supported-workflow.md
@@ -1,0 +1,251 @@
+# Supported Common-Case Workflow for 1.0
+
+## Purpose
+
+This document states the officially supported common-case developer workflow for 1.0.
+
+The external demo guide (`docs/guides/external-demo-guide.md`) is the practical tutorial
+showing each step with working examples. This document is the official support boundary
+statement: it says what Multiverse officially supports as the common case, what is outside
+the common case but still supported, and what is explicitly deferred.
+
+## The 1.0 common-case workflow
+
+The supported common-case workflow is: a Node.js application developer working inside a
+git repository with multiple worktree checkouts on one machine, using Multiverse to isolate
+mutable local resources and local endpoint addresses across those worktrees.
+
+### Preconditions
+
+Before the workflow can operate, all of the following must be in place:
+
+1. The multiverse repository is cloned and `pnpm install` has been run at the repo root.
+   This makes `pnpm cli` available and resolves provider workspace packages.
+2. The target application repository has a `multiverse.json` declaring its resources and
+   endpoints.
+3. The target application repository has a `providers.ts` registering provider
+   implementations for each declared resource and endpoint name.
+4. The developer is operating from inside a git worktree directory, so that worktree
+   identity can be discovered automatically from git state (ADR-0021).
+
+When preconditions 2–4 are met at the current working directory, no flag overrides are
+needed for common invocations.
+
+### Workflow steps
+
+**Declare configuration (`multiverse.json`)**
+
+Create `multiverse.json` at the root of the repository. Declare each resource and endpoint
+the application needs, with its provider name and lifecycle flags. This file is read from
+`./multiverse.json` relative to the working directory by default (ADR-0014).
+
+**Register providers (`providers.ts`)**
+
+Create `providers.ts` registering provider instances for each name declared in
+`multiverse.json`. Provider packages (`@multiverse/provider-*`) are workspace packages that
+resolve once `pnpm install` has been run. This file is read from `./providers.ts` by
+default (ADR-0014).
+
+**Run the application under isolation**
+
+```
+pnpm cli run -- <your-command>
+```
+
+Multiverse discovers the current worktree identity from git state (ADR-0021), derives
+isolated values for that identity, injects them into the child process environment alongside
+any declared `appEnv` aliases, and starts the command. If derivation fails for any reason,
+Multiverse writes a JSON refusal to stderr and exits non-zero without starting the child.
+
+**Inspect derived values**
+
+```
+pnpm cli derive
+pnpm cli derive --format env
+```
+
+Inspect what Multiverse would derive for the current worktree: JSON (default) or
+shell-sourceable `KEY=VALUE` pairs. The `--format env` output includes canonical
+`MULTIVERSE_RESOURCE_*` and `MULTIVERSE_ENDPOINT_*` variables; it does not include
+`appEnv` aliases (those are injected only by `run`). Useful for debugging and scripting
+against canonical variable names.
+
+**Reset isolated state**
+
+```
+pnpm cli reset
+```
+
+Reinitializes the isolated state belonging to the current worktree, for all resources that
+declare `scopedReset: true`. Intended for use when the next run should start fresh without
+leftover state from prior runs. Does not affect any other worktree's isolated state.
+
+**Clean up isolated state**
+
+```
+pnpm cli cleanup
+```
+
+Permanently removes the isolated state belonging to the current worktree, for all resources
+that declare `scopedCleanup: true`. Intended for use when the worktree is no longer in use.
+Does not affect any other worktree's isolated state.
+
+---
+
+## Common-case invocation path
+
+The officially supported invocation path for in-repository development is **`pnpm cli`**.
+
+`pnpm cli` runs the CLI through the TypeScript source using `tsx`, without requiring a build
+step. It is available from the multiverse repo root once `pnpm install` has been run.
+
+All primary commands (`run`, `derive`, `validate`, `reset`, `cleanup`) are available through
+`pnpm cli`. All flags accept both space form (`--flag VALUE`) and equals form
+(`--flag=VALUE`).
+
+---
+
+## Conventional defaults (ADR-0014, ADR-0021)
+
+| Aspect | Default | Override |
+|---|---|---|
+| Configuration file | `./multiverse.json` (CWD-relative) | `--config PATH` |
+| Provider module | `./providers.ts` (CWD-relative) | `--providers MODULE` |
+| Worktree identity | `path.basename` of current git worktree path | `--worktree-id VALUE` |
+
+When all three resolve correctly, no flags are needed:
+
+```
+pnpm cli run -- node server.js
+pnpm cli derive
+pnpm cli reset
+pnpm cli cleanup
+```
+
+If the current directory is not inside a git worktree, or if git is unavailable, worktree
+identity discovery fails with an actionable refusal directing the caller to pass
+`--worktree-id` explicitly.
+
+---
+
+## Consumer integration model (ADR-0018, ADR-0019)
+
+`run` injects derived values into the child process environment:
+
+- `MULTIVERSE_WORKTREE_ID` — the resolved worktree identity
+- `MULTIVERSE_RESOURCE_<NAME>` — the derived handle for each declared resource
+- `MULTIVERSE_ENDPOINT_<NAME>` — the derived address for each declared endpoint
+
+Where `<NAME>` is the declared name uppercased with hyphens replaced by underscores.
+
+### Preferred consumer pattern: `appEnv` with typed endpoint mapping
+
+Declare `appEnv` on resources and endpoints. `run` then injects both canonical
+`MULTIVERSE_*` variables and the declared app-native names. For endpoint declarations,
+typed extraction supports:
+
+- `url` — the full derived address string
+- `port` — the numeric port extracted from the derived address, as a string
+
+The preferred pattern for composed applications is to read app-owned names at one explicit
+runtime-config boundary rather than scatter `MULTIVERSE_*` reads throughout the
+application code. The `apps/sample-compose/` proving application demonstrates this pattern.
+
+Reading canonical `MULTIVERSE_*` names directly is supported but not the preferred pattern
+for applications with multiple managed seams.
+
+---
+
+## What is outside the common case but supported in 1.0
+
+The following are valid, implemented, and in scope for 1.0, but are not the primary
+common-case recommendation.
+
+### Explicit `--worktree-id` override
+
+Pass `--worktree-id VALUE` on any primary command to override auto-discovery. Required when
+git state is unavailable or the discovered identity does not match the intended value.
+`--worktree-id` always overrides discovery.
+
+### Explicit `--config` and `--providers` overrides
+
+Pass `--config PATH` and `--providers MODULE` when configuration files are not at the
+conventional default locations. Needed when running from a directory that does not contain
+`multiverse.json` or `providers.ts`, or when managing multiple configurations from one
+working directory.
+
+### Formal compiled binary
+
+After running `pnpm --filter @multiverse/cli build`, the compiled binary is available at
+`apps/cli/bin/multiverse.js` and can be invoked as:
+
+```
+node apps/cli/bin/multiverse.js <command> [options]
+```
+
+All commands, flags, auto-discovery, and conventional defaults behave identically to
+`pnpm cli`. Within the workspace, TypeScript provider modules load without manual
+`NODE_OPTIONS`. The compiled binary is the formal artifact that underpins the linked binary
+path (ADR-0017). `pnpm cli` remains the primary development path.
+
+### Globally-linked binary (within-workspace)
+
+The compiled binary can be linked globally using `pnpm link --global` from `apps/cli/`,
+exposing `multiverse` as a shell command. This path is proven within the multiverse
+workspace. All commands behave identically. The structural limitation applies: provider
+packages are workspace-local and must resolve from workspace `node_modules`.
+
+### `validate` command
+
+`validate` verifies that derived values are usable for providers that declare
+`scopedValidate: true`. This is supported and explicit but is not a required step in the
+normal workflow — `run` proceeds with derivation, not validate.
+
+---
+
+## What is deferred for 1.0
+
+The following are explicitly outside the 1.0 workflow support statement. They are not
+deficiencies; they are intentional scope boundaries for the current release.
+
+**Outside-workspace usage**
+
+Provider packages (`@multiverse/provider-*`) are workspace packages not published to npm.
+Any `providers.ts` must import provider packages that resolve in the multiverse workspace.
+Using Multiverse in a repository that is not the multiverse workspace — where provider
+imports cannot resolve — is not a supported workflow for 1.0. Provider packaging and
+distribution are explicitly deferred.
+
+**Standalone global binary for non-workspace repositories**
+
+The globally-linked binary cannot resolve provider package imports from outside the
+workspace. A truly standalone `multiverse` binary usable in any repository requires
+provider package publication, which is deferred.
+
+**Configuration inference from project structure**
+
+Multiverse does not infer the location of `multiverse.json`, the provider module, or
+provider implementations from framework conventions, project layout, or environment hints.
+Configuration is always explicit. ADR-0007 (repository configuration is explicit in 1.0)
+and the hard 1.0 constraint against provider inference apply.
+
+**Configuration overlay or profile selection**
+
+There is one `multiverse.json` and one `providers.ts` per invocation. Environment-specific
+overlay files, profile switching, or conditional configuration are not supported and not
+planned for 1.0.
+
+---
+
+## Relationship to existing docs
+
+| Document | Relationship |
+|---|---|
+| `docs/guides/external-demo-guide.md` | The practical tutorial; this doc is the support boundary statement |
+| `docs/spec/provider-support-classification.md` | Which providers are first-class vs supported-with-constraints |
+| `docs/adr/0014-strict-conventional-defaults.md` | Governs `--config` and `--providers` conventional defaults |
+| `docs/adr/0021-git-worktree-path-conventional-default-for-worktree-id.md` | Governs worktree identity auto-discovery |
+| `docs/adr/0012-explicit-process-wrapper-run.md` | Governs `run` semantics and env injection |
+| `docs/adr/0018-explicit-app-native-env-mapping-for-run.md` | Governs `appEnv` mapping |
+| `docs/adr/0019-explicit-typed-endpoint-mapping.md` | Governs typed endpoint extraction (`url`, `port`) |
+| `docs/adr/0017-cli-package-and-binary-invocation-surface.md` | Governs the formal binary and invocation paths |

--- a/docs/spec/supported-workflow.md
+++ b/docs/spec/supported-workflow.md
@@ -94,7 +94,7 @@ Does not affect any other worktree's isolated state.
 
 ## Common-case invocation path
 
-The officially supported invocation path for in-repository development is **`pnpm cli`**.
+The primary recommendation for in-repository development is **`pnpm cli`**.
 
 `pnpm cli` runs the CLI through the TypeScript source using `tsx`, without requiring a build
 step. It is available from the multiverse repo root once `pnpm install` has been run.
@@ -102,6 +102,11 @@ step. It is available from the multiverse repo root once `pnpm install` has been
 All primary commands (`run`, `derive`, `validate`, `reset`, `cleanup`) are available through
 `pnpm cli`. All flags accept both space form (`--flag VALUE`) and equals form
 (`--flag=VALUE`).
+
+Alternative invocation paths — the formal compiled binary and the globally-linked binary —
+are supported within the workspace and behave identically, but require additional setup
+steps (a build step, or a build plus link step respectively). They are covered in the
+"outside the common case but supported" section below.
 
 ---
 


### PR DESCRIPTION
## Summary

Produces a source-of-truth statement of the officially supported 1.0 common-case workflow, per the Slice 57 planning baseline.

The primary question this answers: _what workflow does Multiverse officially support for 1.0 — without inferring it from guides or ADRs?_

## What is now explicitly stated

**`docs/spec/supported-workflow.md`** (new) states:

- **Common-case workflow**: `pnpm cli run -- <cmd>` from the multiverse workspace; `multiverse.json` and `providers.ts` at CWD; worktree identity auto-discovered from git state; `appEnv` with typed endpoint mapping as the preferred consumer integration pattern; `reset` and `cleanup` for lifecycle; `derive` for inspection
- **Supported outside the common case**: explicit `--worktree-id`, `--config`, `--providers` overrides; compiled binary (`node apps/cli/bin/multiverse.js`); globally-linked binary (within-workspace); `validate` command
- **Deferred**: outside-workspace usage (provider packages not on npm), standalone global binary for non-workspace repos, configuration inference, overlay files

The invocation-path limitation is stated honestly: provider packages are workspace-local and not published to npm; outside-workspace usage is deferred, not a deficiency.

## Scope

Docs-only. Five files changed:

- `docs/spec/supported-workflow.md` — new workflow support statement spec (primary deliverable)
- `docs/development/tasks/dev-slice-59-task-01.md` — task doc
- `docs/development/current-state.md` — Slice 59 proving result
- `docs/development/roadmap.md` — workflow item marked complete in Immediate direction
- `README.md` — new spec linked from Key docs section

No production code changes. No test changes.

## Validation

- `pnpm test:acceptance` — 225 passed (39 test files)
- Docs reviewed against ADR-0012, ADR-0014, ADR-0017, ADR-0018, ADR-0019, ADR-0021, external-demo-guide.md, provider-support-classification.md

## Deferred

All workflow extensions (outside-workspace usage, standalone distribution, configuration overlay) are stated explicitly in the new spec's deferred section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)