### PR TITLE
slice-61: state 1.0 core/extension boundary explicitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ Core product and architecture docs:
 * `docs/spec/provider-support-classification.md` — which first-party providers are first-class vs supported-with-constraints for 1.0
 * `docs/spec/supported-workflow.md` — the officially supported 1.0 common-case developer workflow and what is deferred
 * `docs/spec/consumer-integration-model.md` — which consumer integration patterns are officially supported for 1.0 and what is deferred
+* `docs/spec/core-extension-boundary.md` — the 1.0 core/extension boundary: what core owns, the stable `@multiverse/provider-contracts` extension seam, first-party vs custom provider distinction, and what is deferred
 * `docs/adr/0001-git-worktrees-only-1.0.md`
 * `docs/adr/0004-resource-isolation-strategies.md`
 * `docs/adr/0005-providers-implement-isolation-contracts.md`

--- a/docs/development/current-state.md
+++ b/docs/development/current-state.md
@@ -422,6 +422,21 @@ The `run` stderr refusal routing is stated as a stable 1.0 behavior per `cli-out
 Deferred items are explicit: `appEnv` in `derive --format=env`, resource typed extraction,
 multiple aliases per declaration, additional endpoint value kinds, config overlays.
 
+**What is the official 1.0 core/extension boundary, and what can a custom provider rely on?**
+
+Slice 61 answers this. A new source-of-truth spec, `docs/spec/core-extension-boundary.md`,
+consolidates the boundary definitions distributed across ADR-0005, ADR-0009, `provider-model.md`,
+and the provider authoring guide into one readable reference. Four key statements: (1) core
+owns configuration validation, worktree identity resolution, safety/refusal enforcement, and
+provider coordination — not technology-specific isolation; (2) `@multiverse/provider-contracts`
+is the stable extension seam for 1.0 — a custom provider authored against this package alone
+integrates correctly through core (proven by Slices 32 and 35); (3) the six first-party
+providers (classified in `provider-support-classification.md`) are the 1.0 first-party
+support guarantee; (4) custom providers can implement any isolation strategy the contract
+supports but are outside the first-party support tier. Provider packaging/distribution, community
+extension workflow, and additional first-party providers beyond the current six are explicitly
+deferred.
+
 ## Current priority
 
 The current priority is:

--- a/docs/development/roadmap.md
+++ b/docs/development/roadmap.md
@@ -486,7 +486,7 @@ The current near-term direction is:
 
 * ~~produce an explicit support classification for the six first-party providers~~ — done (Slice 58): `docs/spec/provider-support-classification.md` classifies all six providers into two tiers with rationale; no provider is deferred
 * ~~define which developer workflows are part of the officially supported common case for 1.0~~ — done (Slice 59): `docs/spec/supported-workflow.md` states the common-case workflow, what is outside it but supported, and what is deferred; `appEnv` with typed endpoint mapping is stated as the preferred consumer pattern
-* make the core/extension boundary explicit as a 1.0 support statement in source-of-truth docs
+* ~~make the core/extension boundary explicit as a 1.0 support statement in source-of-truth docs~~ — done (Slice 61): `docs/spec/core-extension-boundary.md` synthesizes ADR-0005, ADR-0009, and the authoring guide into one reference; `@multiverse/provider-contracts` stated as the stable extension seam; first-party vs custom provider distinction explicit; deferred items documented
 * ~~state explicitly which consumer integration model (appEnv, runtime-config boundary) is officially supported for 1.0~~ — done (Slice 60): `docs/spec/consumer-integration-model.md` classifies three supported patterns; runtime-config boundary recommended for composed apps; `run` stderr routing stated as stable 1.0 behavior; deferred items explicit
 
 The `0.7.x` public-surface stability wave is complete. The seven planned slices (50–56)

--- a/docs/development/tasks/dev-slice-61-task-01.md
+++ b/docs/development/tasks/dev-slice-61-task-01.md
@@ -1,0 +1,81 @@
+# Dev Slice 61 Task 01 — Core/Extension Boundary Consolidation
+
+## Slice
+
+Slice 61 — Core/Extension Boundary Consolidation
+
+## Purpose
+
+Consolidate the distributed core/extension boundary definitions into a single readable
+1.0 boundary statement.
+
+The Slice 57 planning audit found that the boundary is stated truthfully but is scattered
+across five documents (ADR-0005, ADR-0009, `provider-model.md`, CLAUDE.md,
+`provider-authoring-guide.md`). No single source-of-truth document answers:
+
+- What is core and what are its responsibilities?
+- What is `@multiverse/provider-contracts` and why is it the extension seam?
+- What do first-party providers guarantee vs what can a custom provider do?
+- What is explicitly deferred for post-1.0 extensibility?
+
+## Slice scope
+
+**Docs-only.** No production code changes. No test changes.
+
+## Files to change
+
+### New files
+
+- `docs/development/tasks/dev-slice-61-task-01.md` — this document
+- `docs/spec/core-extension-boundary.md` — the primary deliverable: a consolidated
+  1.0 boundary statement synthesizing existing ADRs/specs into one readable reference
+
+### Modified files
+
+- `docs/development/current-state.md` — add Slice 61 proving result
+- `docs/development/roadmap.md` — mark core/extension boundary item complete
+- `README.md` — add pointer to `core-extension-boundary.md` in Key docs section
+- `docs/spec/provider-model.md` — add cross-reference to new boundary doc
+
+## Acceptance criteria
+
+- `docs/spec/core-extension-boundary.md` exists and:
+  - states core responsibilities for 1.0 (what core owns, what it does not)
+  - names `@multiverse/provider-contracts` as the stable extension seam
+  - states what first-party providers guarantee (6 providers, workspace-local, classified in
+    `provider-support-classification.md`)
+  - states what custom/extension providers can do (implement any isolation strategy the
+    contract supports) and what they cannot do (access core internals, implement business rules)
+  - states what is deferred (packaging/distribution, ecosystem, community extensions)
+  - includes a relationship table linking to governing ADRs and existing specs
+- `current-state.md` records Slice 61 in the proving-results section
+- `roadmap.md` marks the core/extension boundary item complete in Immediate direction
+- `README.md` Key docs section includes a pointer to the new spec
+
+## Explicit out-of-scope
+
+- No new ADRs
+- No changes to provider contracts or provider implementations
+- No changes to runtime behavior
+- No changes to test files
+- No redesign of provider contracts
+- Do not reopen Portless or optional integrations
+- Do not address packaging/distribution (state it as deferred only)
+- Do not invent a richer taxonomy than the existing four-layer ADR-0009 model
+
+## Source-of-truth grounding
+
+The boundary statement must be derived only from:
+
+1. ADR-0005 — providers implement isolation contracts
+2. ADR-0007 — repository configuration is explicit
+3. ADR-0008 — unsafe operations are refused
+4. ADR-0009 — the four explicit responsibility layers
+5. `docs/spec/provider-model.md` — provider capabilities and boundary
+6. `docs/guides/provider-authoring-guide.md` — extension seam and constraint rules
+7. `docs/spec/provider-support-classification.md` — first-party provider tiers
+8. Slice 32 / 35 proving results — custom provider seam is proven end-to-end
+
+## Safety/refusal expectations
+
+No refusal behavior changes. This is docs-only.

--- a/docs/spec/core-extension-boundary.md
+++ b/docs/spec/core-extension-boundary.md
@@ -1,0 +1,233 @@
+# Core/Extension Boundary for 1.0
+
+## Purpose
+
+This document states the official 1.0 core/extension boundary for Multiverse.
+
+It synthesizes the boundary definitions that are currently distributed across ADR-0005,
+ADR-0009, `provider-model.md`, and the provider authoring guide into one readable
+reference. A user or potential contributor should be able to read this document and
+answer:
+
+- What does Multiverse core own?
+- What is the stable extension seam for writing a custom provider?
+- What do first-party providers guarantee, and where does that guarantee end?
+- What is explicitly deferred for post-1.0 extensibility?
+
+---
+
+## The four responsibility layers
+
+ADR-0009 defines four explicit responsibility layers. Every implementation decision in
+Multiverse is evaluated against these boundaries:
+
+| Layer | Responsibility |
+|---|---|
+| **Core** | Business rules, orchestration, validation, safety/refusal |
+| **Provider** | Technology-specific isolation behavior through explicit contracts |
+| **Repository configuration** | Explicit declaration of what must be isolated and how |
+| **Application/runtime** | Consuming derived values; reading injected environment variables |
+
+These layers are not implementation convenience — they are the enforcement structure for
+keeping the tool predictable, testable, and safe.
+
+---
+
+## Core responsibilities for 1.0
+
+Core (`packages/core/`) owns the following for 1.0:
+
+**Configuration validation**
+Core reads and validates `multiverse.json`. It checks that required fields are present,
+that declared provider names resolve in the registry, and that provider-specific
+configuration is structurally sound. Declaration correctness is a core responsibility,
+not a provider responsibility.
+
+**Worktree identity resolution**
+Core resolves the active worktree identity — either from an explicit `--worktree-id`
+flag or by discovering it from git state (ADR-0021). Identity resolution is a core
+responsibility because the resulting identity governs scope boundaries for all operations.
+
+**Safety and refusal enforcement**
+Core enforces the refusal-first contract (ADR-0008). If scope is ambiguous, if a
+declared provider is not registered, or if a requested capability is not supported,
+core refuses with a structured refusal object rather than guessing or proceeding
+silently. Core-level refusal is not configurable.
+
+**Provider coordination**
+Core dispatches derive, validate, reset, and cleanup operations to the appropriate
+registered provider through the contract defined in `@multiverse/provider-contracts`.
+Core does not implement technology-specific behavior; it coordinates providers through
+the shared contract.
+
+### What core does NOT do
+
+- Core does not implement technology-specific isolation behavior.
+- Core does not infer provider selection from project structure or conventions.
+- Core does not access application code or runtime-injected configuration.
+- Core does not manage application startup, shutdown, or process lifecycle beyond the
+  `run` child-process wrapper.
+
+---
+
+## The extension seam — `@multiverse/provider-contracts`
+
+`@multiverse/provider-contracts` is the stable extension seam for 1.0.
+
+This package defines the complete contract between core and provider implementations:
+
+- `ResourceProvider` — the interface a resource provider must implement
+- `EndpointProvider` — the interface an endpoint provider must implement
+- `ProviderRegistry` — the registry shape core reads at runtime
+- `DerivedResourcePlan` — the shape a successful resource derivation must return
+- `DerivedEndpointMapping` — the shape a successful endpoint derivation must return
+- `Refusal` — the shape a provider must return when it cannot safely proceed
+- Capability types for `validate`, `reset`, and `cleanup`
+
+**A provider authored against this package alone integrates correctly through core.**
+This has been verified end-to-end: a custom provider that imports only from
+`@multiverse/provider-contracts`, is registered in a `ProviderRegistry`, and is
+referenced from `providers.ts` will derive correctly through `pnpm cli derive --providers`.
+Core does not distinguish between first-party and custom providers at runtime — it
+coordinates both through the same contract.
+
+This seam is **stable for 1.0**. No changes to the contract package are planned for 1.0.
+Future changes to the contract would be driven by new explicit ADRs.
+
+### What `@multiverse/provider-contracts` does not provide
+
+- It does not provide provider implementations. Providers that use it must implement
+  their own technology-specific isolation behavior.
+- It does not provide a mechanism for provider auto-discovery or auto-registration.
+  Every provider must be explicitly registered in `providers.ts`.
+- It does not address packaging or distribution. The package is a workspace package
+  in the Multiverse repository and is not published to npm.
+
+---
+
+## First-party providers
+
+The six providers shipped with Multiverse are the 1.0 first-party provider support
+guarantee:
+
+| Package | Domain | Support tier |
+|---|---|---|
+| `@multiverse/provider-name-scoped` | Resource | First-class for the 1.0 common case |
+| `@multiverse/provider-path-scoped` | Resource | First-class for the 1.0 common case |
+| `@multiverse/provider-local-port` | Endpoint | First-class for the 1.0 common case |
+| `@multiverse/provider-process-scoped` | Resource | Supported for specific use cases |
+| `@multiverse/provider-process-port-scoped` | Resource | Supported for specific use cases |
+| `@multiverse/provider-fixed-host-port` | Endpoint | Supported for specific use cases |
+
+Each provider is classified and described in `docs/spec/provider-support-classification.md`,
+including its capabilities, governing ADR, and constraints.
+
+### First-party provider guarantees
+
+- Derive is implemented and tested for all six.
+- Lifecycle capabilities (validate, reset, cleanup) are declared explicitly and match
+  the stated capability matrix in `provider-support-classification.md`.
+- Each provider satisfies the universal derive contract asserted by
+  `tests/contracts/resource-provider.derive.contract.test.ts` (resources) and
+  `tests/contracts/endpoint-provider.derive.contract.test.ts` (endpoints).
+- No first-party provider implements business rules. Business rules remain in core.
+
+### First-party provider limitations
+
+First-party provider packages are workspace packages. They are not published to npm.
+Any `providers.ts` that imports first-party providers must resolve those imports from
+the Multiverse workspace `node_modules`. Outside-workspace provider packaging and
+distribution are explicitly deferred.
+
+---
+
+## Custom/extension providers
+
+A custom provider is any provider that is not shipped with Multiverse and is authored
+by a repository owner or contributor against `@multiverse/provider-contracts`.
+
+### What a custom provider can do
+
+- Implement any isolation strategy the contract supports: resource derivation (logical
+  name, filesystem path, process instance, or any other technology-specific approach),
+  endpoint derivation, and optional lifecycle capabilities (validate, reset, cleanup).
+- Be registered in `providers.ts` under any name, matching the `provider` field in
+  `multiverse.json`.
+- Work through the full CLI path (`pnpm cli derive --providers`, `pnpm cli run`, and all
+  other primary commands) in the same way as first-party providers. Core does not
+  distinguish between them.
+- Be verified for derive contract compliance by adding it to `providerCases` in
+  `tests/contracts/resource-provider.derive.contract.test.ts`.
+
+### What a custom provider must not do
+
+These boundaries keep business rules in core and technology behavior in providers:
+
+- **Do not validate declaration correctness.** By the time a provider receives input,
+  declarations have already been validated by core. Checking whether required fields are
+  present is core's responsibility.
+- **Do not read repository configuration directly.** A provider receives only the narrow
+  input it needs from core. It must not open `multiverse.json` independently.
+- **Do not implement business rules.** Refusal behavior, scope safety, and worktree
+  boundary enforcement belong to core. Providers enforce only technology-specific safety
+  (e.g., refusing when a required path is inaccessible).
+- **Do not perform destructive actions during `deriveResource` or `deriveEndpoint`.** Derive
+  is read-only. Side effects belong in `resetResource` and `cleanupResource`.
+- **Do not operate outside the declared worktree scope.** Every derived value must be
+  scoped to the provided `worktree.id`.
+
+The `provider-authoring-guide.md` has the complete list and examples.
+
+### Support guarantee for custom providers
+
+Multiverse guarantees the contract seam (`@multiverse/provider-contracts`) is stable for
+1.0. A custom provider that correctly implements the contract will integrate with core
+correctly.
+
+Multiverse does **not** guarantee the behavior of any specific custom provider — that is
+the extension author's responsibility. A custom provider is outside the first-party
+support tier regardless of how well it is implemented.
+
+---
+
+## What is deferred for 1.0
+
+The following are explicitly outside the 1.0 extension support statement:
+
+**Provider packaging and distribution**
+First-party and custom provider packages are workspace-local. Publishing provider
+packages as standalone npm packages consumable outside the Multiverse workspace is
+deferred. No accepted ADR governs provider distribution.
+
+**Community extension workflow**
+Multiverse does not provide tooling for discovering, sharing, or installing community
+provider packages. There is no extension registry, marketplace, or distribution
+mechanism.
+
+**Additional first-party providers beyond the current six**
+No new first-party providers are planned for 1.0. New provider shapes require a new ADR
+before implementation.
+
+**Provider auto-discovery or inference**
+Provider selection is always explicit in repository configuration (ADR-0007). Core never
+infers which provider to use from the technology in use, the directory structure, or
+any convention.
+
+**Plugin or ecosystem framing**
+Multiverse's extensibility is through the explicit `@multiverse/provider-contracts`
+seam. There is no plugin system, no provider marketplace, and no generalized ecosystem
+abstraction planned for 1.0.
+
+---
+
+## Relationship to existing docs
+
+| Document | Relationship |
+|---|---|
+| `docs/adr/0005-providers-implement-isolation-contracts.md` | Establishes that providers implement isolation contracts; core does not hardcode technologies |
+| `docs/adr/0007-repository-configuration-is-explicit-in-1-0.md` | Governs explicit provider selection and the absence of provider inference |
+| `docs/adr/0008-unsafe-operations-are-refused-in-1-0.md` | Governs core-level and provider-level refusal behavior |
+| `docs/adr/0009-core-provider-repository-and-application-boundaries-are-explicit.md` | Defines the four responsibility layers this document synthesizes |
+| `docs/spec/provider-model.md` | Defines provider capabilities, domains, and safety rules |
+| `docs/spec/provider-support-classification.md` | Classifies the six first-party providers by support tier |
+| `docs/guides/provider-authoring-guide.md` | Practical guide for implementing a custom provider against the contract seam |

--- a/docs/spec/provider-model.md
+++ b/docs/spec/provider-model.md
@@ -148,6 +148,14 @@ The six first-party providers shipped with Multiverse are classified by support 
 first-class for the 1.0 common case, which are supported for specific use cases with stated
 constraints, and what is deferred.
 
+## Core/Extension Boundary
+
+The boundary between core responsibilities and provider (extension) responsibilities is
+stated explicitly in `docs/spec/core-extension-boundary.md`. That document synthesizes
+ADR-0005, ADR-0009, and the provider authoring guide into a single readable reference:
+what core owns, what `@multiverse/provider-contracts` guarantees as the stable extension
+seam, what first-party providers guarantee, and what custom providers can do.
+
 ## Open Areas
 
 The following remain to be specified in more detail elsewhere:


### PR DESCRIPTION
## Summary

- Produces `docs/spec/core-extension-boundary.md` — the source-of-truth 1.0 boundary statement synthesizing ADR-0005, ADR-0009, `provider-model.md`, and the provider authoring guide into one readable reference
- States core responsibilities (configuration validation, worktree identity, safety/refusal, provider coordination) and what core does not do
- Names `@multiverse/provider-contracts` as the stable extension seam; states what the package provides and what it does not
- Distinguishes first-party providers (6 workspace providers, classified in `provider-support-classification.md`) from custom/extension providers
- States what custom providers can do (implement any isolation strategy the contract supports, work through full CLI path) and must not do (business rules, reading config, operating outside worktree scope)
- Explicitly defers: provider packaging/distribution, community extension workflow, additional first-party providers, plugin/ecosystem framing

## Scope

- `docs/spec/core-extension-boundary.md` — new classification spec (primary deliverable)
- `docs/development/tasks/dev-slice-61-task-01.md` — task doc
- `docs/development/current-state.md` — Slice 61 proving result
- `docs/development/roadmap.md` — core/extension boundary item marked complete in Immediate direction
- `README.md` — pointer to new spec added to Key docs section
- `docs/spec/provider-model.md` — cross-reference to new boundary doc added
- No production code changes

## Validation

- `pnpm test:acceptance`: 225 tests passed (39 test files)
- Docs-only slice; no runtime behavior changed

## Deferred

- Provider packaging and distribution as standalone npm packages
- Community extension workflow and ecosystem tooling
- Additional first-party providers beyond the current six
- Plugin/marketplace framing

🤖 Generated with [Claude Code](https://claude.com/claude-code)