### PR TITLE
docs: close out 0.8.x and bump posture to 0.9.0-alpha.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Today’s repo includes:
 
 ## Current behavior being proven
 
-The current implementation proves the core loop for explicit declarations and deterministic derivation, the composed application consumer workflow, and a complete provider extensibility story. The `0.6.x` semantic stability wave (Slices 44–49) is now complete: lifecycle semantics, refusal behavior and category naming, worktree identity scenario accuracy, and consumer integration boundaries are all aligned across spec, ADR, scenarios, and guide docs. `0.7.0-alpha.1` enters the public surface stability phase: CLI invocation patterns, help text, output format conventions, and guide consistency.
+The current implementation proves the core loop for explicit declarations and deterministic derivation, the composed application consumer workflow, and a complete provider extensibility story. The `0.6.x` semantic stability wave (Slices 44–49) is complete. The `0.7.x` public-surface stability wave (Slices 50–56) is complete: CLI surface, help text, output shapes, and guide consistency. The `0.8.x` support boundary definition wave (Slices 57–61) is complete: provider support tiers, the official common-case workflow, the consumer integration model, and the core/extension boundary are all now explicit in source-of-truth specs. `0.9.0-alpha.1` enters the release-candidate hardening phase.
 
 1.0 remains intentionally narrow; outside-workspace packaging and distribution remain deferred.
 

--- a/docs/development/current-state.md
+++ b/docs/development/current-state.md
@@ -15,7 +15,7 @@ This is a short state-of-the-project document, not a full history.
 
 ## Current version posture
 
-Current version posture: **0.8.0-alpha.1**
+Current version posture: **0.9.0-alpha.1**
 
 Interpretation:
 
@@ -27,7 +27,8 @@ Interpretation:
 * all 0.5.x exit criteria are met: the documented second-engineer workflow is proven end-to-end, including real two-worktree auto-discovery/isolation and no-manual-`NODE_OPTIONS` TypeScript provider loading in workspace scope; outside-workspace packaging and distribution remain explicitly deferred
 * all 0.6.x exit criteria are met: lifecycle semantics, refusal behavior, naming, worktree identity accuracy, and consumer integration boundaries are now aligned across spec, ADR, scenarios, and guide docs; the planned six-seam semantic stability wave (Slices 44–49) is complete
 * all 0.7.x exit criteria are met: the CLI surface is coherent and stable — `--help`/`-h` works correctly, output shapes are specified and tested, help text is complete, documentation examples are consistent with actual usage, and common command flows feel intentional; the planned seven-slice public-surface stability wave (Slices 50–56) is complete
-* `0.8.0-alpha.1` enters the support boundary definition phase: the next honest proving question is whether Multiverse's support boundaries can be made explicit enough that a user can tell what the tool officially supports for 1.0, without reading the source code
+* all 0.8.x exit criteria are met: Multiverse's 1.0 support boundaries are now explicit in source-of-truth docs — provider support tiers, the official common-case workflow, the supported consumer integration model, and the core/extension boundary are all stated clearly enough that a user can answer those questions without reading source code; the planned five-slice support boundary definition wave (Slices 57–61) is complete
+* `0.9.0-alpha.1` enters the release-candidate hardening phase: the next honest proving question is whether the defined support boundaries hold up under final workflow validation, guide accuracy review, and CLI polish
 * 1.0 expectations remain intentionally narrow
 
 ## What is already proven
@@ -441,7 +442,7 @@ deferred.
 
 The current priority is:
 
-**`0.8.x` support boundary definition — making Multiverse's 1.0 support boundaries explicit enough that a user can tell what the tool officially supports without reading the source code. The `0.7.x` public-surface stability wave is complete. Outside-workspace packaging and distribution remain explicitly deferred.**
+**`0.9.x` release-candidate hardening — verifying that the defined 1.0 support boundaries hold up in practice: final guide and README accuracy, end-to-end workflow validation against the now-explicit support specs, and final CLI polish. The `0.8.x` support boundary definition wave is complete. Outside-workspace packaging and distribution remain explicitly deferred.**
 
 ## What kinds of work are highest-value right now
 
@@ -513,24 +514,29 @@ The following remain explicitly deferred:
 
 When deciding what to work on next, prefer work that answers the current proving question:
 
-**Can Multiverse's support boundaries be made explicit enough that a user can tell what the
-tool officially supports for 1.0, without reading the source code?**
+**Do the defined 1.0 support boundaries hold up in practice? Can a user read the support
+specs, follow the guide, and reproduce the documented experience without gaps or surprises?**
 
-Use this preference order:
+The `0.8.x` support boundary definition wave is complete. The `0.9.x` hardening wave is
+the current focus. Work in this phase verifies that already-stated boundaries are accurate
+and trustworthy — it does not invent new boundaries.
 
-1. audit which of the six first-party providers (name-scoped, path-scoped, process-scoped,
-   process-port-scoped, local-port, fixed-host-port) are first-class for 1.0 vs experimental
-   vs deferred — produce an explicit support classification
-2. define which workflows are part of the officially supported common case for 1.0
-3. make the core/extension boundary explicit as a 1.0 support statement
-4. state explicitly what consumer integration model is officially supported (appEnv,
-   runtime-config boundary) vs what remains experimental
+Highest-value work for `0.9.x`:
 
-Each item requires its own slice and task doc before any implementation changes.
-Begin with audit and classification work; do not invent new providers or workflows.
+1. Final guide and README accuracy pass — verify that `external-demo-guide.md`, `README.md`,
+   and the new support specs are mutually consistent and that no step produces a surprise
+2. End-to-end validation of the supported workflows against the now-explicit support specs
+   (`supported-workflow.md`, `consumer-integration-model.md`, `provider-support-classification.md`)
+3. Final CLI polish — error messages, edge-case refusal clarity, any rough edge that would
+   undermine trust in the common-case workflow
+4. Final verification that the core/extension boundary statement is accurate against the actual
+   provider-contracts package contents
 
-Do not attempt Slices 50–56 work as if it were pending — the 0.7.x wave is complete.
-0.8.x post-wave candidates (not current work): `validate-repository` guide docs,
+Each item requires a targeted audit and task doc before implementation. Begin with audit;
+do not invent new providers, commands, or workflows.
+
+Do not attempt 0.8.x work as if it were pending — the support boundary definition wave is
+complete. `0.9.x` candidates that are not yet current work: `validate-repository` guide docs,
 utility-command subcommand restructuring, outside-workspace packaging (always deferred).
 
 ## Related documents

--- a/docs/development/roadmap.md
+++ b/docs/development/roadmap.md
@@ -26,7 +26,7 @@ Multiverse development continues under the same core assumptions:
 
 ## Current version posture
 
-Current version posture: **0.8.0-alpha.1**
+Current version posture: **0.9.0-alpha.1**
 
 What that means:
 
@@ -43,7 +43,8 @@ What that means:
 * all `0.5.x` exit criteria are met; the early outside-usability phase is complete in substance
 * all `0.6.x` exit criteria are met; the semantic stability wave (Slices 44–49) is complete: lifecycle semantics, refusal behavior and category naming, worktree identity scenario accuracy, and consumer integration boundary classification are all aligned across spec, ADR, scenarios, and guide docs
 * all `0.7.x` exit criteria are met; the public-surface stability wave (Slices 50–56) is complete: `--help`/`-h` exit 0, structured usage, output-shape spec, Options section, guide/README alignment, utility-command classification, and `validate-worktree` removal
-* `0.8.0-alpha.1` enters the support boundary definition phase: the next proving target is making Multiverse's 1.0 support boundaries explicit — which providers are first-class, which workflows are officially supported, and what remains experimental or deferred
+* all `0.8.x` exit criteria are met; the support boundary definition wave (Slices 57–61) is complete: provider support classification, official common-case workflow, consumer integration model classification, and core/extension boundary consolidation are all now explicit in source-of-truth specs
+* `0.9.0-alpha.1` enters the release-candidate hardening phase: the next proving target is verifying that the defined 1.0 support boundaries hold up in practice — final guide/README accuracy, end-to-end workflow validation, and CLI polish
 * outside-workspace packaging/distribution remains explicitly deferred
 
 ## Version roadmap
@@ -489,15 +490,15 @@ The current near-term direction is:
 * ~~make the core/extension boundary explicit as a 1.0 support statement in source-of-truth docs~~ — done (Slice 61): `docs/spec/core-extension-boundary.md` synthesizes ADR-0005, ADR-0009, and the authoring guide into one reference; `@multiverse/provider-contracts` stated as the stable extension seam; first-party vs custom provider distinction explicit; deferred items documented
 * ~~state explicitly which consumer integration model (appEnv, runtime-config boundary) is officially supported for 1.0~~ — done (Slice 60): `docs/spec/consumer-integration-model.md` classifies three supported patterns; runtime-config boundary recommended for composed apps; `run` stderr routing stated as stable 1.0 behavior; deferred items explicit
 
-The `0.7.x` public-surface stability wave is complete. The seven planned slices (50–56)
-addressed help text, output-shape specification, guide/README alignment, utility-command
-classification, and CLI surface cleanup. The next honest proving question is whether the
-product's support boundaries can be made explicit enough that a user can identify what
-Multiverse officially supports for 1.0 without reading the source code.
+The `0.8.x` support boundary definition wave is complete. The five planned slices (57–61)
+defined provider support tiers, the official common-case workflow, the supported consumer
+integration model, and the core/extension boundary — all now explicit in source-of-truth
+specs. The next honest proving question is whether those defined boundaries hold up in
+practice under final guide and workflow validation.
 
-Each 0.8.x slice should begin with a targeted audit and task doc before any implementation.
-Broad redefinition of what Multiverse is without clear source-of-truth grounding is not
-the right direction for this phase.
+Each 0.9.x slice should begin with a targeted audit and task doc before any implementation.
+Do not invent new providers, commands, or workflows. Harden and verify what is already
+defined and proven.
 
 Provider-ecosystem formalization and external distribution remain deferred.
 

--- a/docs/development/tasks/post-wave-57-61-assessment.md
+++ b/docs/development/tasks/post-wave-57-61-assessment.md
@@ -1,0 +1,101 @@
+# Post-Wave Assessment: 0.8.x Support Boundary Definition
+
+## Purpose
+
+This document records the completion assessment for the `0.8.x` support boundary
+definition wave (Slices 57–61) and the rationale for the posture move to
+`0.9.0-alpha.1`.
+
+## Wave summary
+
+The `0.8.x` wave set out to answer one proving question:
+
+> Can Multiverse's support boundaries be made explicit enough that a user can tell what
+> the tool officially supports for 1.0, without reading the source code?
+
+Five slices addressed four planned seams:
+
+| Slice | Seam | Deliverable |
+|---|---|---|
+| 57 | Planning baseline | Four-seam audit and proposed slice sequence |
+| 58 | Provider support classification | `docs/spec/provider-support-classification.md` |
+| 59 | Official supported workflow | `docs/spec/supported-workflow.md` |
+| 60 | Consumer integration model | `docs/spec/consumer-integration-model.md` |
+| 61 | Core/extension boundary | `docs/spec/core-extension-boundary.md` |
+
+No production code changes were made in this wave. All work was docs and classification.
+
+## 0.8.x exit criteria audit
+
+The roadmap defines five exit criteria for moving beyond `0.8.x`. Each is assessed
+against the source-of-truth docs as of Slice 61.
+
+**"Users can tell what Multiverse officially supports"**
+
+Met. Four new specs now give explicit answers to the four support-boundary questions:
+which providers are first-class (Slice 58), which workflow is common-case (Slice 59),
+which consumer integration patterns are supported (Slice 60), and what the
+core/extension boundary is (Slice 61). Before this wave, the answers existed in code,
+ADRs, and guide text but required reading several documents without a consolidated view.
+
+**"Users can tell what remains experimental or deferred"**
+
+Met. Every new spec includes an explicit "What is deferred" section enumerating named
+deferred items. Nothing material is left ambiguous as "maybe supported" without a clear
+classification.
+
+**"The core-versus-extension boundary is understandable"**
+
+Met by Slice 61. `docs/spec/core-extension-boundary.md` synthesizes ADR-0005, ADR-0009,
+and the provider authoring guide into a single readable reference.
+
+**"The supported consumer integration model is explicit"**
+
+Met by Slice 60. `docs/spec/consumer-integration-model.md` classifies three supported
+patterns with explicit "when to use" guidance, and states the `run` stderr refusal
+routing as a stable 1.0 behavior.
+
+**"1.0 no longer depends on broad or ambiguous promises"**
+
+Met. Each boundary is now named and explicit. The deferred items in each spec make the
+1.0 scope narrower and more honest, not broader.
+
+## Contradiction check
+
+No contradictions were found between ADRs, specs, or guide docs. The boundary work
+found that truth was distributed but consistent — it needed consolidation, not
+correction.
+
+## What remains open (not blocking 0.9.x)
+
+The following items remain open but belong to 0.9.x hardening, not 0.8.x boundary
+definition:
+
+- `validate-repository` guide documentation — still optional; flagged since 0.7.x; no
+  user workflow depends on it being in the guide
+- `repo-map.md` slice narrative — still describes through Slice 43; not incorrect but
+  would benefit from a 0.9.x accuracy pass
+- Final guide accuracy pass — the external-demo-guide and README accurately reflect the
+  current CLI surface but have not been reviewed against the now-explicit support specs;
+  a 0.9.x accuracy pass should check alignment
+- End-to-end validation of supported workflows against final support specs
+
+None of these are support-boundary gaps. They are hardening work appropriate for 0.9.x.
+
+## Posture recommendation: move to 0.9.0-alpha.1
+
+The `0.8.x` wave is complete in substance. All five exit criteria are met. The
+Immediate direction items in `roadmap.md` are all marked complete.
+
+Moving to `0.9.0-alpha.1` is honest: the product has stopped discovering its identity
+and is now ready to harden the defined boundaries through final validation, guide
+accuracy, and CLI polish.
+
+The next highest-signal proving question for `0.9.x` is:
+
+> Do the defined support boundaries hold up under final workflow validation? Can a user
+> read the support specs, follow the guide, and reproduce the documented experience
+> without gaps or surprises?
+
+The `0.9.x` wave should not invent new boundaries — it should verify that the
+already-stated boundaries are accurate and trustworthy in practice.


### PR DESCRIPTION
## Summary

The `0.8.x` support boundary definition wave (Slices 57–61) is now complete in substance. This PR closes it out with a narrow posture bump to `0.9.0-alpha.1` and records the completion rationale.

**0.8.x exit criteria — all met:**
- Users can tell what Multiverse officially supports — 4 new specs (`provider-support-classification.md`, `supported-workflow.md`, `consumer-integration-model.md`, `core-extension-boundary.md`)
- Users can tell what remains deferred — every new spec has an explicit deferred section
- Core-versus-extension boundary is understandable — `core-extension-boundary.md` (Slice 61)
- Supported consumer integration model is explicit — `consumer-integration-model.md` (Slice 60)
- 1.0 no longer depends on broad/ambiguous promises — each boundary is named and explicit

No contradictions were found in source-of-truth docs. The boundary work found truth that was distributed but consistent.

## Scope

- `docs/development/tasks/post-wave-57-61-assessment.md` — assessment doc recording the 0.8.x completion rationale and posture decision
- `docs/development/current-state.md` — version posture bumped to 0.9.0-alpha.1; current priority and practical instruction updated for 0.9.x hardening
- `docs/development/roadmap.md` — current version posture updated; Immediate direction note updated to 0.9.x
- `README.md` — "Current behavior being proven" paragraph updated to reflect completed 0.7.x, 0.8.x waves and 0.9.0-alpha.1 entry
- No production code changes

## Validation

- `pnpm test:acceptance`: 225 tests passed (39 test files)
- Docs-only change; no runtime behavior changed

## Next (0.9.x hardening — not in this PR)

- Final guide and README accuracy pass against the now-explicit support specs
- End-to-end workflow validation
- Final CLI polish and refusal-message clarity
- `validate-repository` guide documentation (optional, carried from 0.7.x)

🤖 Generated with [Claude Code](https://claude.com/claude-code)